### PR TITLE
JSHint-based cleanup

### DIFF
--- a/beautify.js
+++ b/beautify.js
@@ -1,4 +1,3 @@
-/*jslint onevar: false, plusplus: false */
 /*jshint curly:true, eqeqeq:true, laxbreak:true, noempty:false */
 /*
 


### PR DESCRIPTION
I started finding more "functional-yet-ambiguous" JS errors in beautify.js (thanks for being so responsive to my inline comments!), so I figured I'd wrap them all in a pull request for simplicity's sake.

For the most part, these are idempotent changes that simply fulfill the contract espoused in the existing `/*jshint */` instructions.

To verify these fixes, you'll need to have `jshint` installed:

``` sh
$ npm -g install jshint
$ jshint beautify.js
```
