### PR TITLE
preserve single spacing and treat img as inline element

### DIFF
--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -1549,6 +1549,11 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '    content\n' +
             '</li>');
 
+        bth('<img> content');
+        bth('<img>   content', '<img> content');
+        bth('<div> content <img> content</div>');
+        bth('<div>    content <img>    content </div>', '<div> content <img> content </div>');
+
         // Tests that don't pass, but probably should.
         // bth('<div><span>content</span></div>');
 
@@ -1687,7 +1692,6 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bth('<div class="{{#if thingIs \'value\'}}content{{/if}}"></div>');
         bth('<div class=\'{{#if thingIs "value"}}content{{/if}}\'></div>');
         bth('<div class=\'{{#if thingIs \'value\'}}content{{/if}}\'></div>');
-
 
         opts.wrap_line_length = 0;
         //...---------1---------2---------3---------4---------5---------6---------7


### PR DESCRIPTION
i ran into a couple of edge cases where the HTML was not being preserved properly after it was beautified. i think it comes down to the fact that HTML does allow for single spaces to be interpreted as spaces in the content.

for example

```
<img src='test.jpg'> this is a test image
```

will beautify incorrectly to

```
<img src='test.jpg'>this is a test image
```

in digging deeper, i found a few other edge cases in similar nature (particular with spaces after tags not being preserved.

the following PR address this, and adds a few more tests to show that the library is still in a fully functional state. i also added <code>img</code> to the unformatted list to prevent new lines from being added after <code>img</code> tags, since they are inline elements much like <code>span</code> tags.

let me know if you are interested in additional tests or feel the changes could be cleaner.
