### PR TITLE
Expand travis build and default make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,28 @@
 language: node_js
-node_js:
-   - "0.8"
-   - "0.10"
 
+node_js:
+  - "0.6"
+  - "0.8"
+  - "0.10"
+
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+
+matrix:
+  exclude:
+    - node_js: "0.6"
+      python: "3.2"
+    - node_js: "0.6"
+      python: "3.3"
+    - node_js: "0.8"
+      python: "2.7"
+    - node_js: "0.8"
+      python: "3.3"
+    - node_js: "0.10"
+      python: "2.7"
+    - node_js: "0.10"
+      python: "3.2"
+
+script: "make"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 define AVAILABLE_ACTIONS
 
+build:		do static checking and build of js
 test:		test both implementations, js and python
 testp:		test python implementation
 testj:		test javascript implementation
@@ -10,22 +11,26 @@ export AVAILABLE_ACTIONS
 
 
 .SILENT:
+all: build test
 
-all:
+help:
 	echo "$$AVAILABLE_ACTIONS"
 
+build:
+	echo Building... ;\
+	npm install ;\
+
 testp:
+	echo Testing python implementation...
 	cd python ;\
-	echo Testing python3 ;\
-	PYTHON=python3 ./js-beautify-test ;\
-	echo Testing python2 ;\
-	PYTHON=python2 ./js-beautify-test
-	echo
+	python --version ;\
+	PYTHON=python ./js-beautify-test
 
 testj:
 	echo Testing javascript implementation...
-	./tests/run-tests
-	echo
+	node --version; \
+	npm test
+
 
 edit:
 	vim \


### PR DESCRIPTION
Expands the matrix of travis builds to include python. 
Simplifies the default make command - run `make` and you're covered.

This pull request should report build success before we merge it.
