### PR TITLE
 CSS: support add newline between rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Beautifier Options:
   -m, --max-preserve-newlines       Number of line-breaks to be preserved in one chunk [10]
   -P, --space-in-paren              Add padding spaces within paren, ie. f( a, b )
   -j, --jslint-happy                Enable jslint-stricter mode
-  -a, --space_after_anon_function   Add a space before an anonymous function's parens, ie. function ()
+  -a, --space-after-anon-function   Add a space before an anonymous function's parens, ie. function ()
   -b, --brace-style                 [collapse|expand|end-expand|none] ["collapse"]
   -B, --break-chained-methods       Break chained method calls across subsequent lines
   -k, --keep-array-indentation      Preserve array indentation
@@ -151,20 +151,22 @@ The CSS & HTML beautifiers are much simpler in scope, and possess far fewer opti
 
 ```text
 CSS Beautifier Options:
-  -s, --indent-size             Indentation size [4]
-  -c, --indent-char             Indentation character [" "]
+  -s, --indent-size                  Indentation size [4]
+  -c, --indent-char                  Indentation character [" "]
+  -L, --selector-separator-newline   Add a newline between multiple selectors
+  -N, --newline-between-rules        Add a newline between CSS rules
 
 HTML Beautifier Options:
-  -I, --indent-inner-html       Indent <head> and <body> sections. Default is false.
-  -s, --indent-size             Indentation size [4]
-  -c, --indent-char             Indentation character [" "]
-  -b, --brace-style             [collapse|expand|end-expand|none] ["collapse"]
-  -S, --indent-scripts          [keep|separate|normal] ["normal"]
-  -w, --wrap-line-length        Maximum characters per line (0 disables) [250]
-  -p, --preserve-newlines       Preserve existing line-breaks (--no-preserve-newlines disables)
-  -m, --max-preserve-newlines   Maximum number of line-breaks to be preserved in one chunk [10]
-  -U, --unformatted             List of tags (defaults to inline) that should not be reformatted
-  -n, --end_with_newline        End output with newline
+  -I, --indent-inner-html            Indent <head> and <body> sections. Default is false.
+  -s, --indent-size                  Indentation size [4]
+  -c, --indent-char                  Indentation character [" "]
+  -b, --brace-style                  [collapse|expand|end-expand|none] ["collapse"]
+  -S, --indent-scripts               [keep|separate|normal] ["normal"]
+  -w, --wrap-line-length             Maximum characters per line (0 disables) [250]
+  -p, --preserve-newlines            Preserve existing line-breaks (--no-preserve-newlines disables)
+  -m, --max-preserve-newlines        Maximum number of line-breaks to be preserved in one chunk [10]
+  -U, --unformatted                  List of tags (defaults to inline) that should not be reformatted
+  -n, --end_with_newline             End output with newline
 ```
 
 # License

--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -65,6 +65,7 @@
         var indentCharacter = options.indent_char || ' ';
         var selectorSeparatorNewline = (options.selector_separator_newline === undefined) ? true : options.selector_separator_newline;
         var end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
+        var newline_between_rules = (options.newline_between_rules === undefined) ? true : options.newline_between_rules;
 
         // compatibility
         if (typeof indentSize === "string") {
@@ -163,9 +164,9 @@
         // and the next special character found opens
         // a new block
         function foundNestedPseudoClass() {
-            for (var i = pos + 1; i < source_text.length; i++){
+            for (var i = pos + 1; i < source_text.length; i++) {
                 var ch = source_text.charAt(i);
-                if (ch === "{"){
+                if (ch === "{") {
                     return true;
                 } else if (ch === ";" || ch === "}" || ch === ")") {
                     return false;
@@ -230,7 +231,7 @@
             }
         };
 
-        
+
         var output = [];
         if (basebaseIndentString) {
             output.push(basebaseIndentString);
@@ -282,7 +283,7 @@
                     if (variableOrRule in css_beautify.CONDITIONAL_GROUP_RULE) {
                         enteringConditionalGroup = true;
                     }
-                } else if (': '.indexOf(variableOrRule[variableOrRule.length -1]) >= 0) {
+                } else if (': '.indexOf(variableOrRule[variableOrRule.length - 1]) >= 0) {
                     //we have a variable, add it and insert one space before continuing
                     next();
                     variableOrRule = eatString(": ").replace(/\s$/, '');
@@ -295,6 +296,10 @@
                     next();
                     print.singleSpace();
                     output.push("{}");
+                    print.newLine();
+                    if (newline_between_rules && indentLevel === 0) {
+                        print.newLine(true);
+                    }
                 } else {
                     indent();
                     print["{"](ch);
@@ -314,10 +319,13 @@
                 if (nestedLevel) {
                     nestedLevel--;
                 }
+                if (newline_between_rules && indentLevel === 0) {
+                    print.newLine(true);
+                }
             } else if (ch === ":") {
                 eatWhitespace();
-                if ((insideRule || enteringConditionalGroup) && 
-                        !(lookBack("&") || foundNestedPseudoClass())) {
+                if ((insideRule || enteringConditionalGroup) &&
+                    !(lookBack("&") || foundNestedPseudoClass())) {
                     // 'property: value' delimiter
                     // which could be in a conditional group query
                     output.push(':');

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -62,6 +62,9 @@ var fs = require('fs'),
         "wrap_line_length": Number,
         "e4x": Boolean,
         "end_with_newline": Boolean,
+        // CSS-only
+        "selector_separator_newline": Boolean,
+        "newline_between_rules": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
         "unformatted": [String, Array],
@@ -98,6 +101,9 @@ var fs = require('fs'),
         "w": ["--wrap_line_length"],
         "X": ["--e4x"],
         "n": ["--end_with_newline"],
+        // CSS-only
+        "L": ["--selector_separator_newline"],
+        "N": ["--newline_between_rules"],
         // HTML-only
         "W": ["--max_char"], // obsolete since 1.3.5
         "U": ["--unformatted"],
@@ -216,7 +222,7 @@ function usage(err) {
             msg.push('  -P, --space-in-paren              Add padding spaces within paren, ie. f( a, b )');
             msg.push('  -E, --space-in-empty-paren        Add a single space inside empty paren, ie. f( )');
             msg.push('  -j, --jslint-happy                Enable jslint-stricter mode');
-            msg.push('  -a, --space_after_anon_function   Add a space before an anonymous function\'s parens, ie. function ()');
+            msg.push('  -a, --space-after-anon-function   Add a space before an anonymous function\'s parens, ie. function ()');
             msg.push('  -b, --brace-style                 [collapse|expand|end-expand|none] ["collapse"]');
             msg.push('  -B, --break-chained-methods       Break chained method calls across subsequent lines');
             msg.push('  -k, --keep-array-indentation      Preserve array indentation');
@@ -235,6 +241,9 @@ function usage(err) {
             msg.push('  -m, --max-preserve-newlines   Number of line-breaks to be preserved in one chunk [10]');
             msg.push('  -U, --unformatted             List of tags (defaults to inline) that should not be reformatted');
             break;
+        case "css":
+            msg.push('  -L, --selector-separator-newline        Add a newline between multiple selectors.')
+            msg.push('  -N, --newline-between-rules             Add a newline between CSS rules.')
     }
 
     if (err) {

--- a/js/test/beautify-css-tests.js
+++ b/js/test/beautify-css-tests.js
@@ -13,7 +13,8 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         space_before_conditional: true,
         break_chained_methods: false,
         selector_separator: '\n',
-        end_with_newline: false
+        end_with_newline: false,
+        newline_between_rules: true,
     };
 
     function test_css_beautifier(input)
@@ -60,6 +61,7 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         opts.indent_char = '\t';
         opts.selector_separator_newline = true;
         opts.end_with_newline = false;
+        opts.newline_between_rules = false;
 
         // End With Newline - (eof = "\n")
         opts.end_with_newline = true;
@@ -80,6 +82,32 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         t('.tabs { }', '.tabs {}');
         t('.tabs    {    }', '.tabs {}');
         t('.tabs    \n{\n    \n  }', '.tabs {}');
+
+        // Newline Between Rules - (separator = "\n")
+        opts.newline_between_rules = true;
+        t('.div {}\n.span {}', '.div {}\n\n.span {}');
+        t('.div{}\n   \n.span{}', '.div {}\n\n.span {}');
+        t('.div {}    \n  \n.span { } \n', '.div {}\n\n.span {}');
+        t('.div {\n    \n} \n  .span {\n }  ', '.div {}\n\n.span {}');
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n\n.div {\n\theight: 15px;\n}');
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n\n.div {\n\theight: 15px;\n}');
+        t('#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n\n.div {\n\theight: 15px;\n}');
+        t('@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n\n.div {\n\theight: 15px;\n}');
+        t('@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}', '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}');
+        t('a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n\n.div {\n\theight: 15px;\n}');
+
+        // Newline Between Rules - (separator = "")
+        opts.newline_between_rules = false;
+        t('.div {}\n.span {}');
+        t('.div{}\n   \n.span{}', '.div {}\n.span {}');
+        t('.div {}    \n  \n.span { } \n', '.div {}\n.span {}');
+        t('.div {\n    \n} \n  .span {\n }  ', '.div {}\n.span {}');
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div {\n\theight: 15px;\n}');
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n.div {\n\theight: 15px;\n}');
+        t('#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div {\n\theight: 15px;\n}');
+        t('@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div {\n\theight: 15px;\n}');
+        t('@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}');
+        t('a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n.div {\n\theight: 15px;\n}');
 
         // 
 

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -35,6 +35,7 @@ class BeautifierOptions:
         self.indent_char = ' '
         self.selector_separator_newline = True
         self.end_with_newline = False
+        self.newline_between_rules = True
 
     def __repr__(self):
         return \
@@ -42,8 +43,9 @@ class BeautifierOptions:
 indent_char = [%s]
 separate_selectors_newline = [%s]
 end_with_newline = [%s]
+newline_between_rules = [%s]
 """ % (self.indent_size, self.indent_char,
-       self.separate_selectors, self.end_with_newline)
+       self.selector_separator_newline, self.end_with_newline, self.newline_between_rules)
 
 
 def default_options():
@@ -325,6 +327,9 @@ class Beautifier:
                     self.next()
                     printer.singleSpace()
                     printer.push("{}")
+                    printer.newLine()
+                    if self.opts.newline_between_rules and printer.indentLevel == 0:
+                        printer.newLine(True)
                 else:
                     printer.indent()
                     printer.openBracket()
@@ -341,6 +346,8 @@ class Beautifier:
                 insideRule = False
                 if printer.nestedLevel:
                     printer.nestedLevel -= 1
+                if self.opts.newline_between_rules and printer.indentLevel == 0:
+                    printer.newLine(True)
             elif self.ch == ":":
                 self.eatWhitespace()
                 if (insideRule or enteringConditionalGroup) and \

--- a/python/cssbeautifier/tests/test.py
+++ b/python/cssbeautifier/tests/test.py
@@ -12,6 +12,7 @@ class CSSBeautifierTest(unittest.TestCase):
         self.options.indent_char = '\t'
         self.options.selector_separator_newline = true
         self.options.end_with_newline = false
+        self.options.newline_between_rules = false
 
     def testGenerated(self):
         self.resetOptions()
@@ -25,6 +26,7 @@ class CSSBeautifierTest(unittest.TestCase):
         self.options.indent_char = '\t'
         self.options.selector_separator_newline = true
         self.options.end_with_newline = false
+        self.options.newline_between_rules = false
 
         # End With Newline - (eof = "\n")
         self.options.end_with_newline = true
@@ -45,6 +47,32 @@ class CSSBeautifierTest(unittest.TestCase):
         t('.tabs { }', '.tabs {}')
         t('.tabs    {    }', '.tabs {}')
         t('.tabs    \n{\n    \n  }', '.tabs {}')
+
+        # Newline Between Rules - (separator = "\n")
+        self.options.newline_between_rules = true
+        t('.div {}\n.span {}', '.div {}\n\n.span {}')
+        t('.div{}\n   \n.span{}', '.div {}\n\n.span {}')
+        t('.div {}    \n  \n.span { } \n', '.div {}\n\n.span {}')
+        t('.div {\n    \n} \n  .span {\n }  ', '.div {}\n\n.span {}')
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n\n.div {\n\theight: 15px;\n}')
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n\n.div {\n\theight: 15px;\n}')
+        t('#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n\n.div {\n\theight: 15px;\n}')
+        t('@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n\n.div {\n\theight: 15px;\n}')
+        t('@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}', '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}')
+        t('a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n\n.div {\n\theight: 15px;\n}')
+
+        # Newline Between Rules - (separator = "")
+        self.options.newline_between_rules = false
+        t('.div {}\n.span {}')
+        t('.div{}\n   \n.span{}', '.div {}\n.span {}')
+        t('.div {}    \n  \n.span { } \n', '.div {}\n.span {}')
+        t('.div {\n    \n} \n  .span {\n }  ', '.div {}\n.span {}')
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div {\n\theight: 15px;\n}')
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n.div {\n\theight: 15px;\n}')
+        t('#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div {\n\theight: 15px;\n}')
+        t('@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div {\n\theight: 15px;\n}')
+        t('@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}')
+        t('a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n.div {\n\theight: 15px;\n}')
 
         # 
 

--- a/test/data/css.js
+++ b/test/data/css.js
@@ -4,6 +4,7 @@ exports.test_data = {
         { name: "indent_char", value: "'\\t'" },
         { name: "selector_separator_newline", value: "true" },
         { name: "end_with_newline", value: "false" },
+        { name: "newline_between_rules", value: "false"},
     ],
     groups: [{
         name: "End With Newline",
@@ -36,6 +37,34 @@ exports.test_data = {
             { input: '.tabs    {    }', output: '.tabs {}' },
             // When we support preserving newlines this will need to change
             { input: '.tabs    \n{\n    \n  }', output: '.tabs {}' }
+        ],
+    }, {
+        name: "Newline Between Rules",
+        description: "",
+        matrix: [
+            {
+                options: [
+                    { name: "newline_between_rules", value: "true" }
+                ],
+                separator: '\\n'
+            }, {
+                options: [
+                    { name: "newline_between_rules", value: "false" }
+                ],
+                separator: ''
+            }
+        ],
+        tests: [
+            { input: '.div {}\n.span {}', output: '.div {}\n{{separator}}.span {}'},
+            { input: '.div{}\n   \n.span{}', output: '.div {}\n{{separator}}.span {}'},
+            { input: '.div {}    \n  \n.span { } \n', output: '.div {}\n{{separator}}.span {}'},
+            { input: '.div {\n    \n} \n  .span {\n }  ', output: '.div {}\n{{separator}}.span {}'},
+            { input: '.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', output: '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n{{separator}}.div {\n\theight: 15px;\n}'},
+            { input: '.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n{{separator}}.div {\n\theight: 15px;\n}'},
+            { input: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', output: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'},
+            { input: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', output: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'},
+            { input: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}', output: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n{{separator}}@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}'},
+            { input: 'a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', output: 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'},
         ],
     }, {
 

--- a/test/template/node-css.mustache
+++ b/test/template/node-css.mustache
@@ -13,7 +13,8 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         space_before_conditional: true,
         break_chained_methods: false,
         selector_separator: '\n',
-        end_with_newline: false
+        end_with_newline: false,
+        newline_between_rules: true,
     };
 
     function test_css_beautifier(input)

--- a/test/template/python-css.mustache
+++ b/test/template/python-css.mustache
@@ -12,6 +12,7 @@ class CSSBeautifierTest(unittest.TestCase):
         self.options.indent_char = '\t'
         self.options.selector_separator_newline = true
         self.options.end_with_newline = false
+        self.options.newline_between_rules = false
 
     def testGenerated(self):
         self.resetOptions()


### PR DESCRIPTION
It's suggested by [Google](https://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml#CSS_Formatting_Rules) that newline should be added between rules, so I think we should support
that and try to make it.

I added this behavior to both JS and Python with tests. Besides, I added
the new option to README and cli.js.

If I need to modify other files, please let me know.

Thanks!
