### PR TITLE
Updating npm metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "Stan <stasson@orc.ru>",
     "Vittorio Gambaletta <VittGam@vittgam.net>",
     "Daniel Stockman <daniel.stockman@gmail.com>",
-    "Liam Newman <bitwiseman@gmail.com"
+    "Liam Newman <bitwiseman@gmail.com>"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Just updating the metadata, which for the time being we can publish by bumping the patch version.

After pulling this, `npm version` is a handy way of bumping the package version and creating a tag.

``` sh
$ npm version patch
# bumps package.json version to 0.4.2, tagging "v0.4.2"
$ git push --tags origin master
$ npm publish
```

For the last line, I'll need to add you to the owners. 
