### PR TITLE
Print newline only if the tag has no content and has child

### DIFF
--- a/beautify-html.js
+++ b/beautify-html.js
@@ -444,7 +444,11 @@ function style_html(html_source, options) {
         multi_parser.current_mode = 'CONTENT';
         break;
       case 'TK_TAG_END':
-        multi_parser.print_newline(true, multi_parser.output);
+        //Print new line only if the tag has no content and has child
+        if ((multi_parser.last_token === 'TK_CONTENT' && multi_parser.last_text === '')
+               && (multi_parser.output[multi_parser.output.length -1]
+                .indexOf(multi_parser.token_text.replace("</", "<").replace(">", " ")) !== 0)) 
+            multi_parser.print_newline(true, multi_parser.output);
         multi_parser.print_token(multi_parser.token_text);
         multi_parser.current_mode = 'CONTENT';
         break;
@@ -455,7 +459,6 @@ function style_html(html_source, options) {
         break;
       case 'TK_CONTENT':
         if (multi_parser.token_text !== '') {
-          multi_parser.print_newline(false, multi_parser.output);
           multi_parser.print_token(multi_parser.token_text);
         }
         multi_parser.current_mode = 'TAG';


### PR DESCRIPTION
When there's content, we actually don't need to print new line. Only when there's child and no content that we need a new ine, for example:
&lt;h1&gt;hello&lt;/h1&gt; doesn't need a new line, 
&lt;div&gt;
    &lt;div&gt;&lt;/div&gt;
&lt;div&gt;
needs a new line for the outer div.
