### PR TITLE
Issue#84: Wrong indentation for block comments

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1031,7 +1031,6 @@ class Beautifier:
             if len(lines) > 1:
                 # multiline comment starts on a new line
                 self.append_newline()
-                self.trim_output()
             else:
                 # single line /* ... */ comment stays on the same line
                 self.append(' ')


### PR DESCRIPTION
The following simple patch seems to work well for me.

You are calling 'self.trim_output' in 'self.append_newline' anyway. With an additional call to it in line 1034 you're undoing the effect of 'append_newline'.
