### PR TITLE
Make the AMD API match the rest of the APIs

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -1620,7 +1620,7 @@
         } else {
             // if is AMD ( https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property- )
             define([], function() {
-                return js_beautify;
+                return {js_beautify: js_beautify};
             });
         }
 


### PR DESCRIPTION
If I require `js-beautify` from Node, I get back an object. If I require it (I use Common.js wrapper from RequireJS) in the browser I get the beautify function itself. These should match.
