### PR TITLE
respect unformatted option when peeking to support A html5 block level

### DIFF
--- a/beautify-html.js
+++ b/beautify-html.js
@@ -449,7 +449,14 @@ function style_html(html_source, options) {
         //at this point we have an  tag; is its first child something we want to remain
         //unformatted?
         var next_tag = this.get_tag(true /* peek. */);
-        if (next_tag && this.Utils.in_array(next_tag, unformatted)){
+
+        // tets next_tag to see if it is just html tag (no external content)
+        var tag = (next_tag || "").match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
+
+        // if next_tag comes back but is not an isolated tag, then
+        // let's treat the 'a' tag as having content
+        // and respect the unformatted option
+        if (!tag || this.Utils.in_array(tag, unformatted)){
             return true;
         } else {
             return false;


### PR DESCRIPTION
this patch addresses the following problem where

``` html
[<a href="http://jsbeautifier.org">beautify</a> js and more]
```

gets formatted as

``` html
[
<a href="http://jsbeautifier.org">beautify it</a>js and more]
```

you'll notice that before the <code>&lt;a&gt;</code> there is a newline and after the <code>&lt;a&gt;</code> a space is removed. 

this happens because <code>get_tag()</code> when peeking (in order to support HTML5 A block mode) returns <code>beautify it&lt;a&gt;</code> and sets that value to <code>next_tag</code>.

thus, <code>this.Utils.in_array(next_tag, unformatted)</code> will now return false, causing the entire <code>&lt;a&gt;</code> code block to be treated as a formatted tag (even though by default <code>&lt;a&gt;</code> is an unformatted tag).

this patch now inspects <code>next_tag</code> properly. if it comes back as a valid HTML tag, then it respects the unformatted rules, otherwise if a non HTML tag (ex: text content) comes back, then it gets treated as as unformatted block.

with this change, it preserves spacing and the above example will properly return

``` html
[<a href="http://jsbeautifier.org">beautify</a> js and more]
```

after being parsed. since the test framework does not seem to support HTML beautification, i did not submit tests with this PR.
