### PR TITLE
Add wrap_attributes and wrap_indent config parameters for HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Beautifier Options:
   -k, --keep-array-indentation  Preserve array indentation
   -x, --unescape-strings        Decode printable characters encoded in xNN notation
   -w, --wrap-line-length        Wrap lines at next opportunity after N characters [0]
+  -a, --wrap-attributes         Wrap attributes to new lines
+  -i, --wrap-indent             Indent wrapped attributes to after N characters [indent-size]
   -X, --e4x                     Pass E4X xml literals through untouched
   --good-stuff                  Warm the cockles of Crockford's heart
 ```
@@ -117,7 +119,9 @@ These largely correspond to the underscored option keys for both library interfa
     "break_chained_methods": false,
     "eval_code": false,
     "unescape_strings": false,
-    "wrap_line_length": 0
+    "wrap_line_length": 0,
+    "wrap_attributes": false,
+    "wrap_indent": 4
 }
 ```
 
@@ -180,4 +184,3 @@ Vasilevsky, Vital Batmanov, Ron Baldwin, Gabriel Harrison, Chris J. Shull,
 Mathias Bynens, Vittorio Gambaletta and others.
 
 js-beautify@1.5.1
-

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -90,7 +90,9 @@
             unformatted,
             preserve_newlines,
             max_preserve_newlines,
-            indent_handlebars;
+            indent_handlebars,
+            wrap_attributes,
+            wrap_indent;
 
         options = options || {};
 
@@ -111,6 +113,8 @@
             (isNaN(parseInt(options.max_preserve_newlines, 10)) ? 32786 : parseInt(options.max_preserve_newlines, 10))
             : 0;
         indent_handlebars = (options.indent_handlebars === undefined) ? false : options.indent_handlebars;
+        wrap_attributes = (options.wrap_attributes === undefined) ? false : options.wrap_attributes;
+        wrap_indent = (options.wrap_indent === undefined) ? indent_size : parseInt(options.wrap_indent, 10) || indent_size;
 
         function Parser() {
 
@@ -287,6 +291,7 @@
                     content = [],
                     comment = '',
                     space = false,
+                    first_attr = true,
                     tag_start, tag_end,
                     tag_start_char,
                     orig_pos = this.pos,
@@ -326,9 +331,18 @@
                         if (this.line_char_count >= this.wrap_line_length) {
                             this.print_newline(false, content);
                             this.print_indentation(content);
+                        } else if (!first_attr && wrap_attributes) {
+                            this.print_newline(true, content);
+                            this.print_indentation(content);
+                            for (var count = 0; count < wrap_indent; count++) {
+                                content.push(indent_character);
+                            }
                         } else {
                             content.push(' ');
                             this.line_char_count++;
+                        }
+                        if (content.filter(function (i) { return i === ' ';}).length === 1){
+                            first_attr = false;
                         }
                         space = false;
                     }

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -59,6 +59,8 @@ var fs = require('fs'),
         "keep_array_indentation": Boolean,
         "unescape_strings": Boolean,
         "wrap_line_length": Number,
+        "wrap_attributes": Boolean,
+        "wrap_indent": Number,
         "e4x": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
@@ -93,6 +95,8 @@ var fs = require('fs'),
         "k": ["--keep_array_indentation"],
         "x": ["--unescape_strings"],
         "w": ["--wrap_line_length"],
+        "a": ["--wrap_attributes"],
+        "i": ["--wrap_indent"],
         "X": ["--e4x"],
         // HTML-only
         "W": ["--max_char"], // obsolete since 1.3.5
@@ -225,6 +229,8 @@ function usage(err) {
             msg.push('  -I, --indent-inner-html       Indent body and head sections. Default is false.');
             msg.push('  -S, --indent-scripts          [keep|separate|normal] ["normal"]');
             msg.push('  -w, --wrap-line-length        Wrap lines at next opportunity after N characters [0]');
+            msg.push('  -a, --wrap-attributes         Wrap html tag attributes to new lines');
+            msg.push('  -i, --wrap-indent             Indent wrapped tags to after N characters [indent-level]');
             msg.push('  -p, --preserve-newlines       Preserve line-breaks (--no-preserve-newlines disables)');
             msg.push('  -m, --max-preserve-newlines   Number of line-breaks to be preserved in one chunk [10]');
             msg.push('  -U, --unformatted             List of tags (defaults to inline) that should not be reformatted');


### PR DESCRIPTION
This will put attributes on new lines if configured

#### input
-------
```html
<div    {{something}} attr1="123" data-attr2="hello    t here" {{#test}}disabled {{/test}}

>
This is some content    </div>
<div oneattr="one">
    Some content
            </div>
```

#### `config.json`
```json
{
    "wrap_attributes": true,
    "wrap_indent": 8,
    "wrap_line_length": 144
}
```

#### output
```html
<div {{something}}
        attr1="123"
        data-attr2="hello    t here"
        {{#test}}disabled
        {{/test}}>
    This is some content</div>
<div oneattr="one">
    Some content
</div>

```