### PR TITLE
Run tests with node.js more easily

### DIFF
--- a/tests/beautify-tests.js
+++ b/tests/beautify-tests.js
@@ -1,5 +1,12 @@
+#!/usr/bin/env node
 /*global js_beautify */
+/*jshint node:true */
 
+var isNode = (typeof module !== 'undefined' && module.exports);
+if (isNode) {
+    var SanityTest = require('./sanitytest'),
+        js_beautify = require('../beautify').js_beautify;
+}
 
 var opts = {
     indent_size: 4,
@@ -503,3 +510,11 @@ function run_beautifier_tests(test_obj)
     return sanitytest;
 }
 
+if (isNode) {
+    module.exports = run_beautifier_tests;
+
+    // http://nodejs.org/api/modules.html#modules_accessing_the_main_module
+    if (require.main === module) {
+        console.log(run_beautifier_tests().results_raw());
+    }
+}

--- a/tests/sanitytest.js
+++ b/tests/sanitytest.js
@@ -128,3 +128,7 @@ function SanityTest (func, test_name) {
     };
 
 }
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = SanityTest;
+}


### PR DESCRIPTION
Instead of copy and pasting the one-liner at the end of `run-tests`, let's just make `beautify-tests.js` executable as a node.js script. It won't interfere with Spidermonkey (`/usr/bin/js`), and it's behaviour is identical.

To run the tests with node, simply ensure `node` is on your `PATH` and `./tests/beautify-tests.js` from the root of the repo.
