### PR TITLE
Universal handling of inline comments (by skipping them).

### DIFF
--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -491,9 +491,17 @@ class TestJSBeautifier(unittest.TestCase):
         self.options.preserve_newlines = False
         bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
         bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
+        bt('var a = /*i*/ "b";');
+        bt('var a = /*i*/\n"b";', 'var a = /*i*/ "b";');
+        bt('{\n\n\n"x"\n}', '{\n    "x"\n}');
+        test_fragment('\n\n"x"', '"x"');
         self.options.preserve_newlines = True
         bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
         bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
+        bt('var a = /*i*/ "b";');
+        bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
+        bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
+        test_fragment('\n\n"x"', '"x"');
 
 
 

--- a/tests/beautify-tests.js
+++ b/tests/beautify-tests.js
@@ -554,10 +554,17 @@ function run_beautifier_tests(test_obj)
     opts.preserve_newlines = false;
     bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
     bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
+    bt('var a = /*i*/ "b";');
+    bt('var a = /*i*/\n"b";', 'var a = /*i*/ "b";');
+    bt('{\n\n\n"x"\n}', '{\n    "x"\n}');
+    test_fragment('\n\n"x"', '"x"');
     opts.preserve_newlines = true;
     bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
     bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
-
+    bt('var a = /*i*/ "b";');
+    bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
+    bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
+    test_fragment('\n\n"x"', '"x"');
     Urlencoded.run_tests(sanitytest);
 
     return sanitytest;


### PR DESCRIPTION
Universal handling of inline comments (by skipping them).
Fix string getting indented at start of file.

Instead of having inline comments do back flips and having other handlers have to special case for them, just print them out and then ignore them.  That is exactly what js engines do, and this lets us handle them universally instead of having to special case them.
