### PR TITLE
Consider var, let and const as equal

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -103,7 +103,7 @@
         punct = punct.split(' ');
 
         // words which should always start on new line.
-        line_starters = 'continue,try,throw,return,var,if,switch,case,default,for,while,break,function'.split(',');
+        line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function'.split(',');
 
         MODE = {
             BlockStatement: 'BlockStatement', // 'BLOCK'
@@ -1199,7 +1199,7 @@
             } else if (input_wanted_newline && !is_expression(flags.mode) &&
                 (last_type !== 'TK_OPERATOR' || (flags.last_text === '--' || flags.last_text === '++')) &&
                 last_type !== 'TK_EQUALS' &&
-                (opt.preserve_newlines || flags.last_text !== 'var')) {
+                (opt.preserve_newlines || !in_array(flags.last_text, ['var', 'let', 'const']))) {
 
                 print_newline();
             }
@@ -1341,7 +1341,7 @@
                     // no newline between 'return nnn'
                     output_space_before_token = true;
                 } else if (last_type !== 'TK_END_EXPR') {
-                    if ((last_type !== 'TK_START_EXPR' || token_text !== 'var') && flags.last_text !== ':') {
+                    if ((last_type !== 'TK_START_EXPR' || !in_array(token_text, ['var', 'let', 'const'])) && flags.last_text !== ':') {
                         // no need to force newline on 'var': for (var x = 0...)
                         if (token_text === 'if' && flags.last_word === 'else' && flags.last_text !== '{') {
                             // no newline for } else if {
@@ -1365,7 +1365,7 @@
             print_token();
             flags.last_word = token_text;
 
-            if (token_text === 'var') {
+            if (in_array(token_text, ['var', 'let', 'const'])) {
                 flags.var_line = true;
                 flags.var_line_reindented = false;
                 flags.var_line_tainted = false;

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -152,6 +152,12 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('var a = 1 var b = 2', "var a = 1\nvar b = 2");
         bt('var a=1, b=c[d], e=6;', 'var a = 1,\n    b = c[d],\n    e = 6;');
         bt('var a,\n    b,\n    c;');
+        bt('let a = 1 let b = 2', "let a = 1\nlet b = 2");
+        bt('let a=1, b=c[d], e=6;', 'let a = 1,\n    b = c[d],\n    e = 6;');
+        bt('let a,\n    b,\n    c;');
+        bt('const a = 1 const b = 2', "const a = 1\nconst b = 2");
+        bt('const a=1, b=c[d], e=6;', 'const a = 1,\n    b = c[d],\n    e = 6;');
+        bt('const a,\n    b,\n    c;');
         bt('a = " 12345 "');
         bt("a = ' 12345 '");
         bt('if (a == 1) b = 2;', "if (a == 1) b = 2;");
@@ -1729,7 +1735,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bth('<div>Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all.</div>',
             /* expected */
             '<div>Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all.</div>');
-     
+
         //BUGBUG: This should wrap before 40 not after.
         opts.wrap_line_length = 40;
         //...---------1---------2---------3---------4---------5---------6---------7

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -264,7 +264,7 @@ class Beautifier:
 
 
         # Words which always should start on a new line
-        self.line_starters = 'continue,try,throw,return,var,if,switch,case,default,for,while,break,function'.split(',')
+        self.line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function'.split(',')
 
         self.set_mode(MODE.BlockStatement)
 
@@ -1028,7 +1028,7 @@ class Beautifier:
                 not self.is_expression(self.flags.mode) and \
                 (self.last_type != 'TK_OPERATOR' or (self.flags.last_text == '--' or self.flags.last_text == '++')) and \
                 self.last_type != 'TK_EQUALS' and \
-                (self.opts.preserve_newlines or self.flags.last_text != 'var'):
+                (self.opts.preserve_newlines or self.flags.last_text not in ['var', 'let', 'const']):
             self.append_newline()
 
         if self.flags.do_block and not self.flags.do_while:
@@ -1151,7 +1151,7 @@ class Beautifier:
                 # no newline between return nnn
                 self.output_space_before_token = True
             elif self.last_type != 'TK_END_EXPR':
-                if (self.last_type != 'TK_START_EXPR' or token_text != 'var') and self.flags.last_text != ':':
+                if (self.last_type != 'TK_START_EXPR' or token_text not in ['var', 'let', 'const']) and self.flags.last_text != ':':
                     # no need to force newline on VAR -
                     # for (var x = 0...
                     if token_text == 'if' and self.flags.last_word == 'else' and self.flags.last_text != '{':
@@ -1173,7 +1173,7 @@ class Beautifier:
         self.append_token(token_text)
         self.flags.last_word = token_text
 
-        if token_text == 'var':
+        if token_text in ['var', 'let', 'const']:
             self.flags.var_line = True
             self.flags.var_line_reindented = False
             self.flags.var_line_tainted = False

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -46,6 +46,10 @@ class TestJSBeautifier(unittest.TestCase):
         bt("a();\n\nb();", "a();\n\nb();");
         bt('var a = 1 var b = 2', "var a = 1\nvar b = 2");
         bt('var a=1, b=c[d], e=6;', 'var a = 1,\n    b = c[d],\n    e = 6;');
+        bt('let a = 1 let b = 2', "let a = 1\nlet b = 2");
+        bt('let a=1, b=c[d], e=6;', 'let a = 1,\n    b = c[d],\n    e = 6;');
+        bt('const a = 1 const b = 2', "const a = 1\nconst b = 2");
+        bt('const a=1, b=c[d], e=6;', 'const a = 1,\n    b = c[d],\n    e = 6;');
         bt('a = " 12345 "');
         bt("a = ' 12345 '");
         bt('if (a == 1) b = 2;', "if (a == 1) b = 2;");


### PR DESCRIPTION
This should take care of alignment issues when `let` and `const` are used, I think the behavior should be the same as `var`.
