### PR TITLE
Issue 635 - leave handelbars comments as unformatted

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -405,7 +405,7 @@
                     if (indent_handlebars && content[1] && content[1] === '{' && content[2] && content[2] === '!') { //if we're in a comment, do something special
                         // We treat all comments as literals, even more than preformatted tags
                         // we just look for the appropriate close tag
-                        content = [this.get_handlebars_comment(tag_start)];
+                        content = [this.get_comment(tag_start)];
                         break;
                     }
 
@@ -535,32 +535,10 @@
                         } else if (comment.indexOf('<!--') === 0) { // <!-- comment ...
                             delimiter = '-->';
                             matched = true;
+                        } else if (comment.indexOf('{{!') === 0) { // {{! handlebars comment
+                            delimiter = '}}';
+                            matched = true;
                         }
-                    }
-
-                    input_char = this.input.charAt(this.pos);
-                    this.pos++;
-                }
-
-                return comment;
-            };
-
-            this.get_handlebars_comment = function(start_pos) { //function to return handlebars comment content in its entirety
-                var comment = '',
-                    delimiter = '}}',
-                    matched = false;
-
-                this.pos = start_pos;
-                input_char = this.input.charAt(this.pos);
-                this.pos++;
-
-                while (this.pos <= this.input.length) {
-                    comment += input_char;
-
-                    // only need to check for the delimiter if the last chars match
-                    if (comment[comment.length - 1] === delimiter[delimiter.length - 1] &&
-                        comment.indexOf(delimiter) !== -1) {
-                        break;
                     }
 
                     input_char = this.input.charAt(this.pos);

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -417,6 +417,7 @@
                 var tag_complete = content.join('');
                 var tag_index;
                 var tag_offset;
+
                 if (tag_complete.indexOf(' ') !== -1) { //if there's whitespace, thats where the tag name ends
                     tag_index = tag_complete.indexOf(' ');
                 } else if (tag_complete[0] === '{') {
@@ -497,6 +498,7 @@
                     this.pos = orig_pos;
                     this.line_char_count = orig_line_char_count;
                 }
+
                 return content.join(''); //returns fully formatted tag
             };
 
@@ -619,6 +621,7 @@
 
             this.get_token = function() { //initial handler for token-retrieval
                 var token;
+
                 if (this.last_token === 'TK_TAG_SCRIPT' || this.last_token === 'TK_TAG_STYLE') { //check if we need to format javascript
                     var type = this.last_token.substr(7);
                     token = this.get_contents_to(type);

--- a/js/test/beautify-html-tests.js
+++ b/js/test/beautify-html-tests.js
@@ -67,6 +67,13 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             field_expectation = expectation.replace(/content/g, '{{! comment}}');
             test_fragment(field_input, field_expectation);
 
+            // issue 635 test that handlebars comments including multi-line remain unformatted
+            if (opts.indent_handlebars) {
+                field_input = input.replace(/content/g, '{{! \n mult-line\ncomment \n}}');
+                field_expectation = expectation.replace(/content/g, '{{! \n mult-line\ncomment \n}}');
+                test_fragment(field_input, field_expectation);
+            }
+
             // mixed {{field}} and content
             field_input = input.replace(/content/g, 'pre{{field1}} {{field2}} {{field3}}post');
             field_expectation = expectation.replace(/content/g, 'pre{{field1}} {{field2}} {{field3}}post');

--- a/test/template/node-html.mustache
+++ b/test/template/node-html.mustache
@@ -68,6 +68,13 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             field_expectation = expectation.replace(/content/g, '{{! comment}}');
             test_fragment(field_input, field_expectation);
 
+            // issue 635 test that handlebars comments including multi-line remain unformatted
+            if (opts.indent_handlebars) {
+                field_input = input.replace(/content/g, '{{! \n mult-line\ncomment \n}}');
+                field_expectation = expectation.replace(/content/g, '{{! \n mult-line\ncomment \n}}');
+                test_fragment(field_input, field_expectation);
+            }
+
             // mixed {{field}} and content
             field_input = input.replace(/content/g, 'pre{{field1}} {{field2}} {{field3}}post');
             field_expectation = expectation.replace(/content/g, 'pre{{field1}} {{field2}} {{field3}}post');


### PR DESCRIPTION
This is a code suggestion for issue 635 to leave handelbars comments unformatted like html comments. I haven't figured out the test case heirarchy yet to understand where to put a test case. Suggestions would be appreciated.