### PR TITLE
Avoid breaking catch/finally on angular promises

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -1323,7 +1323,7 @@
 
             }
 
-            if (in_array(token_text, ['else', 'catch', 'finally'])) {
+            if (token_text === 'else' || (flags.last_text !== '.' && in_array(token_text, ['catch', 'finally']))) {
                 if (last_type !== 'TK_END_BLOCK' || opt.brace_style === "expand" || opt.brace_style === "end-expand") {
                     print_newline();
                 } else {

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -141,7 +141,6 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         opts.keep_array_indentation = false;
         opts.brace_style       = "collapse";
 
-
         bt('');
         bt('return .5');
         test_fragment('   return .5');
@@ -269,6 +268,10 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
         // a common snippet in jQuery plugins
         bt("settings = $.extend({},defaults,settings);", "settings = $.extend({}, defaults, settings);");
+
+        // promises specific
+        bt("$http().then().finally()", "$http().then().finally()");
+        bt("$http()\n.then()\n.finally()", "$http()\n    .then()\n    .finally()");
 
         bt('{xxx;}()', '{\n    xxx;\n}()');
 
@@ -1729,7 +1732,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bth('<div>Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all.</div>',
             /* expected */
             '<div>Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all. Some text that should not wrap at all.</div>');
-     
+
         //BUGBUG: This should wrap before 40 not after.
         opts.wrap_line_length = 40;
         //...---------1---------2---------3---------4---------5---------6---------7

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1131,7 +1131,7 @@ class Beautifier:
             else:
                 prefix = 'NEWLINE'
 
-        if token_text in ['else', 'catch', 'finally']:
+        if token_text == 'else' or (self.flags.last_text != '.' and token_text in ['else', 'catch', 'finally']):
             if self.last_type != 'TK_END_BLOCK' \
                or self.opts.brace_style == 'expand' \
                or self.opts.brace_style == 'end-expand':

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -165,6 +165,10 @@ class TestJSBeautifier(unittest.TestCase):
         # a common snippet in jQuery plugins
         bt("settings = $.extend({},defaults,settings);", "settings = $.extend({}, defaults, settings);");
 
+        # promises specific
+        bt("$http().then().finally()", "$http().then().finally()");
+        bt("$http()\n.then()\n.finally()", "$http()\n    .then()\n    .finally()");
+
         bt('{xxx;}()', '{\n    xxx;\n}()');
 
         bt("a = 'a'\nb = 'b'");


### PR DESCRIPTION
Fixes cases where code like :

``` js
$http(...)
  .then(...)
  .catch(...)
  .finally(...)
```

would end up looking like this :

``` js
$http(...)
  .then(...)
  .
  catch(...)
  .
  finally(...)
```
