### PR TITLE
first draft of operator_position functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ python/dist
 python/jsbeautifier.egg-info
 
 target
+.idea/

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -66,6 +66,7 @@ var fs = require('fs'),
         "e4x": Boolean,
         "end_with_newline": Boolean,
         "comma_first": Boolean,
+        "operator_position": ["before-newline", "after-newline", "preserve-newline"],
         // CSS-only
         "selector_separator_newline": Boolean,
         "newline_between_rules": Boolean,
@@ -108,6 +109,7 @@ var fs = require('fs'),
         "X": ["--e4x"],
         "n": ["--end_with_newline"],
         "C": ["--comma_first"],
+        "O": ["--operator_position"],
         // CSS-only
         "L": ["--selector_separator_newline"],
         "N": ["--newline_between_rules"],
@@ -259,6 +261,7 @@ function usage(err) {
             msg.push('  -X, --e4x                         Pass E4X xml literals through untouched');
             msg.push('  --good-stuff                      Warm the cockles of Crockford\'s heart');
             msg.push('  -C, --comma-first                 Put commas at the beginning of new line instead of end');
+            msg.push('  -O, --operator-position           Set operator position (before-newline|after-newline|preserve-newline) [before-newline]');
             break;
         case "html":
             msg.push('  -b, --brace-style                 [collapse|expand|end-expand] ["collapse"]');

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -28,6 +28,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
     default_opts.jslint_happy = false;
     default_opts.keep_array_indentation = false;
     default_opts.brace_style = 'collapse';
+    default_opts.operator_position = 'before-newline';
 
     function reset_options()
     {
@@ -495,6 +496,494 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '        src: [ "im/design_standards/*.*" ],\n' +
             '        dest: "www/gui/build"\n' +
             '    } ]\n' +
+            '}');
+
+
+        reset_options();
+        //============================================================
+        // operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        opts.operator_position = 'before-newline';
+        opts.preserve_newlines = false;
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+
+        // operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        opts.operator_position = 'after-newline';
+        opts.preserve_newlines = false;
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+
+        // operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        opts.operator_position = 'preserve-newline';
+        opts.preserve_newlines = false;
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad');
+
+
+        reset_options();
+        //============================================================
+        // operator_position option - set to 'before-newline' (default value)
+        
+        // comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b -\n' +
+            '    c /\n' +
+            '    d * e %\n' +
+            '    f;\n' +
+            'var res = g & h |\n' +
+            '    i ^\n' +
+            '    j;\n' +
+            'var res = (k &&\n' +
+            '        l ||\n' +
+            '        m) ?\n' +
+            '    n :\n' +
+            '    o;\n' +
+            'var res = p >>\n' +
+            '    q <<\n' +
+            '    r >>>\n' +
+            '    s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    ===\n' +
+            '    u !== v !=\n' +
+            '    w ==\n' +
+            '    x >=\n' +
+            '    y <= z > aa <\n' +
+            '    ab;\n' +
+            'ac +\n' +
+            '    -ad');
+        
+        // colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g :\n' +
+            '    h;\n' +
+            'var i = j ? k :\n' +
+            '    l;');
+        
+        // catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
+            '}',
+            'var d = 1;\n' +
+            'if (a === b &&\n' +
+            '    c) {\n' +
+            '    d = (c * everything /\n' +
+            '            something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean ||\n' +
+            '        aRiver);\n' +
+            '}');
+
+
+        reset_options();
+        //============================================================
+        // operator_position option - set to 'after_newline'
+        opts.operator_position = 'after-newline';
+        
+        // comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b\n' +
+            '    - c\n' +
+            '    / d * e\n' +
+            '    % f;\n' +
+            'var res = g & h\n' +
+            '    | i\n' +
+            '    ^ j;\n' +
+            'var res = (k\n' +
+            '        && l\n' +
+            '        || m)\n' +
+            '    ? n\n' +
+            '    : o;\n' +
+            'var res = p\n' +
+            '    >> q\n' +
+            '    << r\n' +
+            '    >>> s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    === u !== v\n' +
+            '    != w\n' +
+            '    == x\n' +
+            '    >= y <= z > aa\n' +
+            '    < ab;\n' +
+            'ac\n' +
+            '    + -ad');
+        
+        // colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            '    : h;\n' +
+            'var i = j ? k\n' +
+            '    : l;');
+        
+        // catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
+            '}',
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else)\n' +
+            '        % b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple)\n' +
+            '    || (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many\n' +
+            '        || anOcean\n' +
+            '        || aRiver);\n' +
+            '}');
+
+
+        reset_options();
+        //============================================================
+        // operator_position option - set to 'preserve-newline'
+        opts.operator_position = 'preserve-newline';
+        
+        // comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b\n' +
+            '    - c /\n' +
+            '    d * e\n' +
+            '    %\n' +
+            '    f;\n' +
+            'var res = g & h\n' +
+            '    | i ^\n' +
+            '    j;\n' +
+            'var res = (k &&\n' +
+            '        l\n' +
+            '        || m) ?\n' +
+            '    n\n' +
+            '    : o;\n' +
+            'var res = p\n' +
+            '    >> q <<\n' +
+            '    r\n' +
+            '    >>> s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    === u !== v\n' +
+            '    !=\n' +
+            '    w\n' +
+            '    == x >=\n' +
+            '    y <= z > aa <\n' +
+            '    ab;\n' +
+            'ac +\n' +
+            '    -ad');
+        
+        // colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            '    : h;\n' +
+            'var i = j ? k :\n' +
+            '    l;');
+        
+        // catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
             '}');
 
 
@@ -2437,7 +2926,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         // Line wrap test intputs
         //.............---------1---------2---------3---------4---------5---------6---------7
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
-        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -2452,7 +2941,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         //.............---------1---------2---------3---------4---------5---------6---------7
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_2=('{\n' +
-                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -2867,8 +3356,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
         bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;');
         bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
-        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c || d &&\n    e) e = f');
-        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c || d) &&\n    e) e = f');
+        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c ||\n    d &&\n    e) e = f');
+        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c ||\n        d) &&\n    e) e = f');
         test_fragment('\n\n"x"', '"x"');
 
         // this beavior differs between js and python, defaults to unlimited in js, 10 in python

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -39,6 +39,7 @@ class TestJSBeautifier(unittest.TestCase):
         default_options.jslint_happy = false
         default_options.keep_array_indentation = false
         default_options.brace_style = 'collapse'
+        default_options.operator_position = 'before-newline'
 
         cls.default_options = default_options
         cls.wrapregex = re.compile('^(.+)$', re.MULTILINE)
@@ -321,6 +322,494 @@ class TestJSBeautifier(unittest.TestCase):
             '        src: [ "im/design_standards/*.*" ],\n' +
             '        dest: "www/gui/build"\n' +
             '    } ]\n' +
+            '}')
+
+
+        self.reset_options();
+        #============================================================
+        # operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        self.options.operator_position = 'before-newline'
+        self.options.preserve_newlines = false
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+
+        # operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        self.options.operator_position = 'after-newline'
+        self.options.preserve_newlines = false
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+
+        # operator_position option - ensure no neswlines if preserve_newlines is false - ()
+        self.options.operator_position = 'preserve-newline'
+        self.options.preserve_newlines = false
+        bt(
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b - c / d * e % f;\n' +
+            'var res = g & h | i ^ j;\n' +
+            'var res = (k && l || m) ? n : o;\n' +
+            'var res = p >> q << r >>> s;\n' +
+            'var res = t === u !== v != w == x >= y <= z > aa < ab;\n' +
+            'ac + -ad')
+
+
+        self.reset_options();
+        #============================================================
+        # operator_position option - set to 'before-newline' (default value)
+        
+        # comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b -\n' +
+            '    c /\n' +
+            '    d * e %\n' +
+            '    f;\n' +
+            'var res = g & h |\n' +
+            '    i ^\n' +
+            '    j;\n' +
+            'var res = (k &&\n' +
+            '        l ||\n' +
+            '        m) ?\n' +
+            '    n :\n' +
+            '    o;\n' +
+            'var res = p >>\n' +
+            '    q <<\n' +
+            '    r >>>\n' +
+            '    s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    ===\n' +
+            '    u !== v !=\n' +
+            '    w ==\n' +
+            '    x >=\n' +
+            '    y <= z > aa <\n' +
+            '    ab;\n' +
+            'ac +\n' +
+            '    -ad')
+        
+        # colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g :\n' +
+            '    h;\n' +
+            'var i = j ? k :\n' +
+            '    l;')
+        
+        # catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
+            '}',
+            'var d = 1;\n' +
+            'if (a === b &&\n' +
+            '    c) {\n' +
+            '    d = (c * everything /\n' +
+            '            something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean ||\n' +
+            '        aRiver);\n' +
+            '}')
+
+
+        self.reset_options();
+        #============================================================
+        # operator_position option - set to 'after_newline'
+        self.options.operator_position = 'after-newline'
+        
+        # comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b\n' +
+            '    - c\n' +
+            '    / d * e\n' +
+            '    % f;\n' +
+            'var res = g & h\n' +
+            '    | i\n' +
+            '    ^ j;\n' +
+            'var res = (k\n' +
+            '        && l\n' +
+            '        || m)\n' +
+            '    ? n\n' +
+            '    : o;\n' +
+            'var res = p\n' +
+            '    >> q\n' +
+            '    << r\n' +
+            '    >>> s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    === u !== v\n' +
+            '    != w\n' +
+            '    == x\n' +
+            '    >= y <= z > aa\n' +
+            '    < ab;\n' +
+            'ac\n' +
+            '    + -ad')
+        
+        # colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            '    : h;\n' +
+            'var i = j ? k\n' +
+            '    : l;')
+        
+        # catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
+            '}',
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else)\n' +
+            '        % b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple)\n' +
+            '    || (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many\n' +
+            '        || anOcean\n' +
+            '        || aRiver);\n' +
+            '}')
+
+
+        self.reset_options();
+        #============================================================
+        # operator_position option - set to 'preserve-newline'
+        self.options.operator_position = 'preserve-newline'
+        
+        # comprehensive, various newlines
+        bt(
+            'var res = a + b\n' +
+            '- c /\n' +
+            'd  *     e\n' +
+            '%\n' +
+            'f;\n' +
+            '   var res = g & h\n' +
+            '| i ^\n' +
+            'j;\n' +
+            'var res = (k &&\n' +
+            'l\n' +
+            '|| m) ?\n' +
+            'n\n' +
+            ': o\n' +
+            ';\n' +
+            'var res = p\n' +
+            '>> q <<\n' +
+            'r\n' +
+            '>>> s;\n' +
+            'var res\n' +
+            '  = t\n' +
+            '\n' +
+            ' === u !== v\n' +
+            ' !=\n' +
+            'w\n' +
+            '== x >=\n' +
+            'y <= z > aa <\n' +
+            'ab;\n' +
+            'ac +\n' +
+            '-ad',
+            'var res = a + b\n' +
+            '    - c /\n' +
+            '    d * e\n' +
+            '    %\n' +
+            '    f;\n' +
+            'var res = g & h\n' +
+            '    | i ^\n' +
+            '    j;\n' +
+            'var res = (k &&\n' +
+            '        l\n' +
+            '        || m) ?\n' +
+            '    n\n' +
+            '    : o;\n' +
+            'var res = p\n' +
+            '    >> q <<\n' +
+            '    r\n' +
+            '    >>> s;\n' +
+            'var res = t\n' +
+            '\n' +
+            '    === u !== v\n' +
+            '    !=\n' +
+            '    w\n' +
+            '    == x >=\n' +
+            '    y <= z > aa <\n' +
+            '    ab;\n' +
+            'ac +\n' +
+            '    -ad')
+        
+        # colon special case
+        bt(
+            'var a = {\n' +
+            '    b\n' +
+            ': bval,\n' +
+            '    c:\n' +
+            'cval\n' +
+            '    ,d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            ': h;\n' +
+            'var i = j ? k :\n' +
+            'l;',
+            'var a = {\n' +
+            '    b: bval,\n' +
+            '    c: cval,\n' +
+            '    d: dval\n' +
+            '};\n' +
+            'var e = f ? g\n' +
+            '    : h;\n' +
+            'var i = j ? k :\n' +
+            '    l;')
+        
+        # catch-all, includes brackets and other various code
+        bt(
+            'var d = 1;\n' +
+            'if (a === b\n' +
+            '    && c) {\n' +
+            '    d = (c * everything\n' +
+            '            / something_else) %\n' +
+            '        b;\n' +
+            '    e\n' +
+            '        += d;\n' +
+            '\n' +
+            '} else if (!(complex && simple) ||\n' +
+            '    (emotion && emotion.name === "happy")) {\n' +
+            '    cryTearsOfJoy(many ||\n' +
+            '        anOcean\n' +
+            '        || aRiver);\n' +
             '}')
 
 
@@ -2598,7 +3087,7 @@ class TestJSBeautifier(unittest.TestCase):
         # Line wrap test intputs
         #..............---------1---------2---------3---------4---------5---------6---------7
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
-        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -2613,7 +3102,7 @@ class TestJSBeautifier(unittest.TestCase):
         #..............---------1---------2---------3---------4---------5---------6---------7
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_2=('{\n' +
-                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -3033,8 +3522,8 @@ class TestJSBeautifier(unittest.TestCase):
         bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";')
         bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;')
         bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}')
-        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c || d &&\n    e) e = f')
-        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c || d) &&\n    e) e = f')
+        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c ||\n    d &&\n    e) e = f')
+        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c ||\n        d) &&\n    e) e = f')
         test_fragment('\n\n"x"', '"x"')
         # this beavior differs between js and python, defaults to unlimited in js, 10 in python
         bt('a = 1;\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nb = 2;',

--- a/test/data/javascript/inputlib.js
+++ b/test/data/javascript/inputlib.js
@@ -1,0 +1,88 @@
+'use strict';
+
+
+//--------//
+// Inputs //
+//--------//
+
+var ops = ['>', '<', '+', '-', '*', '/', '%', '&', '|', '^', '?', ':'];
+var operator_position = {
+    sanity: [
+        'var res = a + b - c / d * e % f;',
+        'var res = g & h | i ^ j;',
+        'var res = (k && l || m) ? n : o;',
+        'var res = p >> q << r >>> s;',
+        'var res = t === u !== v != w == x >= y <= z > aa < ab;',
+        'ac + -ad'
+    ],
+    comprehensive: [
+        'var res = a + b',
+        '- c /',
+        'd  *     e',
+        '%',
+        'f;',
+        '   var res = g & h',
+        '| i ^',
+        'j;',
+        'var res = (k &&',
+        'l',
+        '|| m) ?',
+        'n',
+        ': o',
+        ';',
+        'var res = p',
+        '>> q <<',
+        'r',
+        '>>> s;',
+        'var res',
+        '  = t',
+        '',
+        ' === u !== v',
+        ' !=',
+        'w',
+        '== x >=',
+        'y <= z > aa <',
+        'ab;',
+        'ac +',
+        '-ad'
+    ],
+    colon_special_case: [
+        'var a = {',
+        '    b',
+        ': bval,',
+        '    c:',
+        'cval',
+        '    ,d: dval',
+        '};',
+        'var e = f ? g',
+        ': h;',
+        'var i = j ? k :',
+        'l;'
+    ],
+    catch_all: [
+        'var d = 1;',
+        'if (a === b',
+        '    && c) {',
+        '    d = (c * everything',
+        '            / something_else) %',
+        '        b;',
+        '    e',
+        '        += d;',
+        '',
+        '} else if (!(complex && simple) ||',
+        '    (emotion && emotion.name === "happy")) {',
+        '    cryTearsOfJoy(many ||',
+        '        anOcean',
+        '        || aRiver);',
+        '}'
+    ]
+};
+
+
+//---------//
+// Exports //
+//---------//
+
+module.exports = {
+    operator_position: operator_position
+}

--- a/test/data/javascript/node.mustache
+++ b/test/data/javascript/node.mustache
@@ -611,7 +611,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         // Line wrap test intputs
         //.............---------1---------2---------3---------4---------5---------6---------7
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
-        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -626,7 +626,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         //.............---------1---------2---------3---------4---------5---------6---------7
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_2=('{\n' +
-                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -1041,8 +1041,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";');
         bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;');
         bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}');
-        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c || d &&\n    e) e = f');
-        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c || d) &&\n    e) e = f');
+        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c ||\n    d &&\n    e) e = f');
+        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c ||\n        d) &&\n    e) e = f');
         test_fragment('\n\n"x"', '"x"');
 
         // this beavior differs between js and python, defaults to unlimited in js, 10 in python

--- a/test/data/javascript/python.mustache
+++ b/test/data/javascript/python.mustache
@@ -772,7 +772,7 @@ class TestJSBeautifier(unittest.TestCase):
         # Line wrap test intputs
         #..............---------1---------2---------3---------4---------5---------6---------7
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
-        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+        wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -787,7 +787,7 @@ class TestJSBeautifier(unittest.TestCase):
         #..............---------1---------2---------3---------4---------5---------6---------7
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_2=('{\n' +
-                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
+                      '    foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
@@ -1207,8 +1207,8 @@ class TestJSBeautifier(unittest.TestCase):
         bt('var a = /*i*/\n"b";', 'var a = /*i*/\n    "b";')
         bt('var a = /*i*/\nb;', 'var a = /*i*/\n    b;')
         bt('{\n\n\n"x"\n}', '{\n\n\n    "x"\n}')
-        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c || d &&\n    e) e = f')
-        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c || d) &&\n    e) e = f')
+        bt('if(a &&\nb\n||\nc\n||d\n&&\ne) e = f', 'if (a &&\n    b ||\n    c ||\n    d &&\n    e) e = f')
+        bt('if(a &&\n(b\n||\nc\n||d)\n&&\ne) e = f', 'if (a &&\n    (b ||\n        c ||\n        d) &&\n    e) e = f')
         test_fragment('\n\n"x"', '"x"')
         # this beavior differs between js and python, defaults to unlimited in js, 10 in python
         bt('a = 1;\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nb = 2;',

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -1,3 +1,5 @@
+var inputlib = require('./inputlib');
+
 exports.test_data = {
     default_options: [
         { name: "indent_size", value: "4" },
@@ -5,7 +7,8 @@ exports.test_data = {
         { name: "preserve_newlines", value: "true" },
         { name: "jslint_happy", value: "false" },
         { name: "keep_array_indentation", value: "false" },
-        { name: "brace_style", value: "'collapse'" }
+        { name: "brace_style", value: "'collapse'" },
+        { name: "operator_position", value: "'before-newline'" }
     ],
     groups: [{
         name: "Unicode Support",
@@ -315,6 +318,233 @@ exports.test_data = {
                 ],
             },
         ],
+    }, {
+        name: "operator_position option - ensure no neswlines if preserve_newlines is false",
+        matrix: [
+            {
+                options: [
+                    { name: "operator_position", value: "'before-newline'" },
+                    { name: "preserve_newlines", value: "false" }
+                ]
+            }, {
+                options: [
+                    { name: "operator_position", value: "'after-newline'" },
+                    { name: "preserve_newlines", value: "false" }
+                ]
+            }, {
+                options: [
+                    { name: "operator_position", value: "'preserve-newline'" },
+                    { name: "preserve_newlines", value: "false" }
+                ]
+            }
+        ],
+        tests: [
+            {
+                unchanged: inputlib.operator_position.sanity
+            }, {
+                input: inputlib.operator_position.comprehensive,
+                output: inputlib.operator_position.sanity,
+            }
+        ]
+    }, {
+        name: "operator_position option - set to 'before-newline' (default value)",
+        tests: [
+            {
+                comment: 'comprehensive, various newlines',
+                input: inputlib.operator_position.comprehensive,
+                output: [
+                    'var res = a + b -',
+                    '    c /',
+                    '    d * e %',
+                    '    f;',
+                    'var res = g & h |',
+                    '    i ^',
+                    '    j;',
+                    'var res = (k &&',
+                    '        l ||',
+                    '        m) ?',
+                    '    n :',
+                    '    o;',
+                    'var res = p >>',
+                    '    q <<',
+                    '    r >>>',
+                    '    s;',
+                    'var res = t',
+                    '',
+                    '    ===',
+                    '    u !== v !=',
+                    '    w ==',
+                    '    x >=',
+                    '    y <= z > aa <',
+                    '    ab;',
+                    'ac +',
+                    '    -ad'
+                ]
+            }, {
+                comment: 'colon special case',
+                input: inputlib.operator_position.colon_special_case,
+                output: [
+                    'var a = {',
+                    '    b: bval,',
+                    '    c: cval,',
+                    '    d: dval',
+                    '};',
+                    'var e = f ? g :',
+                    '    h;',
+                    'var i = j ? k :',
+                    '    l;'
+                ]
+            }, {
+                comment: 'catch-all, includes brackets and other various code',
+                input: inputlib.operator_position.catch_all,
+                output: [
+                    'var d = 1;',
+                    'if (a === b &&',
+                    '    c) {',
+                    '    d = (c * everything /',
+                    '            something_else) %',
+                    '        b;',
+                    '    e',
+                    '        += d;',
+                    '',
+                    '} else if (!(complex && simple) ||',
+                    '    (emotion && emotion.name === "happy")) {',
+                    '    cryTearsOfJoy(many ||',
+                    '        anOcean ||',
+                    '        aRiver);',
+                    '}'
+                ]
+            }
+        ]
+    }, {
+        name: "operator_position option - set to 'after_newline'",
+        options: [{
+            name: "operator_position", value: "'after-newline'"
+        }],
+        tests: [
+            {
+                comment: 'comprehensive, various newlines',
+                input: inputlib.operator_position.comprehensive,
+                output: [
+                    'var res = a + b',
+                    '    - c',
+                    '    / d * e',
+                    '    % f;',
+                    'var res = g & h',
+                    '    | i',
+                    '    ^ j;',
+                    'var res = (k',
+                    '        && l',
+                    '        || m)',
+                    '    ? n',
+                    '    : o;',
+                    'var res = p',
+                    '    >> q',
+                    '    << r',
+                    '    >>> s;',
+                    'var res = t',
+                    '',
+                    '    === u !== v',
+                    '    != w',
+                    '    == x',
+                    '    >= y <= z > aa',
+                    '    < ab;',
+                    'ac',
+                    '    + -ad'
+                ]
+            }, {
+                comment: 'colon special case',
+                input: inputlib.operator_position.colon_special_case,
+                output: [
+                    'var a = {',
+                    '    b: bval,',
+                    '    c: cval,',
+                    '    d: dval',
+                    '};',
+                    'var e = f ? g',
+                    '    : h;',
+                    'var i = j ? k',
+                    '    : l;'
+                ]
+            }, {
+                comment: 'catch-all, includes brackets and other various code',
+                input: inputlib.operator_position.catch_all,
+                output: [
+                    'var d = 1;',
+                    'if (a === b',
+                    '    && c) {',
+                    '    d = (c * everything',
+                    '            / something_else)',
+                    '        % b;',
+                    '    e',
+                    '        += d;',
+                    '',
+                    '} else if (!(complex && simple)',
+                    '    || (emotion && emotion.name === "happy")) {',
+                    '    cryTearsOfJoy(many',
+                    '        || anOcean',
+                    '        || aRiver);',
+                    '}'
+                ]
+            }
+        ]
+    }, {
+        name: "operator_position option - set to 'preserve-newline'",
+        options: [{
+            name: "operator_position", value: "'preserve-newline'"
+        }],
+        tests: [
+            {
+                comment: 'comprehensive, various newlines',
+                input: inputlib.operator_position.comprehensive,
+                output: [
+                    'var res = a + b',
+                    '    - c /',
+                    '    d * e',
+                    '    %',
+                    '    f;',
+                    'var res = g & h',
+                    '    | i ^',
+                    '    j;',
+                    'var res = (k &&',
+                    '        l',
+                    '        || m) ?',
+                    '    n',
+                    '    : o;',
+                    'var res = p',
+                    '    >> q <<',
+                    '    r',
+                    '    >>> s;',
+                    'var res = t',
+                    '',
+                    '    === u !== v',
+                    '    !=',
+                    '    w',
+                    '    == x >=',
+                    '    y <= z > aa <',
+                    '    ab;',
+                    'ac +',
+                    '    -ad'
+                ]
+            }, {
+                comment: 'colon special case',
+                input: inputlib.operator_position.colon_special_case,
+                output: [
+                    'var a = {',
+                    '    b: bval,',
+                    '    c: cval,',
+                    '    d: dval',
+                    '};',
+                    'var e = f ? g',
+                    '    : h;',
+                    'var i = j ? k :',
+                    '    l;'
+                ]
+            }, {
+                comment: 'catch-all, includes brackets and other various code',
+                unchanged: inputlib.operator_position.catch_all
+            }
+        ]
     }, {
         name: "New Test Suite"
     },


### PR DESCRIPTION
 - Added verification of operator_position option.  Throws error if
    invalid.
 - Possible operator_position options are:
    1) undefined (use default behavior)
    2) 'before_newline'
    3) 'after_newline'
    4) 'preserve_newline'
    5) 'remove_newline'
 - Moved some code around in handle_operator in order to separate
    conflicting logic when handling operators.
 - Modified allow_wrap_or_preserved_newline to handle operator
    preserved newlines as well.
 - Fixed a few boolean variable assignments within if statements.
    Though not always the case, the expression within the if can
    be assigned directly to the variable
 - Added -> built tests
 - Within the tests, added an 'inputlib.js' file which holds common
    input arrays.  This was necessary due to the matrices not working
    cleanly with default behavior.
 - It is worth noting that although the python test file was modified,
    this is a result of the built test and not actually providing
    a python port for this option (yet).