### PR TITLE
Fixed require.js support

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -362,7 +362,8 @@
     };
 
     /*global define */
-    if (typeof define === "function") {
+    if (typeof define === "function" && define.amd) {
+        // Add support for require.js
         define([], function () {
             return css_beautify;
         });

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -806,7 +806,7 @@
         return multi_parser.output.join('');
     }
 
-    if (typeof define === "function") {
+    if (typeof define === "function" && define.amd) {
         // Add support for require.js
         define(["./beautify", "./beautify-css"], function(js_beautify, css_beautify) {
             return {

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -1611,7 +1611,8 @@
     }
 
 
-    if (typeof define === "function") {
+    if (typeof define === "function" && define.amd) {
+        // Add support for require.js
         define([], function() {
             return js_beautify;
         });


### PR DESCRIPTION
List of changes:
- Unified require.js support blocks on three artifacts (beautify, beautify-css & beautify-html) using the standard `define` usage suggested at https://github.com/jrburke/r.js/issues/558#issuecomment-33546625
- Changed dependency definitions in `beautify-html.js` file to avoid using relative paths _and_ extensions, as it generates a problem on second degree dependency loading.
