### PR TITLE
Use "unformatted" instead of "this.unformatted"

### DIFF
--- a/beautify-html.js
+++ b/beautify-html.js
@@ -472,7 +472,7 @@ function style_html(html_source, options) {
       case 'TK_TAG_SINGLE':
         // Don't add a newline before elements that should remain unformatted.
         var tag_check = multi_parser.token_text.match(/^\s*<([a-z]+)/i);
-        if (!tag_check || !multi_parser.Utils.in_array(tag_check[1], this.unformatted)){
+        if (!tag_check || !multi_parser.Utils.in_array(tag_check[1], unformatted)){
             multi_parser.print_newline(false, multi_parser.output);
         }
         multi_parser.print_token(multi_parser.token_text);


### PR DESCRIPTION
Like https://github.com/einars/js-beautify/blob/master/beautify-html.js#L248

See

``` javascript
function style_html(html_source, options) {
  // ...
  unformatted = options.unformatted || [ ... ];
```

this.foo = ... doesn't work in <a href="https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Functions_and_function_scope/Strict_mode">strict mode</a> (w/o func.call/apply):

``` javascript
"use strict";
(function() {
    this.test = 1; // Exception: this is undefined
})();
```

Or (my case) "this" can be just broken in global scope: http://akelpad.sourceforge.net/forum/viewtopic.php?p=18304#18304 (in Russian, <a href="http://translate.google.com/translate?sl=auto&tl=en&ie=windows-1251&u=http%3A%2F%2Fakelpad.sourceforge.net%2Fforum%2Fviewtopic.php%3Fp%3D18304%2318304">translation</a>)
