### PR TITLE
Bring back space_after_anon_function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,22 @@ CLI Options:
   -v, --version    Show the version
 
 Beautifier Options:
-  -s, --indent-size             Indentation size [4]
-  -c, --indent-char             Indentation character [" "]
-  -l, --indent-level            Initial indentation level [0]
-  -t, --indent-with-tabs        Indent with tabs, overrides -s and -c
-  -p, --preserve-newlines       Preserve line-breaks (--no-preserve-newlines disables)
-  -m, --max-preserve-newlines   Number of line-breaks to be preserved in one chunk [10]
-  -P, --space-in-paren          Add padding spaces within paren, ie. f( a, b )
-  -j, --jslint-happy            Enable jslint-stricter mode
-  -b, --brace-style             [collapse|expand|end-expand] ["collapse"]
-  -B, --break-chained-methods   Break chained method calls across subsequent lines
-  -k, --keep-array-indentation  Preserve array indentation
-  -x, --unescape-strings        Decode printable characters encoded in xNN notation
-  -w, --wrap-line-length        Wrap lines at next opportunity after N characters [0]
-  -X, --e4x                     Pass E4X xml literals through untouched
-  --good-stuff                  Warm the cockles of Crockford's heart
+  -s, --indent-size                 Indentation size [4]
+  -c, --indent-char                 Indentation character [" "]
+  -l, --indent-level                Initial indentation level [0]
+  -t, --indent-with-tabs            Indent with tabs, overrides -s and -c
+  -p, --preserve-newlines           Preserve line-breaks (--no-preserve-newlines disables)
+  -m, --max-preserve-newlines       Number of line-breaks to be preserved in one chunk [10]
+  -P, --space-in-paren              Add padding spaces within paren, ie. f( a, b )
+  -j, --jslint-happy                Enable jslint-stricter mode
+  -a, --space_after_anon_function   Add a space before an anonymous function's parens, ie. function ()
+  -b, --brace-style                 [collapse|expand|end-expand] ["collapse"]
+  -B, --break-chained-methods       Break chained method calls across subsequent lines
+  -k, --keep-array-indentation      Preserve array indentation
+  -x, --unescape-strings            Decode printable characters encoded in xNN notation
+  -w, --wrap-line-length            Wrap lines at next opportunity after N characters [0]
+  -X, --e4x                         Pass E4X xml literals through untouched
+  --good-stuff                      Warm the cockles of Crockford's heart
 ```
 
 These largely correspond to the underscored option keys for both library interfaces, which have these defaults:
@@ -110,6 +111,7 @@ These largely correspond to the underscored option keys for both library interfa
     "preserve_newlines": true,
     "max_preserve_newlines": 10,
     "jslint_happy": false,
+    "space_after_anon_function": false,
     "brace_style": "collapse",
     "keep_array_indentation": false,
     "keep_function_indentation": false,

--- a/js/config/defaults.json
+++ b/js/config/defaults.json
@@ -6,6 +6,7 @@
     "preserve_newlines": true,
     "max_preserve_newlines": 10,
     "jslint_happy": false,
+    "space_after_anon_function": false,
     "brace_style": "collapse",
     "keep_array_indentation": false,
     "keep_function_indentation": false,

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -49,9 +49,17 @@
 
     jslint_happy (default false) - if true, then jslint-stricter mode is enforced.
 
-            jslint_happy       !jslint_happy
+            jslint_happy        !jslint_happy
             ---------------------------------
-            function ()        function()
+            function ()         function()
+
+            switch () {         switch() {
+            case 1:               case 1:
+              break;                break;
+            }                   }
+
+    space_after_anon_function (default false) - should the space before an anonymous function's parens be added, "function()" vs "function ()",
+          NOTE: This option is overriden by jslint_happy (i.e. if jslint_happy is true, space_after_anon_function is true by design)
 
     brace_style (default "collapse") - "collapse" | "expand" | "end-expand"
             put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line.
@@ -244,9 +252,6 @@
         opt = {};
 
         // compatibility
-        if (options.space_after_anon_function !== undefined && options.jslint_happy === undefined) {
-            options.jslint_happy = options.space_after_anon_function;
-        }
         if (options.braces_on_own_line !== undefined) { //graceful handling of deprecated option
             opt.brace_style = options.braces_on_own_line ? "expand" : "collapse";
         }
@@ -266,11 +271,17 @@
         opt.space_in_paren = (options.space_in_paren === undefined) ? false : options.space_in_paren;
         opt.space_in_empty_paren = (options.space_in_empty_paren === undefined) ? false : options.space_in_empty_paren;
         opt.jslint_happy = (options.jslint_happy === undefined) ? false : options.jslint_happy;
+        opt.space_after_anon_function = (options.space_after_anon_function === undefined) ? false : options.space_after_anon_function;
         opt.keep_array_indentation = (options.keep_array_indentation === undefined) ? false : options.keep_array_indentation;
         opt.space_before_conditional = (options.space_before_conditional === undefined) ? true : options.space_before_conditional;
         opt.unescape_strings = (options.unescape_strings === undefined) ? false : options.unescape_strings;
         opt.wrap_line_length = (options.wrap_line_length === undefined) ? 0 : parseInt(options.wrap_line_length, 10);
         opt.e4x = (options.e4x === undefined) ? false : options.e4x;
+
+        // force opt.space_after_anon_function to true if opt.jslint_happy
+        if(opt.jslint_happy) {
+            opt.space_after_anon_function = true;
+        }
 
         if(options.indent_with_tabs){
             opt.indent_char = '\t';
@@ -1146,7 +1157,7 @@
             } else if ((last_type === 'TK_RESERVED' && (flags.last_word === 'function' || flags.last_word === 'typeof')) ||
                 (flags.last_text === '*' && last_last_text === 'function')) {
                 // function() vs function ()
-                if (opt.jslint_happy) {
+                if (opt.space_after_anon_function) {
                     output_space_before_token = true;
                 }
             } else if (last_type === 'TK_RESERVED' && (in_array(flags.last_text, line_starters) || flags.last_text === 'catch')) {

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -53,6 +53,7 @@ var fs = require('fs'),
         "space_in_paren": Boolean,
         "space_in_empty_paren": Boolean,
         "jslint_happy": Boolean,
+        "space_after_anon_function": Boolean,
         // TODO: expand-strict is obsolete, now identical to expand.  Remove in future version
         "brace_style": ["collapse", "expand", "end-expand", "expand-strict"],
         "break_chained_methods": Boolean,
@@ -88,6 +89,7 @@ var fs = require('fs'),
         "P": ["--space_in_paren"],
         "E": ["--space_in_empty_paren"],
         "j": ["--jslint_happy"],
+        "a": ["--space_after_anon_function"],
         "b": ["--brace_style"],
         "B": ["--break_chained_methods"],
         "k": ["--keep_array_indentation"],
@@ -205,20 +207,21 @@ function usage(err) {
 
     switch (scriptName.split('-').shift()) {
         case "js":
-            msg.push('  -l, --indent-level            Initial indentation level [0]');
-            msg.push('  -t, --indent-with-tabs        Indent with tabs, overrides -s and -c');
-            msg.push('  -p, --preserve-newlines       Preserve line-breaks (--no-preserve-newlines disables)');
-            msg.push('  -m, --max-preserve-newlines   Number of line-breaks to be preserved in one chunk [10]');
-            msg.push('  -P, --space-in-paren          Add padding spaces within paren, ie. f( a, b )');
-            msg.push('  -E, --space-in-empty-paren    Add a single space inside empty paren, ie. f( )');
-            msg.push('  -j, --jslint-happy            Enable jslint-stricter mode');
-            msg.push('  -b, --brace-style             [collapse|expand|end-expand] ["collapse"]');
-            msg.push('  -B, --break-chained-methods   Break chained method calls across subsequent lines');
-            msg.push('  -k, --keep-array-indentation  Preserve array indentation');
-            msg.push('  -x, --unescape-strings        Decode printable characters encoded in xNN notation');
-            msg.push('  -w, --wrap-line-length        Wrap lines at next opportunity after N characters [0]');
-            msg.push('  -X, --e4x                     Pass E4X xml literals through untouched');
-            msg.push('  --good-stuff                  Warm the cockles of Crockford\'s heart');
+            msg.push('  -l, --indent-level                Initial indentation level [0]');
+            msg.push('  -t, --indent-with-tabs            Indent with tabs, overrides -s and -c');
+            msg.push('  -p, --preserve-newlines           Preserve line-breaks (--no-preserve-newlines disables)');
+            msg.push('  -m, --max-preserve-newlines       Number of line-breaks to be preserved in one chunk [10]');
+            msg.push('  -P, --space-in-paren              Add padding spaces within paren, ie. f( a, b )');
+            msg.push('  -E, --space-in-empty-paren        Add a single space inside empty paren, ie. f( )');
+            msg.push('  -j, --jslint-happy                Enable jslint-stricter mode');
+            msg.push('  -a, --space_after_anon_function   Add a space before an anonymous function\'s parens, ie. function ()');
+            msg.push('  -b, --brace-style                 [collapse|expand|end-expand] ["collapse"]');
+            msg.push('  -B, --break-chained-methods       Break chained method calls across subsequent lines');
+            msg.push('  -k, --keep-array-indentation      Preserve array indentation');
+            msg.push('  -x, --unescape-strings            Decode printable characters encoded in xNN notation');
+            msg.push('  -w, --wrap-line-length            Wrap lines at next opportunity after N characters [0]');
+            msg.push('  -X, --e4x                         Pass E4X xml literals through untouched');
+            msg.push('  --good-stuff                      Warm the cockles of Crockford\'s heart');
             break;
         case "html":
             msg.push('  -b, --brace-style             [collapse|expand|end-expand] ["collapse"]');

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -457,6 +457,21 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             'var whatever = require("whatever")\n\nfunction() {\n    a = 6\n}');
 
 
+        opts.space_after_anon_function = true;
+
+        bt('switch(x) {case 0: case 1: a(); break; default: break}',
+            "switch (x) {\n    case 0:\n    case 1:\n        a();\n        break;\n    default:\n        break\n}");
+        bt('switch(x){case -1:break;case !y:break;}',
+            'switch (x) {\n    case -1:\n        break;\n    case !y:\n        break;\n}');
+        bt('a=typeof(x)', 'a = typeof (x)');
+        bt('x();\n\nfunction(){}', 'x();\n\nfunction () {}');
+        bt('function () {\n    var a, b, c, d, e = [],\n        f;\n}');
+        test_fragment("// comment 1\n(function()", "// comment 1\n(function ()"); // typical greasemonkey start
+        bt('var o1=$.extend(a);function(){alert(x);}', 'var o1 = $.extend(a);\n\nfunction () {\n    alert(x);\n}');
+        bt('function* () {\n    yield 1;\n}');
+
+        opts.space_after_anon_function = false;
+
         opts.jslint_happy = true;
 
         bt('a=typeof(x)', 'a = typeof (x)');

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -70,6 +70,7 @@ class BeautifierOptions:
         self.space_in_empty_paren = False
         self.e4x = False
         self.jslint_happy = False
+        self.space_after_anon_function = False
         self.brace_style = 'collapse'
         self.keep_array_indentation = False
         self.keep_function_indentation = False
@@ -88,6 +89,7 @@ preserve_newlines = %s
 max_preserve_newlines = %d
 space_in_paren = %s
 jslint_happy = %s
+space_after_anon_function = %s
 indent_with_tabs = %s
 brace_style = %s
 keep_array_indentation = %s
@@ -100,6 +102,7 @@ unescape_strings = %s
         self.max_preserve_newlines,
         self.space_in_paren,
         self.jslint_happy,
+        self.space_after_anon_function,
         self.indent_with_tabs,
         self.brace_style,
         self.keep_array_indentation,
@@ -258,6 +261,7 @@ Output options:
  -P,  --space-in-paren             add padding spaces within paren, ie. f( a, b )
  -E,  --space-in-empty-paren       Add a single space inside empty paren, ie. f( )
  -j,  --jslint-happy               more jslint-compatible output
+ -a,  --space_after_anon_function  add a space before an anonymous function's parens, ie. function ()
  -b,  --brace-style=collapse       brace style (collapse, expand, end-expand)
  -k,  --keep-array-indentation     keep array indentation.
  -o,  --outfile=FILE               specify a file to output to (default stdout)
@@ -305,6 +309,11 @@ class Beautifier:
         self.previous_flags = None
         self.flag_store = []
         self.input_wanted_newline = False
+
+        # force opts.space_after_anon_function to true if opts.jslint_happy
+        if self.opts.jslint_happy:
+            self.opts.space_after_anon_function = True
+
         if self.opts.indent_with_tabs:
             self.opts.indent_char = "\t"
             self.opts.indent_size = 1
@@ -981,7 +990,7 @@ class Beautifier:
         elif (self.last_type == 'TK_RESERVED' and (self.flags.last_word == 'function' or self.flags.last_word == 'typeof')) or \
             (self.flags.last_text == '*' and self.last_last_text =='function'):
             # function() vs function (), typeof() vs typeof ()
-            if self.opts.jslint_happy:
+            if self.opts.space_after_anon_function:
                 self.output_space_before_token = True
         elif self.last_type == 'TK_RESERVED' and (self.flags.last_text in self.line_starters or self.flags.last_text == 'catch'):
             # TODO: option space_before_conditional
@@ -1498,11 +1507,11 @@ def main():
     argv = sys.argv[1:]
 
     try:
-        opts, args = getopt.getopt(argv, "s:c:o:dEPjbkil:xhtfvXw:",
+        opts, args = getopt.getopt(argv, "s:c:o:dEPjabkil:xhtfvXw:",
             ['indent-size=','indent-char=','outfile=', 'disable-preserve-newlines',
-            'space-in-paren', 'space-in-empty-paren', 'jslint-happy', 'brace-style=',
-            'keep-array-indentation', 'indent-level=', 'unescape-strings', 'help', 'usage',
-            'stdin', 'eval-code', 'indent-with-tabs', 'keep-function-indentation', 'version',
+            'space-in-paren', 'space-in-empty-paren', 'jslint-happy', 'space-after-anon-function',
+            'brace-style=', 'keep-array-indentation', 'indent-level=', 'unescape-strings', 'help',
+            'usage', 'stdin', 'eval-code', 'indent-with-tabs', 'keep-function-indentation', 'version',
             'e4x', 'wrap-line-length'])
     except getopt.GetoptError as ex:
         print(ex, file=sys.stderr)
@@ -1536,6 +1545,8 @@ def main():
             js_options.space_in_empty_paren = True
         elif opt in ('--jslint-happy', '-j'):
             js_options.jslint_happy = True
+        elif opt in ('--space_after_anon_function', '-a'):
+            js_options.space_after_anon_function = True
         elif opt in ('--eval-code'):
             js_options.eval_code = True
         elif opt in ('--brace-style', '-b'):

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -351,6 +351,21 @@ class TestJSBeautifier(unittest.TestCase):
             'var whatever = require("whatever")\n\nfunction() {\n    a = 6\n}');
 
 
+        self.options.space_after_anon_function = True
+
+        bt('switch(x) {case 0: case 1: a(); break; default: break}',
+            "switch (x) {\n    case 0:\n    case 1:\n        a();\n        break;\n    default:\n        break\n}");
+        bt('switch(x){case -1:break;case !y:break;}',
+            'switch (x) {\n    case -1:\n        break;\n    case !y:\n        break;\n}');
+        bt('a=typeof(x)', 'a = typeof (x)');
+        bt('x();\n\nfunction(){}', 'x();\n\nfunction () {}');
+        bt('function () {\n    var a, b, c, d, e = [],\n        f;\n}');
+        test_fragment("// comment 1\n(function()", "// comment 1\n(function ()"); # typical greasemonkey start
+        bt('var o1=$.extend(a);function(){alert(x);}', 'var o1 = $.extend(a);\n\nfunction () {\n    alert(x);\n}');
+        bt('function* () {\n    yield 1;\n}');
+
+        self.options.space_after_anon_function = False
+
         self.options.jslint_happy = True
 
         bt('x();\n\nfunction(){}', 'x();\n\nfunction () {}');


### PR DESCRIPTION
This PR adds the option `jslint_happy_align_switch_case` which allows to opt out of switch-case alignment when using `jslint_happy`.

With `jslint_happy_align_switch_case = true` (the default):

``` javascript
switch (something) {
case 1:
  break;
case 2:
  break;
}
```

With `jslint_happy_align_switch_case = false`:

``` javascript
switch (something) {
  case 1:
    break;
  case 2:
    break;
}
```

Most changes in this PR are trimmed trailing whitespace, use [?w=1](https://github.com/gabrielmaldi/js-beautify/commit/4831333cd23c8ccc2d69955f273820a3878f8296?w=1) to focus on the real changes.
#15, #213, #372

ToDo:
- [X] JavaScript
- [X] Python
- [X] CLI
- [X] Tests
- [X] Docs
