### PR TITLE
Add GUI support for `--indent-inner-html`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
             $('#unescape-strings').prop('checked', $.cookie('unescape-strings') === 'on');
             $('#jslint-happy').prop('checked', $.cookie('jslint-happy') === 'on');
             $('#end-with-newline').prop('checked', $.cookie('end-with-newline') === 'on');
+            $('#indent-inner-html').prop('checked', $.cookie('indent-inner-html') === 'on');
         }
 
         function store_settings_to_cookie() {
@@ -194,6 +195,8 @@
             $.cookie('end-with-newline', $('#end-with-newline').prop('checked') ? 'on' : 'off', opts);
             $.cookie('wrap-line-length', $('#wrap-line-length').val(), opts);
             $.cookie('indent-scripts', $('#indent-scripts').val(), opts);
+            $.cookie('indent-inner-html', $('#indent-inner-html').prop('checked') ? 'on' : 'off', opts);
+            
         }
 
         function unpacker_filter(source) {
@@ -256,6 +259,7 @@
             opts.jslint_happy = $('#jslint-happy').prop('checked');
             opts.end_with_newline = $('#end-with-newline').prop('checked');
             opts.wrap_line_length = $('#wrap-line-length').val();
+            opts.indent_inner_html = $('#indent-inner-html').prop('checked');
 
             if (looks_like_html(source)) {
                 output = html_beautify(source, opts);
@@ -368,6 +372,9 @@
                 <br>
                 <input class="checkbox" type="checkbox" id="jslint-happy">
                 <label for="jslint-happy">Use JSLint-happy formatting tweaks?</label>
+                <br>
+                <input class="checkbox" type="checkbox" id="indent-inner-html">
+                <label for="indent-inner-html">Indent &lt;head&gt; and &lt;body&gt; sections?</label>
                 <br><a href="?without-codemirror" class="turn-off-codemirror">Use a simple textarea for code input?</a>
 
 


### PR DESCRIPTION
Creates a GUI option to go from:
```html
<html>

<head></head>

<body></body>

</html>
```
To:
```html
<html>

    <head></head>

    <body></body>

</html>
```
I would like to also add an option to go to:
```html
<html>
    <head></head>
    <body></body>
</html>
```
But maybe later, seeing as the underlying engine does not seem to support it (?).