### PR TITLE
Changing python version to sync with repo version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='jsbeautifier',
-      version='1.0',
+      version='0.4.2',
       description='JavaScript unobfuscator and beautifier.',
       long_description=('Beautify, unpack or deobfuscate JavaScript. '
                         'Handles popular online obfuscators.'),


### PR DESCRIPTION
I don't know [what you want to do about](https://www.kernel.org/pub/software/scm/git/docs/git-tag.html#_on_re_tagging) the v0.4.2 tag, but for the pypi submission I changed the version number in setup.py to match the github repo tag.

I think we need to make a version release checklist and note where all the version numbers need to be recorded.
