### PR TITLE
modified cli.js so that it can read from piped input by default

### DIFF
--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -262,6 +262,11 @@ function processInputSync(filepath) {
     if (filepath === '-') {
         input = process.stdin;
         input.resume();
+
+        if (input.isRaw === false) {
+          throw 'No input detected';
+        }
+
         input.setEncoding('utf8');
 
         input.on('data', function(chunk) {
@@ -406,7 +411,8 @@ function checkFiles(parsed) {
     }
 
     if (!parsed.files.length) {
-        throw 'Must define at least one file.';
+        // read stdin by default
+        parsed.files.push('-');
     }
     debug('files.length ' + parsed.files.length);
 


### PR DESCRIPTION
I modified `cli.js` so that it expects stdin by default if no arguments are provided and will detect when no stdin is provided:

- `stdin` piping before:
```
$ cat package.json | js-beautify -f -
{{ pretty output }}
$ cat package.json | js-beautify
Must define at least one file.
Run `js-beautify.js -h` for help.
```

- `stdin` piping after:
```
$ cat package.json | js-beautify -f -
{{ pretty output }}
$ cat package.json | js-beautify
{{ pretty output }}
```

- before with no `stdin`:
```
$ js-beautify -f -
{{ hangs until ctrl+c }}
$ js-beautify
Must define at least one file.
Run `js-beautify.js -h` for help.
```

- after with no `stdin`:
```
$ js-beautify -f -
No input detected
Run `js-beautify.js -h` for help.
$ js-beautify
No input detected
Run `js-beautify.js -h` for help.
```