### PR TITLE
Update documentation of brace style options (related to #538 and #554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Beautifier Options:
   -P, --space-in-paren              Add padding spaces within paren, ie. f( a, b )
   -j, --jslint-happy                Enable jslint-stricter mode
   -a, --space_after_anon_function   Add a space before an anonymous function's parens, ie. function ()
-  -b, --brace-style                 [collapse|expand|end-expand] ["collapse"]
+  -b, --brace-style                 [collapse|expand|end-expand|none] ["collapse"]
   -B, --break-chained-methods       Break chained method calls across subsequent lines
   -k, --keep-array-indentation      Preserve array indentation
   -x, --unescape-strings            Decode printable characters encoded in xNN notation
@@ -158,7 +158,7 @@ HTML Beautifier Options:
   -I, --indent-inner-html       Indent <head> and <body> sections. Default is false.
   -s, --indent-size             Indentation size [4]
   -c, --indent-char             Indentation character [" "]
-  -b, --brace-style             [collapse|expand|end-expand] ["collapse"]
+  -b, --brace-style             [collapse|expand|end-expand|none] ["collapse"]
   -S, --indent-scripts          [keep|separate|normal] ["normal"]
   -w, --wrap-line-length        Maximum characters per line (0 disables) [250]
   -p, --preserve-newlines       Preserve existing line-breaks (--no-preserve-newlines disables)

--- a/index.html
+++ b/index.html
@@ -331,6 +331,8 @@
                     <option value="collapse">Braces with control statement</option>
                     <option value="expand">Braces on own line</option>
                     <option value="end-expand">End braces on own line</option>
+                    <option value="none">Attempt to keep braces where
+                    they are</option>
                 </select>
 
                 <p style="margin:6px 0 0 0">HTML &lt;style&gt;, &lt;script&gt; formatting:</p>

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -44,8 +44,8 @@
     indent_size (default 4)          — indentation size,
     indent_char (default space)      — character to indent with,
     wrap_line_length (default 250)            -  maximum amount of characters per line (0 = disable)
-    brace_style (default "collapse") - "collapse" | "expand" | "end-expand"
-            put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line.
+    brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none"
+            put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.
     unformatted (defaults to inline tags) - list of tags, that shouldn't be reformatted
     indent_scripts (default normal)  - "keep"|"separate"|"normal"
     preserve_newlines (default true) - whether existing line breaks before elements should be preserved


### PR DESCRIPTION
Looks like I forgot to update the README and a few other places with the new option for brace style.

Also, I updated the comments/documentation for beautify-html as well but it looks like brace_style is never actually used there? Maybe it gets passed along to the js beautifier somewhere, didn't dig too deep.
