### PR TITLE
Reuse option 'brace_style' in HTML beautifier to allow displaying tags wi

### DIFF
--- a/beautify-html.js
+++ b/beautify-html.js
@@ -45,7 +45,7 @@ function style_html(html_source, options) {
   options = options || {};
   indent_size = options.indent_size || 4;
   indent_character = options.indent_char || ' ';
-  brace_style = options.brace_style || 'collapse';
+  brace_style = options.brace_style || 'expand';
   max_char = options.max_char || '70';
 
   function Parser() {
@@ -439,7 +439,10 @@ function style_html(html_source, options) {
         multi_parser.current_mode = 'CONTENT';
         break;
       case 'TK_TAG_END':
-        multi_parser.print_newline(true, multi_parser.output);
+        var skipNL = (multi_parser.brace_style == 'collapse' && multi_parser.last_text !== '');
+        if (!skipNL) {
+          multi_parser.print_newline(true, multi_parser.output);
+        }
         multi_parser.print_token(multi_parser.token_text);
         multi_parser.current_mode = 'CONTENT';
         break;
@@ -450,7 +453,9 @@ function style_html(html_source, options) {
         break;
       case 'TK_CONTENT':
         if (multi_parser.token_text !== '') {
-          multi_parser.print_newline(false, multi_parser.output);
+            if (multi_parser.brace_style === 'expand') {
+                multi_parser.print_newline(false, multi_parser.output);
+            }
           multi_parser.print_token(multi_parser.token_text);
         }
         multi_parser.current_mode = 'TAG';


### PR DESCRIPTION
Reuse option 'brace_style' in HTML beautifier to allow displaying tags with text content on one line (e.g. "&lt;foo>hello world&lt;/foo>" instead of "&lt;foo>\nhello world\n&lt;/foo>")
