### PR TITLE
Fix tokenizer's bracket pairs' open stack

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -1518,13 +1518,13 @@
 
                 if (next.type === 'TK_START_BLOCK' || next.type === 'TK_START_EXPR') {
                     next.parent = last;
+                    open_stack.push(open);
                     open = next;
-                    open_stack.push(next);
                 }  else if ((next.type === 'TK_END_BLOCK' || next.type === 'TK_END_EXPR') &&
                     (open && (
                         (next.text === ']' && open.text === '[') ||
                         (next.text === ')' && open.text === '(') ||
-                        (next.text === '}' && open.text === '}')))) {
+                        (next.text === '}' && open.text === '{')))) {
                     next.parent = open.parent;
                     open = open_stack.pop();
                 }

--- a/js/test/beautify-javascript-tests.js
+++ b/js/test/beautify-javascript-tests.js
@@ -1234,6 +1234,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('switch (a) {\n    case /foo\\//:\n        b\n}');
         bt('if (a) /foo\\//\nelse /foo\\//;');
         bt('if (foo) /regex/.test();');
+        bt('for (index in [1, 2, 3]) /^test$/i.test(s)');
         bt('result = yield pgClient.query_(queryString);');
         bt('function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}');
         bt('a=[[1,2],[4,5],[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]');

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1374,13 +1374,13 @@ class Tokenizer:
 
             if next.type == 'TK_START_BLOCK' or next.type == 'TK_START_EXPR':
                 next.parent = last
+                open_stack.append(open)
                 open = next
-                open_stack.append(next)
             elif (next.type == 'TK_END_BLOCK' or next.type == 'TK_END_EXPR') and \
                 (not open == None and ( \
                     (next.text == ']' and open.text == '[') or \
                     (next.text == ')' and open.text == '(') or \
-                    (next.text == '}' and open.text == '}'))):
+                    (next.text == '}' and open.text == '{'))):
                 next.parent = open.parent
                 open = open_stack.pop()
 

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -1029,6 +1029,7 @@ class TestJSBeautifier(unittest.TestCase):
         bt('switch (a) {\n    case /foo\\//:\n        b\n}')
         bt('if (a) /foo\\//\nelse /foo\\//;')
         bt('if (foo) /regex/.test();')
+        bt('for (index in [1, 2, 3]) /^test$/i.test(s)')
         bt('result = yield pgClient.query_(queryString);')
         bt('function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}')
         bt('a=[[1,2],[4,5],[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]')

--- a/test/data/javascript.js
+++ b/test/data/javascript.js
@@ -1108,6 +1108,7 @@ exports.test_data = {
             { unchanged: 'if (a) /foo\\\\//\nelse /foo\\\\//;' },
 
             { unchanged: 'if (foo) /regex/.test();' },
+            { unchanged: "for (index in [1, 2, 3]) /^test$/i.test(s)"},
             { unchanged: 'result = yield pgClient.query_(queryString);' },
 
             { unchanged: 'function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}' },


### PR DESCRIPTION
I found this bug while parsing things like:
```
for (index in [1,2,3]) /^salign$/i.test('salign')
```
(from https://github.com/rspivak/slimit/issues/54)

Before the fix, you get:
```
for (index in [1, 2, 3]) / ^ salign$ / i.test('salign')
```
The regular expression is not detected.

With this fix, the regular expression literal is kept as-is:
```
>>> import jsbeautifier
>>> print jsbeautifier.beautify("for (index in [1,2,3]) /^salign$/i.test('salign')")
for (index in [1,2,3]) /^salign$/i.test('salign')
>>> 
```