### PR TITLE
-h option in cli.js

### DIFF
--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -157,7 +157,7 @@ if (require.main === module) {
 function usage(err) {
     var scriptName = getScriptName();
     var msg = [
-        scriptName + '@' + require('./package.json').version,
+        scriptName + '@' + require(__dirname + '/../../package.json').version,
         '',
         'CLI Options:',
         '  -f, --file       Input file(s) (Pass \'-\' for stdin)',


### PR DESCRIPTION
bugfix: -h option did not work due to path of package.json not updated in cli.js, after new directory structure.

Rasmus Erik :)
