### PR TITLE
Allows unicode output

### DIFF
--- a/python/jsbeautifier.py
+++ b/python/jsbeautifier.py
@@ -3,6 +3,7 @@
 import sys
 import getopt
 import re
+import os
 
 #
 # Originally written by Einar Lielmanis et al.,
@@ -1063,6 +1064,11 @@ def main():
     outfile = 'stdout'
     if len(args) == 1:
         file = args[0]
+    elif len(args) == 0:
+        if os.isatty(0):
+            return usage()
+        else:
+            file = '-'
 
     for opt, arg in opts:
         if opt in ('--keep-array-indentation', '-k'):


### PR DESCRIPTION
I adapted this as a text-filter in BBEdit, and one issue I ran into is that BBEdit often supplies files with unicode text in them. The filters work fine on this, but when print is called at the end it chokes on the non-ascii character set. A quick .encode('utf-8') fixes this.

Relevant blog post (re BBEdit text filter): http://objectivesea.tumblr.com/post/9700437213/jsbeautifierforbbedit
