### PR TITLE
add support to less functions paramters braces

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -78,7 +78,7 @@
 
         var pos = -1,
             ch;
-        var roundBraceLevel = 0;
+        var parenLevel = 0;
 
         function next() {
             ch = source_text.charAt(++pos);
@@ -355,7 +355,7 @@
                         }
                     }
                 } else {
-                    roundBraceLevel++;
+                    parenLevel++;
                     if (isAfterSpace) {
                         print.singleSpace();
                     }
@@ -364,11 +364,11 @@
                 }
             } else if (ch === ')') {
                 output.push(ch);
-                roundBraceLevel--;
+                parenLevel--;
             } else if (ch === ',') {
                 output.push(ch);
                 eatWhitespace();
-                if (!insideRule && selectorSeparatorNewline && roundBraceLevel < 1) {
+                if (!insideRule && selectorSeparatorNewline && parenLevel < 1) {
                     print.newLine();
                 } else {
                     print.singleSpace();

--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -78,6 +78,7 @@
 
         var pos = -1,
             ch;
+        var roundBraceLevel = 0;
 
         function next() {
             ch = source_text.charAt(++pos);
@@ -120,7 +121,7 @@
         function eatWhitespace() {
             var result = '';
             while (whiteRe.test(peek())) {
-                next()
+                next();
                 result += ch;
             }
             return result;
@@ -132,14 +133,14 @@
                 result = ch;
             }
             while (whiteRe.test(next())) {
-                result += ch
+                result += ch;
             }
             return result;
         }
 
         function eatComment(singleLine) {
             var start = pos;
-            var singleLine = peek() === "/";
+            singleLine = peek() === "/";
             next();
             while (next()) {
                 if (!singleLine && ch === "*" && peek() === "/") {
@@ -230,7 +231,7 @@
             }
         };
 
-        
+
         var output = [];
         if (basebaseIndentString) {
             output.push(basebaseIndentString);
@@ -246,8 +247,8 @@
             var whitespace = skipWhitespace();
             var isAfterSpace = whitespace !== '';
             var isAfterNewline = whitespace.indexOf('\n') !== -1;
-            var last_top_ch = top_ch;
-            var top_ch = ch;
+            last_top_ch = top_ch;
+            top_ch = ch;
 
             if (!ch) {
                 break;
@@ -354,6 +355,7 @@
                         }
                     }
                 } else {
+                    roundBraceLevel++;
                     if (isAfterSpace) {
                         print.singleSpace();
                     }
@@ -362,10 +364,11 @@
                 }
             } else if (ch === ')') {
                 output.push(ch);
+                roundBraceLevel--;
             } else if (ch === ',') {
                 output.push(ch);
                 eatWhitespace();
-                if (!insideRule && selectorSeparatorNewline) {
+                if (!insideRule && selectorSeparatorNewline && roundBraceLevel < 1) {
                     print.newLine();
                 } else {
                     print.singleSpace();

--- a/js/test/beautify-css-tests.js
+++ b/js/test/beautify-css-tests.js
@@ -81,6 +81,11 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         t('.tabs    {    }', '.tabs {}');
         t('.tabs    \n{\n    \n  }', '.tabs {}');
 
+        // Functions braces
+        t('.tabs(){}', '.tabs() {}');
+        t('.tabs (pa, pa(1,2)), .cols { }', '.tabs (pa, pa(1, 2)),\n.cols {}');
+        t('.tabs  (t, t2)  \n{\n  key: val(p1  ,p2);  \n  }', '.tabs (t, t2) {\n\tkey: val(p1, p2);\n}');
+
         // 
 
         // test basic css beautifier

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -268,6 +268,7 @@ class Beautifier:
         enteringConditionalGroup = False
         top_ch = '' 
         last_top_ch = '' 
+        roundBraceLevel = 0
         
         while True:
             whitespace = self.skipWhitespace();
@@ -377,16 +378,18 @@ class Beautifier:
                         else:
                             self.pos = self.pos - 1
                 else:
+                    roundBraceLevel += 1
                     if isAfterSpace:
                         printer.singleSpace()
                     printer.push(self.ch)
                     self.eatWhitespace()
             elif self.ch == ')':
                 printer.push(self.ch)
+                roundBraceLevel -= 1
             elif self.ch == ',':
                 printer.push(self.ch)
                 self.eatWhitespace()
-                if not insideRule and self.opts.selector_separator_newline:
+                if not insideRule and self.opts.selector_separator_newline and roundBraceLevel < 1:
                     printer.newLine()
                 else:
                     printer.singleSpace()

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -268,7 +268,7 @@ class Beautifier:
         enteringConditionalGroup = False
         top_ch = '' 
         last_top_ch = '' 
-        roundBraceLevel = 0
+        parenLevel = 0
         
         while True:
             whitespace = self.skipWhitespace();
@@ -378,18 +378,18 @@ class Beautifier:
                         else:
                             self.pos = self.pos - 1
                 else:
-                    roundBraceLevel += 1
+                    parenLevel += 1
                     if isAfterSpace:
                         printer.singleSpace()
                     printer.push(self.ch)
                     self.eatWhitespace()
             elif self.ch == ')':
                 printer.push(self.ch)
-                roundBraceLevel -= 1
+                parenLevel -= 1
             elif self.ch == ',':
                 printer.push(self.ch)
                 self.eatWhitespace()
-                if not insideRule and self.opts.selector_separator_newline and roundBraceLevel < 1:
+                if not insideRule and self.opts.selector_separator_newline and parenLevel < 1:
                     printer.newLine()
                 else:
                     printer.singleSpace()

--- a/python/cssbeautifier/tests/test.py
+++ b/python/cssbeautifier/tests/test.py
@@ -46,6 +46,11 @@ class CSSBeautifierTest(unittest.TestCase):
         t('.tabs    {    }', '.tabs {}')
         t('.tabs    \n{\n    \n  }', '.tabs {}')
 
+        # Functions braces
+        t('.tabs(){}', '.tabs() {}')
+        t('.tabs (pa, pa(1,2)), .cols { }', '.tabs (pa, pa(1, 2)),\n.cols {}')
+        t('.tabs  (t, t2)  \n{\n  key: val(p1  ,p2);  \n  }', '.tabs (t, t2) {\n\tkey: val(p1, p2);\n}')
+
         # 
 
 

--- a/test/data/css.js
+++ b/test/data/css.js
@@ -38,6 +38,16 @@ exports.test_data = {
             { input: '.tabs    \n{\n    \n  }', output: '.tabs {}' }
         ],
     }, {
+        name: "Functions braces",
+        description: "",
+        tests: [
+            { input: '.tabs(){}', output: '.tabs() {}' },
+            { input: '.tabs (pa, pa(1,2)), .cols { }', output: '.tabs (pa, pa(1, 2)),\n.cols {}' },
+//          Still not supported to check if there are opening roundBracs after name
+//          { input: '.tabs (   )   {    }', output: '.tabs() {}' },
+            { input: '.tabs  (t, t2)  \n{\n  key: val(p1  ,p2);  \n  }', output: '.tabs (t, t2) {\n\tkey: val(p1, p2);\n}' }
+        ],
+    }, {
 
     }]
 }


### PR DESCRIPTION
this PR adds better support for less functions braces (no new lines between function parameters)
e.g: the new code outputs this
```less
.box-shadow(@shadow: 0 1px 3px rgba(0, 0, 0, .25)) {
    -webkit-box-shadow: @shadow;
    -moz-box-shadow: @shadow;
    box-shadow: @shadow;
}
```
and the old code outputs this:
```less
.box-shadow(@shadow: 0 1px 3px rgba(0,
0,
0,
.25)) {
    -webkit-box-shadow: @shadow;
    -moz-box-shadow: @shadow;
    box-shadow: @shadow;
}

```