### PR TITLE
Support for Common JS

### DIFF
--- a/beautify.js
+++ b/beautify.js
@@ -1078,3 +1078,8 @@ function js_beautify(js_source_text, options) {
     return output.join('').replace(/[\n ]+$/, '');
 
 }
+
+// Add support for CommonJS. Just put this file somewhere on your require.paths
+// and you will be able to `var js_beautify = require("beautify").js_beautify`.
+if (typeof exports !== "undefined")
+    exports.js_beautify = js_beautify;


### PR DESCRIPTION
Hey Einar,

This adds support for beautify.js to be used as a Common JS module by "exporting" the js_beautify function so that other modules can "require" it. To learn more: http://www.commonjs.org/specs/modules/1.0/

It is up to the end user to place the beautify.js file somewhere on their require.paths to enable this.

Thanks!

Nick
