### PR TITLE
Repair to work in windows

### DIFF
--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -131,7 +131,7 @@ var interpret = exports.interpret = function(argv, slice) {
         cleanOptions(cc.env('jsbeautify_'), knownOpts),
         parsed.config,
         cc.find('.jsbeautifyrc'),
-        cc.find(path.join(process.env.HOME, ".jsbeautifyrc")),
+        cc.find(path.join(process.env.HOME || "", ".jsbeautifyrc")),
         __dirname + '/../config/defaults.json'
     ).snapshot;
 


### PR DESCRIPTION
HOME environment variable usually not defined in windows.
