### PR TITLE
Support 'starless' docblock comments.

### DIFF
--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -410,6 +410,19 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('/**\n* foo\n*/', '/**\n * foo\n */');
         bt('{\n/**\n* foo\n*/\n}', '{\n    /**\n     * foo\n     */\n}');
 
+        // starless block comment
+        bt('/**\nfoo\n*/');
+        bt('/**\nfoo\n**/');
+        bt('/**\nfoo\nbar\n**/');
+        bt('/**\nfoo\n\nbar\n**/');
+        bt('/**\nfoo\n    bar\n**/');
+        bt('{\n/**\nfoo\n*/\n}', '{\n    /**\n    foo\n    */\n}');
+        bt('{\n/**\nfoo\n**/\n}', '{\n    /**\n    foo\n    **/\n}');
+        bt('{\n/**\nfoo\nbar\n**/\n}', '{\n    /**\n    foo\n    bar\n    **/\n}');
+        bt('{\n/**\nfoo\n\nbar\n**/\n}', '{\n    /**\n    foo\n\n    bar\n    **/\n}');
+        bt('{\n/**\nfoo\n    bar\n**/\n}', '{\n    /**\n    foo\n        bar\n    **/\n}');
+        bt('{\n    /**\n    foo\nbar\n    **/\n}');
+
         bt('var a,b,c=1,d,e,f=2;', 'var a, b, c = 1,\n    d, e, f = 2;');
         bt('var a,b,c=[],d,e,f=2;', 'var a, b, c = [],\n    d, e, f = 2;');
         bt('function() {\n    var a, b, c, d, e = [],\n        f;\n}');

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -304,6 +304,19 @@ class TestJSBeautifier(unittest.TestCase):
         bt('/**\n* foo\n*/', '/**\n * foo\n */');
         bt('{\n/**\n* foo\n*/\n}', '{\n    /**\n     * foo\n     */\n}');
 
+        # starless block comment
+        bt('/**\nfoo\n*/');
+        bt('/**\nfoo\n**/');
+        bt('/**\nfoo\nbar\n**/');
+        bt('/**\nfoo\n\nbar\n**/');
+        bt('/**\nfoo\n    bar\n**/');
+        bt('{\n/**\nfoo\n*/\n}', '{\n    /**\n    foo\n    */\n}');
+        bt('{\n/**\nfoo\n**/\n}', '{\n    /**\n    foo\n    **/\n}');
+        bt('{\n/**\nfoo\nbar\n**/\n}', '{\n    /**\n    foo\n    bar\n    **/\n}');
+        bt('{\n/**\nfoo\n\nbar\n**/\n}', '{\n    /**\n    foo\n\n    bar\n    **/\n}');
+        bt('{\n/**\nfoo\n    bar\n**/\n}', '{\n    /**\n    foo\n        bar\n    **/\n}');
+        bt('{\n    /**\n    foo\nbar\n    **/\n}');
+
         bt('var a,b,c=1,d,e,f=2;', 'var a, b, c = 1,\n    d, e, f = 2;');
         bt('var a,b,c=[],d,e,f=2;', 'var a, b, c = [],\n    d, e, f = 2;');
         bt('function() {\n    var a, b, c, d, e = [],\n        f;\n}');


### PR DESCRIPTION
I've been using "starless" docblocks for awhile now, and I thought it'd be nice to format them properly. I first encountered them in YUI3, and find it makes inline docs much easier to write and maintain.
##### Javadoc

``` js
/**
 * stuff
 */
```
##### Starless

``` js
/**
stuff
**/
```

We already handle the Javadoc-style well enough, so it was frustrating when I found my immaculately formatted source was getting mangled by js-beautify:
#### Input & Expected Output

``` js
var foo = {
    /**
    Do stuff to the fizzbuzz

    @method doStuff
    **/
    doStuff: function () {
        // etc
    }
};
```
#### Actual Output

``` js
var foo = {
    /**
        Do stuff to the fizzbuzz

        @method doStuff
        **/
    doStuff: function () {
        // etc
    }
};
```

The indentation was horked, and there were several edge cases that degraded even further.
## TL;DR:

This pull request fixes that. Bonus, I learned some Python idioms. :)
