### PR TITLE
Update dependencies to current versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
   "dependencies": {
     "config-chain": "~1.1.5",
     "mkdirp": "0.3.5",
-    "nopt": "~2.1.1"
+    "nopt": "~2.2.0"
   },
   "devDependencies": {
-    "jshint": "1.1.0",
+    "jshint": "2.4.4",
     "node-static": "~0.7.1"
   }
 }


### PR DESCRIPTION
Not sure, but some of our travis issues may be due to older version of jshint.  Updating dependencies.
