### PR TITLE
Support newline preservation on words

### DIFF
--- a/beautify.js
+++ b/beautify.js
@@ -1025,6 +1025,13 @@ function js_beautify(js_source_text, options) {
             if (flags.if_line && last_type === 'TK_END_EXPR') {
                 flags.if_line = false;
             }
+
+            if (last_type === 'TK_COMMA' || last_type === 'TK_START_EXPR' || last_type === 'TK_EQUALS' || last_type === 'TK_OPERATOR') {
+                if (flags.mode !== 'OBJECT') {
+                    print_preserved_newline();
+                }
+            }
+
             if (in_array(token_text.toLowerCase(), ['else', 'catch', 'finally'])) {
                 if (last_type !== 'TK_END_BLOCK' || opt_brace_style === "expand" || opt_brace_style === "end-expand" || opt_brace_style === "expand-strict") {
                     print_newline();

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -288,6 +288,13 @@ class Beautifier:
         self.append_newline()
         self.opts.keep_array_indentation = old_array_indentation
 
+    def append_preserved_newline(self):
+        if self.opts.preserve_newlines and self.wanted_newline and not self.just_added_newline:
+            self.append_newline()
+            self.append_indent_string()
+            self.wanted_newline = False
+
+
     def append_newline(self, ignore_repeated = True, reset_statement_flags = True):
 
         self.flags.eat_next_space = False
@@ -881,6 +888,10 @@ class Beautifier:
         if self.flags.if_line and self.last_type == 'TK_END_EXPR':
             self.flags.if_line = False
 
+        if self.last_type in ['TK_COMMA', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']:
+            if self.flags.mode != 'OBJECT':
+                self.append_preserved_newline()
+
         if token_text in self.line_starters:
             if self.last_text == 'else':
                 prefix = 'SPACE'
@@ -950,9 +961,9 @@ class Beautifier:
         elif self.last_type == 'TK_WORD':
             self.append(' ')
         elif self.last_type in ['TK_COMMA', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']:
-            if self.opts.preserve_newlines and self.wanted_newline and self.flags.mode != 'OBJECT':
-                self.append_newline()
-                self.append_indent_string()
+            if self.flags.mode != 'OBJECT':
+                self.append_preserved_newline()
+
         else:
             self.append_newline()
 

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -371,7 +371,6 @@ class TestJSBeautifier(unittest.TestCase):
 
         bt('var a = new function();');
         test_fragment('new function');
-        bt('var a =\nfoo', 'var a = foo');
 
         self.options.brace_style = 'expand';
 
@@ -489,17 +488,23 @@ class TestJSBeautifier(unittest.TestCase):
         bt('this.something.xxx = foo.moo.bar()');
 
         self.options.preserve_newlines = False
+        bt('var a =\nfoo', 'var a = foo');
         bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
         bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
         bt('var a = /*i*/ "b";');
         bt('var a = /*i*/\n"b";', 'var a = /*i*/ "b";');
+        bt('var a = /*i*/\nb;', 'var a = /*i*/ b;');
         bt('{\n\n\n"x"\n}', '{\n    "x"\n}');
+        bt('if(a && b &&\nc\n&& d && e) e = f', 'if (a && b && c && d && e) e = f');
         test_fragment('\n\n"x"', '"x"');
         self.options.preserve_newlines = True
+        bt('var a =\nfoo', 'var a =\n    foo');
         bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
         bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
         bt('var a = /*i*/ "b";');
         bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
+        bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;');
+        bt('if(a && b &&\nc\n&& d && e) e = f', 'if (a && b &&\n    c && d && e) e = f');
         bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
         test_fragment('\n\n"x"', '"x"');
 

--- a/tests/beautify-tests.js
+++ b/tests/beautify-tests.js
@@ -452,7 +452,6 @@ function run_beautifier_tests(test_obj)
 
     bt('var a = new function();');
     test_fragment('new function');
-    bt('var a =\nfoo', 'var a = foo');
 
     opts.brace_style = "end-expand";
 
@@ -551,19 +550,27 @@ function run_beautifier_tests(test_obj)
     bt('this.something = foo.bar().baz().cucumber(fat)', 'this.something = foo.bar()\n    .baz()\n    .cucumber(fat)');
     bt('this.something.xxx = foo.moo.bar()');
 
+    opts.space_before_conditional = true;
     opts.preserve_newlines = false;
+    bt('var a =\nfoo', 'var a = foo');
     bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
     bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
     bt('var a = /*i*/ "b";');
     bt('var a = /*i*/\n"b";', 'var a = /*i*/ "b";');
+    bt('var a = /*i*/\nb;', 'var a = /*i*/ b;');
     bt('{\n\n\n"x"\n}', '{\n    "x"\n}');
+    bt('if(a && b &&\nc\n&& d && e) e = f', 'if (a && b && c && d && e) e = f');
     test_fragment('\n\n"x"', '"x"');
+
     opts.preserve_newlines = true;
+    bt('var a =\nfoo', 'var a =\n    foo');
     bt('var a = {\n"a":1,\n"b":2}', "var a = {\n    \"a\": 1,\n    \"b\": 2\n}");
     bt("var a = {\n'a':1,\n'b':2}", "var a = {\n    'a': 1,\n    'b': 2\n}");
     bt('var a = /*i*/ "b";');
     bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
+    bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;');
     bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
+    bt('if (a && b &&\nc\n&& d && e) e = f', 'if (a && b &&\n    c && d && e) e = f');
     test_fragment('\n\n"x"', '"x"');
     Urlencoded.run_tests(sanitytest);
 


### PR DESCRIPTION
Words should preserve newline's the same as strings.  This allows for poor-man's (manual) word-wrapping.  
