### PR TITLE
Automagical \x-obfuscated strings decoding.

### DIFF
--- a/python/jsbeautifier.py
+++ b/python/jsbeautifier.py
@@ -865,6 +865,10 @@ class Beautifier:
         elif self.last_type == 'TK_WORD':
             self.append(' ')
 
+        # Try to replace \x-encoded characters with their readable equivalent,
+        # if it is possible (e.g. '\x41\x42\x43\x01' becomes 'ABC\x01').
+        token_text = token_text.decode('unicode_escape', 'ignore')
+
         self.append(token_text)
 
 


### PR DESCRIPTION
This little tweak tries to deobfuscate strings containing escaped characters which would fall in the "readable area" of the character map. If a character cannot be decoded, it leaves it untouched and graciously goes on.

I may add a command line switch, `--no-string-decode`, if you'd like - but I don't see any point in leaving unobfuscated strings in the output.

_Note_: Currently this is a tweak of Python command line utility only. I'm working on js code.

---

Why? Simple.

I ran through this piece of nasty JS code some hours ago:

``` javascript
function loading_DoFSCommand(_0x9549x1,_0x9549x2){if(_0x9549x1=="\x62\x6C\x6F\x63\x6B\x31"){} else {if(_0x9549x1=="\x62\x6C\x6F\x63\x6B\x32"){document["\x67\x65\x74\x45\x6C\x65\x6D\x65\x6E\x74\x42\x79\x49\x64"]("\x70\x6F\x70\x75\x70\x5F\x63\x6F\x6E\x74\x61\x69\x6E\x65\x72")["\x73\x74\x79\x6C\x65"]["\x64\x69\x73\x70\x6C\x61\x79"]="\x62\x6C\x6F\x63\x6B";document["\x67\x65\x74\x45\x6C\x65\x6D\x65\x6E\x74\x42\x79\x49\x64"]("\x70\x6F\x70\x75\x70\x5F\x62\x61\x63\x6B\x67\x72\x6F\x75\x6E\x64")["\x73\x74\x79\x6C\x65"]["\x64\x69\x73\x70\x6C\x61\x79"]="\x62\x6C\x6F\x63\x6B";setInterval("\x73\x63\x72\x6F\x6C\x6C\x28\x30\x2C\x30\x29",300);} ;} ;} ;if(AC_FL_RunContent==0){alert("\x54\x68\x69\x73\x20\x70\x61\x67\x65\x20\x72\x65\x71\x75\x69\x72\x65\x73\x20\x41\x43\x5F\x52\x75\x6E\x41\x63\x74\x69\x76\x65\x43\x6F\x6E\x74\x65\x6E\x74\x2E\x6A\x73\x2E");} else {AC_FL_RunContent("\x63\x6F\x64\x65\x62\x61\x73\x65","\x68\x74\x74\x70\x3A\x2F\x2F\x64\x6F\x77\x6E\x6C\x6F\x61\x64\x2E\x6D\x61\x63\x72\x6F\x6D\x65\x64\x69\x61\x2E\x63\x6F\x6D\x2F\x70\x75\x62\x2F\x73\x68\x6F\x63\x6B\x77\x61\x76\x65\x2F\x63\x61\x62\x73\x2F\x66\x6C\x61\x73\x68\x2F\x73\x77\x66\x6C\x61\x73\x68\x2E\x63\x61\x62\x23\x76\x65\x72\x73\x69\x6F\x6E\x3D\x39\x2C\x30\x2C\x30\x2C\x30","\x77\x69\x64\x74\x68","\x39\x35\x30","\x68\x65\x69\x67\x68\x74","\x34\x30\x30","\x73\x72\x63","\x6C\x6F\x61\x64\x69\x6E\x67","\x71\x75\x61\x6C\x69\x74\x79","\x68\x69\x67\x68","\x70\x6C\x75\x67\x69\x6E\x73\x70\x61\x67\x65","\x68\x74\x74\x70\x3A\x2F\x2F\x77\x77\x77\x2E\x6D\x61\x63\x72\x6F\x6D\x65\x64\x69\x61\x2E\x63\x6F\x6D\x2F\x67\x6F\x2F\x67\x65\x74\x66\x6C\x61\x73\x68\x70\x6C\x61\x79\x65\x72","\x61\x6C\x69\x67\x6E","\x6D\x69\x64\x64\x6C\x65","\x70\x6C\x61\x79","\x74\x72\x75\x65","\x6C\x6F\x6F\x70","\x74\x72\x75\x65","\x73\x63\x61\x6C\x65","\x73\x68\x6F\x77\x61\x6C\x6C","\x77\x6D\x6F\x64\x65","\x74\x72\x61\x6E\x73\x70\x61\x72\x65\x6E\x74","\x64\x65\x76\x69\x63\x65\x66\x6F\x6E\x74","\x66\x61\x6C\x73\x65","\x69\x64","\x6C\x6F\x61\x64\x69\x6E\x67","\x62\x67\x63\x6F\x6C\x6F\x72","\x23\x30\x30\x30\x30\x30\x30","\x6E\x61\x6D\x65","\x6C\x6F\x61\x64\x69\x6E\x67","\x6D\x65\x6E\x75","\x74\x72\x75\x65","\x61\x6C\x6C\x6F\x77\x46\x75\x6C\x6C\x53\x63\x72\x65\x65\x6E","\x66\x61\x6C\x73\x65","\x61\x6C\x6C\x6F\x77\x53\x63\x72\x69\x70\x74\x41\x63\x63\x65\x73\x73","\x73\x61\x6D\x65\x44\x6F\x6D\x61\x69\x6E","\x6D\x6F\x76\x69\x65","\x6C\x6F\x61\x64\x69\x6E\x67","\x73\x61\x6C\x69\x67\x6E","");} ;
```

Obviously, those long escaped strings needed to be decoded, so I added a little tweak. Compare the previous output:

``` javascript
function loading_DoFSCommand(_0x9549x1, _0x9549x2) {
    if (_0x9549x1 == "\x62\x6C\x6F\x63\x6B\x31") {} else {
        if (_0x9549x1 == "\x62\x6C\x6F\x63\x6B\x32") {
            document["\x67\x65\x74\x45\x6C\x65\x6D\x65\x6E\x74\x42\x79\x49\x64"]("\x70\x6F\x70\x75\x70\x5F\x63\x6F\x6E\x74\x61\x69\x6E\x65\x72")["\x73\x74\x79\x6C\x65"]["\x64\x69\x73\x70\x6C\x61\x79"] = "\x62\x6C\x6F\x63\x6B";
            document["\x67\x65\x74\x45\x6C\x65\x6D\x65\x6E\x74\x42\x79\x49\x64"]("\x70\x6F\x70\x75\x70\x5F\x62\x61\x63\x6B\x67\x72\x6F\x75\x6E\x64")["\x73\x74\x79\x6C\x65"]["\x64\x69\x73\x70\x6C\x61\x79"] = "\x62\x6C\x6F\x63\x6B";
            setInterval("\x73\x63\x72\x6F\x6C\x6C\x28\x30\x2C\x30\x29", 300);
        };
    };
};
if (AC_FL_RunContent == 0) {
    alert("\x54\x68\x69\x73\x20\x70\x61\x67\x65\x20\x72\x65\x71\x75\x69\x72\x65\x73\x20\x41\x43\x5F\x52\x75\x6E\x41\x63\x74\x69\x76\x65\x43\x6F\x6E\x74\x65\x6E\x74\x2E\x6A\x73\x2E");
} else {
    AC_FL_RunContent("\x63\x6F\x64\x65\x62\x61\x73\x65", "\x68\x74\x74\x70\x3A\x2F\x2F\x64\x6F\x77\x6E\x6C\x6F\x61\x64\x2E\x6D\x61\x63\x72\x6F\x6D\x65\x64\x69\x61\x2E\x63\x6F\x6D\x2F\x70\x75\x62\x2F\x73\x68\x6F\x63\x6B\x77\x61\x76\x65\x2F\x63\x61\x62\x73\x2F\x66\x6C\x61\x73\x68\x2F\x73\x77\x66\x6C\x61\x73\x68\x2E\x63\x61\x62\x23\x76\x65\x72\x73\x69\x6F\x6E\x3D\x39\x2C\x30\x2C\x30\x2C\x30", "\x77\x69\x64\x74\x68", "\x39\x35\x30", "\x68\x65\x69\x67\x68\x74", "\x34\x30\x30", "\x73\x72\x63", "\x6C\x6F\x61\x64\x69\x6E\x67", "\x71\x75\x61\x6C\x69\x74\x79", "\x68\x69\x67\x68", "\x70\x6C\x75\x67\x69\x6E\x73\x70\x61\x67\x65", "\x68\x74\x74\x70\x3A\x2F\x2F\x77\x77\x77\x2E\x6D\x61\x63\x72\x6F\x6D\x65\x64\x69\x61\x2E\x63\x6F\x6D\x2F\x67\x6F\x2F\x67\x65\x74\x66\x6C\x61\x73\x68\x70\x6C\x61\x79\x65\x72", "\x61\x6C\x69\x67\x6E", "\x6D\x69\x64\x64\x6C\x65", "\x70\x6C\x61\x79", "\x74\x72\x75\x65", "\x6C\x6F\x6F\x70", "\x74\x72\x75\x65", "\x73\x63\x61\x6C\x65", "\x73\x68\x6F\x77\x61\x6C\x6C", "\x77\x6D\x6F\x64\x65", "\x74\x72\x61\x6E\x73\x70\x61\x72\x65\x6E\x74", "\x64\x65\x76\x69\x63\x65\x66\x6F\x6E\x74", "\x66\x61\x6C\x73\x65", "\x69\x64", "\x6C\x6F\x61\x64\x69\x6E\x67", "\x62\x67\x63\x6F\x6C\x6F\x72", "\x23\x30\x30\x30\x30\x30\x30", "\x6E\x61\x6D\x65", "\x6C\x6F\x61\x64\x69\x6E\x67", "\x6D\x65\x6E\x75", "\x74\x72\x75\x65", "\x61\x6C\x6C\x6F\x77\x46\x75\x6C\x6C\x53\x63\x72\x65\x65\x6E", "\x66\x61\x6C\x73\x65", "\x61\x6C\x6C\x6F\x77\x53\x63\x72\x69\x70\x74\x41\x63\x63\x65\x73\x73", "\x73\x61\x6D\x65\x44\x6F\x6D\x61\x69\x6E", "\x6D\x6F\x76\x69\x65", "\x6C\x6F\x61\x64\x69\x6E\x67", "\x73\x61\x6C\x69\x67\x6E", "");
};
```

with what would happen now:

``` javascript
function loading_DoFSCommand(_0x9549x1, _0x9549x2) {
    if (_0x9549x1 == "block1") {} else {
        if (_0x9549x1 == "block2") {
            document["getElementById"]("popup_container")["style"]["display"] = "block";
            document["getElementById"]("popup_background")["style"]["display"] = "block";
            setInterval("scroll(0,0)", 300);
        };
    };
};
if (AC_FL_RunContent == 0) {
    alert("This page requires AC_RunActiveContent.js.");
} else {
    AC_FL_RunContent("codebase", "http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0", "width", "950", "height", "400", "src", "loading", "quality", "high", "pluginspage", "http://www.macromedia.com/go/getflashplayer", "align", "middle", "play", "true", "loop", "true", "scale", "showall", "wmode", "transparent", "devicefont", "false", "id", "loading", "bgcolor", "#000000", "name", "loading", "menu", "true", "allowFullScreen", "false", "allowScriptAccess", "sameDomain", "movie", "loading", "salign", "");
};
```

The little thing was not as nasty as I thought.
