### PR TITLE
Beautifying function call chains that end with a callback results in incorrect formatting

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -86,7 +86,7 @@
         var input, output, token_text, token_type, last_type, last_last_text, indent_string;
         var flags, previous_flags, flag_store;
         var whitespace, wordchar, punct, parser_pos, line_starters, digits;
-        var prefix;
+        var prefix, dot_after_newline;
         var input_wanted_newline;
         var output_wrapped, output_space_before_token;
         var input_length, n_newlines, whitespace_before_token;
@@ -969,6 +969,10 @@
                 set_mode(MODE.ArrayLiteral);
                 indent();
             }
+            if(dot_after_newline) {
+              dot_after_newline = false;
+              indent();
+            }
         }
 
         function handle_end_expr() {
@@ -1089,6 +1093,10 @@
                     print_newline();
                     flags.do_block = false;
                 }
+            }
+
+            if(dot_after_newline && is_special_word(token_text)) {
+              dot_after_newline = false;
             }
 
             // if may be followed by else, or not
@@ -1480,7 +1488,12 @@
                 allow_wrap_or_preserved_newline (flags.last_text === ')' && opt.break_chained_methods);
             }
 
+            if (just_added_newline()) {
+                dot_after_newline = true;
+            }
+
             print_token();
+
         }
 
         function handle_unknown() {

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -959,6 +959,28 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify)
         test_fragment('xml=<a></b>\nc<b;', 'xml = <a></b>\nc<b;');
         opts.e4x = false;
 
+        // START tests for issue 241
+        bt('obj\n' +
+           '    .last({\n' +
+           '        foo: 1,\n' +
+           '        bar: 2\n' +
+           '    });\n' +
+           'var test = 1;');
+
+        bt('obj\n' +
+           '    .last(function() {\n' +
+           '        var test;\n' +
+           '    });\n' +
+           'var test = 1;');
+
+        bt('obj.first()\n' +
+           '    .second()\n' +
+           '    .last(function(err, response) {\n' +
+           '        console.log(err);\n' +
+           '    });');
+
+        // END tests for issue 241
+
 
         Urlencoded.run_tests(sanitytest);
 

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -230,6 +230,7 @@ class Beautifier:
         self.last_last_text = ''         # pre-last token text
 
         self.input = None
+        self.dot_after_newline = False
         self.output = []                 # formatted javascript gets built here
         self.output_wrapped = False
         self.output_space_before_token = False
@@ -825,6 +826,9 @@ class Beautifier:
         if self.token_text == '[':
             self.set_mode(MODE.ArrayLiteral)
             self.indent()
+        if self.dot_after_newline:
+            self.dot_after_newline = False
+            self.indent()
 
 
 
@@ -929,6 +933,9 @@ class Beautifier:
                 # if we don't see the expected while, recover
                 self.append_newline()
                 self.flags.do_block = False
+
+        if self.dot_after_newline and self.is_special_word(token_text):
+            self.dot_after_newline = False
 
         # if may be followed by else, or not
         # Bare/inline ifs are tricky
@@ -1279,6 +1286,9 @@ class Beautifier:
             # force newlines on dots after close paren when break_chained - for bar().baz()
             self.allow_wrap_or_preserved_newline(token_text,
                 self.flags.last_text == ')' and self.opts.break_chained_methods)
+
+        if self.just_added_newline():
+            self.dot_after_newline = True
 
         self.append_token(token_text)
 

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -895,6 +895,28 @@ class TestJSBeautifier(unittest.TestCase):
         test_fragment('xml=<a></b>\nc<b;', 'xml = <a></b>\nc<b;');
         self.options.e4x = False
 
+        # START tests for issue 241
+        bt('obj\n' +
+           '    .last({\n' +
+           '        foo: 1,\n' +
+           '        bar: 2\n' +
+           '    });\n' +
+           'var test = 1;');
+
+        bt('obj\n' +
+           '    .last(function() {\n' +
+           '        var test;\n' +
+           '    });\n' +
+           'var test = 1;');
+
+        bt('obj.first()\n' +
+           '    .second()\n' +
+           '    .last(function(err, response) {\n' +
+           '        console.log(err);\n' +
+           '    });');
+
+        # END tests for issue 241
+
 
 
 


### PR DESCRIPTION
I am using `indent_size: 2` and `keep_function_indentation: true`.  I'm trying to beautify chained function calls that end in a callback. Here is the example input:

``` javascript
obj.first()
  .second()
  .last(function (err, response) {
    console.log(err);
  });
```

I expect this to already be correctly formatted and not change by my jsbeautifer config, but when I run it, I get this output.

``` javascript
obj.first()
  .second()
  .last(function (err, response) {
  console.log(err);
});
```

The last two lines are moved one indentation size too far to the left. 

In case this is caused by my misunderstanding of the options, here is my whole jsbeautfier config object.

``` javascript
      options: {
        "indent_size": 2,
        "indent_char": " ",
        "indent_level": 0,
        "indent_with_tabs": false,
        "preserve_newlines": true,
        "max_preserve_newlines": 10,
        "brace_style": "collapse",
        "keep_array_indentation": false,
        "keep_function_indentation": true,
        "space_before_conditional": true,
        "eval_code": false,
        "indent_case": true,
        "unescape_strings": false,
        "space_after_anon_function": true
      }
    }
```
