### PR TITLE
fixed broken run tests script

### DIFF
--- a/js/test/run-tests
+++ b/js/test/run-tests
@@ -10,7 +10,7 @@ load('js/test/sanitytest.js')
 load('js/test/beautify-tests.js')
 load('js/lib/unpackers/urlencode_unpacker.js')
 
-print(run_beautifier_tests().results_raw())
+print(run_beautifier_tests(new SanityTest(), Urlencoded, js_beautify).results_raw())
 
 
 // for nodejs use this from the command line from the main directory:


### PR DESCRIPTION
It appears the smjs test script is broken. Before this change running `smjs js/test/run-tests` would output:
js/test/beautify-tests.js:73: TypeError: sanitytest is undefined

This change gets the test runner working but there are still 2 broken tests
