### PR TITLE
Support for keywords as IdentifierNames such as .catch()

### DIFF
--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -280,6 +280,12 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         // a common snippet in jQuery plugins
         bt("settings = $.extend({},defaults,settings);", "settings = $.extend({}, defaults, settings);");
 
+        // reserved words used as property names
+        bt("$http().then().finally().default()", "$http().then().finally().default()");
+        bt("$http()\n.then()\n.finally()\n.default()", "$http()\n    .then()\n    .finally()\n    .default()");
+        bt("$http().when.in.new.catch().throw()", "$http().when.in.new.catch().throw()");
+        bt("$http()\n.when\n.in\n.new\n.catch()\n.throw()", "$http()\n    .when\n    .in\n    .new\n    .catch()\n    .throw()");
+
         bt('{xxx;}()', '{\n    xxx;\n}()');
 
         bt("a = 'a'\nb = 'b'");

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -173,6 +173,12 @@ class TestJSBeautifier(unittest.TestCase):
         # a common snippet in jQuery plugins
         bt("settings = $.extend({},defaults,settings);", "settings = $.extend({}, defaults, settings);");
 
+        # reserved words used as property names
+        bt("$http().then().finally().default()", "$http().then().finally().default()");
+        bt("$http()\n.then()\n.finally()\n.default()", "$http()\n    .then()\n    .finally()\n    .default()");
+        bt("$http().when.in.new.catch().throw()", "$http().when.in.new.catch().throw()");
+        bt("$http()\n.when\n.in\n.new\n.catch()\n.throw()", "$http()\n    .when\n    .in\n    .new\n    .catch()\n    .throw()");
+
         bt('{xxx;}()', '{\n    xxx;\n}()');
 
         bt("a = 'a'\nb = 'b'");


### PR DESCRIPTION
This supports calling libraries which declare properties of objects using reserved words.
This does not support declaring these fields.

`var a = { 'throw': function() {} }` - works
`a.throw()` - works
`var a = { throw: function() {} }` - does not work

Fixes #309
Fixes #351
Fixes #368
Fixes #378
Closes #436
