### PR TITLE
Fix typo in mode test methods

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -269,11 +269,11 @@ class Beautifier:
         return s in ['case', 'return', 'do', 'if', 'throw', 'else'];
 
     def is_array(self, mode):
-        return mode in ['[EXPRESSION]', '[INDENDED-EXPRESSION]']
+        return mode in ['[EXPRESSION]', '[INDENTED-EXPRESSION]']
 
 
     def is_expression(self, mode):
-        return mode in ['[EXPRESSION]', '[INDENDED-EXPRESSION]', '(EXPRESSION)', '(FOR-EXPRESSION)', '(COND-EXPRESSION)']
+        return mode in ['[EXPRESSION]', '[INDENTED-EXPRESSION]', '(EXPRESSION)', '(FOR-EXPRESSION)', '(COND-EXPRESSION)']
 
 
     def append_newline_forced(self):


### PR DESCRIPTION
`is_array` and `is_expression` methods were attempting to match the `INDENDED-EXPRESSION` string not present anywhere else in the file (everywhere else uses `INDENTED-EXPRESSION`).
