### PR TITLE
Handle Sproutcore doc comments without throwing an exception

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1009,7 +1009,7 @@ class Beautifier:
 
         lines = token_text.replace('\x0d', '').split('\x0a')
         # all lines start with an asterisk? that's a proper box comment
-        if not any(l for l in lines[1:] if (l.lstrip())[0] != '*'):
+        if not any(l for l in lines[1:] if len((l.lstrip())) > 0 and (l.strip())[0] != '*'):
             self.append_newline()
             self.append(lines[0])
             for line in lines[1:]:


### PR DESCRIPTION
Fixed beautifier to work with auto documentation comments generated in sproutcore code which don't have asterisks at the beginning of every line as was previously expected.   

Here's an example of the comments Sproutcore generates:

```
 /** @namespace

    My cool new app.  Describe your application.

    @extends SC.Object
 */
```
