### PR TITLE
Allow custom elements to be unformatted

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -749,7 +749,7 @@
                     break;
                 case 'TK_TAG_SINGLE':
                     // Don't add a newline before elements that should remain unformatted.
-                    var tag_check = multi_parser.token_text.match(/^\s*<([a-z]+)/i);
+                    var tag_check = multi_parser.token_text.match(/^\s*<([a-z-]+)/i);
                     if (!tag_check || !multi_parser.Utils.in_array(tag_check[1], unformatted)) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }

--- a/js/test/beautify-tests.js
+++ b/js/test/beautify-tests.js
@@ -1738,7 +1738,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '<li>\n' +
             '    content\n' +
             '</li>');
-		
+
 		// START tests for issue 453
 		bth('<script type="text/unknown"><div></div></script>',
 			'<script type="text/unknown">\n' +
@@ -1755,7 +1755,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 		bth('<script type="text/javascript">var foo = "bar";</script>',
 			'<script type="text/javascript">\n' +
 			'    var foo = "bar";\n' +
-			'</script>');			
+			'</script>');
 		bth('<script type="application/javascript">var foo = "bar";</script>',
 			'<script type="application/javascript">\n' +
 			'    var foo = "bar";\n' +
@@ -1779,20 +1779,20 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 		bth('<script>var foo = "bar";</script>',
 			'<script>\n' +
 			'    var foo = "bar";\n' +
-			'</script>');					
-					
+			'</script>');
+
 		bth('<style type="text/unknown"><tag></tag></style>',
 			'<style type="text/unknown">\n' +
 			'    <tag></tag>\n' +
-			'</style>');	
+			'</style>');
 		bth('<style type="text/css"><tag></tag></style>',
 			'<style type="text/css">\n' +
 			'    <tag></tag>\n' +
-			'</style>');		
+			'</style>');
 		bth('<style><tag></tag></style>',
 			'<style>\n' +
 			'    <tag></tag>\n' +
-			'</style>');				
+			'</style>');
 		bth('<style type="text/css">.selector {font-size:12px;}</style>',
 			'<style type="text/css">\n' +
 			'    .selector {\n' +
@@ -1804,7 +1804,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 			'    .selector {\n' +
 			'        font-size: 12px;\n' +
 			'    }\n'+
-			'</style>');			
+			'</style>');
 		// END tests for issue 453
 
         var unformatted = opts.unformatted;
@@ -1820,6 +1820,14 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '  body {background-color:lightgrey}\n' +
             '  h1   {color:blue}\n' +
             '</style>');
+        opts.unformatted = unformatted;
+
+        unformatted = opts.unformatted;
+        opts.unformatted = ['custom-element'];
+        test_fragment('<div>should <custom-element>not</custom-element>' +
+                      ' insert newlines</div>',
+                      '<div>should <custom-element>not</custom-element>' +
+                      ' insert newlines</div>');
         opts.unformatted = unformatted;
 
         // Tests that don't pass, but probably should.
@@ -2041,6 +2049,7 @@ function run_beautifier_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '<div>preserve one newline</div>',
                       '<div>Should</div>\n\n\n' +
                       '<div>preserve one newline</div>');
+
         // css beautifier
         opts.indent_size = 1;
         opts.indent_char = '\t';


### PR DESCRIPTION
The regex needed to be loosened to allow a dash

There's one more regex with [a-z] instead of [a-z-] but I couldn't figure out what kind of failing test to write for that so I didn't change it.
