### PR TITLE
Rewrite declaration var, let, const indenting

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -1490,8 +1490,7 @@
 
         function handle_comma() {
             if (flags.declaration_statement) {
-                if (is_expression(flags.parent.mode) ||
-                    (last_type === 'TK_END_BLOCK' && previous_flags.mode === MODE.ObjectLiteral)) {
+                if (is_expression(flags.parent.mode)) {
                     // do not break on comma, for(var a = 1, b = 2)
                     flags.declaration_assignment = false;
                 }

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -395,9 +395,9 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('catch(e)', 'catch (e)');
 
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;',
-            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    }, {\n        baz: 4,\n        wham: 5\n    }, c = 4;');
+            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    }, c = 4;');
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},\nc=4;',
-            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    }, {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;');
+            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;');
 
 
         // inline comment
@@ -1502,12 +1502,10 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
            '    });');
         // END tests for issue 281
 
-        // This is what I think these should look like related #256
-        // we don't have the ability yet
-//         bt('var a=1,b={bang:2},c=3;',
-//             'var a = 1,\n    b = {\n        bang: 2\n    },\n     c = 3;');
-//         bt('var a={bing:1},b=2,c=3;',
-//             'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;');
+        bt('var a=1,b={bang:2},c=3;',
+            'var a = 1,\n    b = {\n        bang: 2\n    },\n    c = 3;');
+        bt('var a={bing:1},b=2,c=3;',
+            'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;');
         Urlencoded.run_tests(sanitytest);
 
         bth('');

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1290,7 +1290,7 @@ class Beautifier:
 
     def handle_comma(self, token_text):
         if self.flags.declaration_statement:
-            if self.is_expression(self.flags.parent.mode) or (self.last_type == 'TK_END_BLOCK' and self.previous_flags.mode == MODE.ObjectLiteral):
+            if self.is_expression(self.flags.parent.mode):
                 # do not break on comma, for ( var a = 1, b = 2
                 self.flags.declaration_assignment = False
 

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -289,9 +289,9 @@ class TestJSBeautifier(unittest.TestCase):
         bt('catch(e)', 'catch (e)');
 
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;',
-           'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    }, {\n        baz: 4,\n        wham: 5\n    }, c = 4;');
+            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    }, c = 4;');
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},\nc=4;',
-           'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    }, {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;');
+            'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;');
 
         # inline comment
         bt('function x(/*int*/ start, /*string*/ foo)', 'function x( /*int*/ start, /*string*/ foo)');
@@ -1375,12 +1375,10 @@ class TestJSBeautifier(unittest.TestCase):
            '    });');
         # END tests for issue 281
 
-        # This is what I think these should look like related #256
-        # we don't have the ability yet
-        #bt('var a=1,b={bang:2},c=3;',
-        #   'var a = 1,\n    b = {\n        bang: 2\n    },\n     c = 3;');
-        #bt('var a={bing:1},b=2,c=3;',
-        #   'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;');
+        bt('var a=1,b={bang:2},c=3;',
+            'var a = 1,\n    b = {\n        bang: 2\n    },\n    c = 3;');
+        bt('var a={bing:1},b=2,c=3;',
+            'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;');
 
 
 


### PR DESCRIPTION
One of the long standing bugs related to incomplete parsing was the mis-indent for the first item in a var list. 

The recently added remove redundant indent code turns out to also work here and reduces the complexity of some of the if/else/do/while statement code as well.   

Fixes  #256, #430
