### PR TITLE
Fix error where leading newline in a CSS file would cause the entire file to become double spaced.

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -148,7 +148,7 @@
         }
 
         // printer
-        var indentString = source_text.match(/^[\r\n]*[\t ]*/)[0];
+        var indentString = source_text.match(/^[\r\n]*[\t ]*/)[0].replace(/(\r\n|\n|\r)/gm, '');
         var singleIndent = new Array(indentSize + 1).join(indentCharacter);
         var indentLevel = 0;
         var nestedLevel = 0;

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -2089,6 +2089,9 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         btc('html.js [data-custom="123"] {\n  opacity: 1.00;\n}\n'); // may not eat the space before "["
         btc('html.js *[data-custom="123"] {\n  opacity: 1.00;\n}\n');
 
+        // Test leading newline
+        btc("\n@media print {.tab{}}", "@media print {\n  .tab {}\n}\n");
+
         return sanitytest;
     }
 


### PR DESCRIPTION
The `indentString` was not being completely stripped of newlines, causing the beautifier to bug and create a double spaced CSS document. I have fixed the issue and added a test case to demonstrate the bug.
