### PR TITLE
Remove unnecessary legacy tests

### DIFF
--- a/js/test/node-beautify-tests.js
+++ b/js/test/node-beautify-tests.js
@@ -6,29 +6,25 @@ var SanityTest = require('./sanitytest'),
     run_javascript_tests = require('./beautify-javascript-tests').run_javascript_tests,
     run_css_tests = require('./beautify-css-tests').run_css_tests,
     run_html_tests = require('./beautify-html-tests').run_html_tests;
-
-function node_beautifier_legacy_tests(name, test_runner) {
-    console.log('Testing ' + name + ' with node.js CommonJS (legacy names)...');
-    var results = new SanityTest();
+    
+function test_legacy_names() {    
     var beautify = require('../index');
-
-    test_runner(
-            results,
-            Urlencoded,
-            beautify.js_beautify,
-            beautify.html_beautify,
-            beautify.css_beautify);
-
+    var results = new SanityTest();
+    
+    console.log('First ensure that legacy import names equal the new ones');
+    results.expect(beautify.js, beautify.js_beautify);
+    results.expect(beautify.css, beautify.css_beautify);
+    results.expect(beautify.html, beautify.html_beautify);
+    
     console.log(results.results_raw());
     return results;
 }
-
+    
 function node_beautifier_tests(name, test_runner) {
-    console.log('Testing ' + name + ' with node.js CommonJS (new names)...');
-    var results = new SanityTest();
+    console.log('Testing ' + name + ' with node.js CommonJS...');
     var beautify = require('../index');
-
-
+    
+    var results = new SanityTest();
     test_runner(
             results,
             Urlencoded,
@@ -40,14 +36,11 @@ function node_beautifier_tests(name, test_runner) {
     return results;
 }
 
-
 if (require.main === module) {
     process.exit(
+            test_legacy_names() +
             node_beautifier_tests('js-beautifier', run_javascript_tests).get_exitcode() +
-            node_beautifier_legacy_tests('js-beautifier', run_javascript_tests).get_exitcode() +
             node_beautifier_tests('cs-beautifier', run_css_tests).get_exitcode() +
-            node_beautifier_legacy_tests('css-beautifier', run_css_tests).get_exitcode() +
-            node_beautifier_tests('html-beautifier', run_html_tests).get_exitcode() +
-            node_beautifier_legacy_tests('html-beautifier', run_html_tests).get_exitcode()
+            node_beautifier_tests('html-beautifier', run_html_tests).get_exitcode()
         );
 }


### PR DESCRIPTION
Since the legacy and new names point to the same object,
  there is no need to run through all the tests separately