### PR TITLE
Fix running tests with node.

### DIFF
--- a/tests/beautify-tests.js
+++ b/tests/beautify-tests.js
@@ -1,9 +1,10 @@
-/*global js_beautify */
+/*global js_beautify: true */
 /*jshint node:true */
 
 var isNode = (typeof module !== 'undefined' && module.exports);
 if (isNode) {
     var SanityTest = require('./sanitytest'),
+        Urlencoded = require('../unpackers/urlencode_unpacker'),
         js_beautify = require('../beautify').js_beautify;
 }
 

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -12,4 +12,4 @@ print(run_beautifier_tests().results_raw())
 
 
 // for nodejs use this from the command line from the main directory:
-// echo "console.log(run_beautifier_tests().results_raw());" | cat beautify.js tests/sanitytest.js tests/beautify-tests.js - | node
+// node tests/beautify-tests.js

--- a/unpackers/urlencode_unpacker.js
+++ b/unpackers/urlencode_unpacker.js
@@ -1,3 +1,5 @@
+/*global unescape */
+/*jshint curly: false, scripturl: true */
 //
 // trivial bookmarklet/escaped script detector for the javascript beautifier
 // written by Einar Lielmanis <einar@jsbeautifier.org>
@@ -9,6 +11,11 @@
 // }
 // 
 //
+
+var isNode = (typeof module !== 'undefined' && module.exports);
+if (isNode) {
+    var SanityTest = require(__dirname + '/../tests/sanitytest');
+}
 
 var Urlencoded = {
     detect: function (str) {
@@ -59,4 +66,8 @@ var Urlencoded = {
     }
 
 
+};
+
+if (isNode) {
+    module.exports = Urlencoded;
 }


### PR DESCRIPTION
I was just poking around on the latest `HEAD`, and I noticed that the tests were no longer running when invoked with `node`. Adding `Urlencode` to the exports and requiring it fixes this simply enough.
