### PR TITLE
Fixes re.sub raising exception with Python 2.6

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -886,8 +886,7 @@ class Beautifier:
                 return char
             return block
 
-        token_text = re.sub(r'\\{1,2}x([a-f0-9]{2})', unescape, token_text,
-            flags=re.I)
+        token_text = re.sub(r'\\{1,2}x([a-fA-F0-9]{2})', unescape, token_text)
 
         self.append(token_text)
 


### PR DESCRIPTION
Code was unusable for me with Python 2.6 due to re.sub raising exception - 2.6 does not have the flags argument. Simple fix to make the pattern itself case insensitive by adding the character group A-F.
