### PR TITLE
Prevent incorrect wrapping of return statements.

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -181,6 +181,8 @@
             Expression: 'Expression' //'(EXPRESSION)'
         };
 
+    var newline_restricted_tokens = /^(continue|break|return|throw)/;
+
     function Beautifier(js_source_text, options) {
         "use strict";
         var output
@@ -415,7 +417,6 @@
             return out;
         }
 
-        var _newline_restricted_tokens = /^(continue|break|return|throw)/;
         function allow_wrap_or_preserved_newline(force_linewrap) {
             force_linewrap = (force_linewrap === undefined) ? false : force_linewrap;
 
@@ -427,7 +428,7 @@
             if ((opt.preserve_newlines && current_token.wanted_newline) || force_linewrap) {
                 print_newline(false, true);
             } else if (opt.wrap_line_length) {
-                if (_newline_restricted_tokens.test(flags.last_text)) {
+                if (last_type == 'TK_RESERVED' && newline_restricted_tokens.test(flags.last_text)) {
                     // These tokens should never have a newline inserted
                     // between them and the following expression.
                     return

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -415,6 +415,7 @@
             return out;
         }
 
+        var _newline_restricted_tokens = /^(continue|break|return|throw)/;
         function allow_wrap_or_preserved_newline(force_linewrap) {
             force_linewrap = (force_linewrap === undefined) ? false : force_linewrap;
 
@@ -426,6 +427,11 @@
             if ((opt.preserve_newlines && current_token.wanted_newline) || force_linewrap) {
                 print_newline(false, true);
             } else if (opt.wrap_line_length) {
+                if (_newline_restricted_tokens.test(flags.last_text)) {
+                    // These tokens should never have a newline inserted
+                    // between them and the following expression.
+                    return
+                }
                 var proposed_line_length = output.current_line.get_character_count() + current_token.text.length +
                     (output.space_before_token ? 1 : 0);
                 if (proposed_line_length >= opt.wrap_line_length) {
@@ -528,7 +534,7 @@
             if (
                     (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type === 'TK_WORD') ||
                     (last_type === 'TK_RESERVED' && flags.last_text === 'do') ||
-                    (last_type === 'TK_RESERVED' && flags.last_text === 'return' && !current_token.wanted_newline) ||
+                    (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['return', 'throw']) && !current_token.wanted_newline) ||
                     (last_type === 'TK_RESERVED' && flags.last_text === 'else' && !(current_token.type === 'TK_RESERVED' && current_token.text === 'if')) ||
                     (last_type === 'TK_END_EXPR' && (previous_flags.mode === MODE.ForInitializer || previous_flags.mode === MODE.Conditional)) ||
                     (last_type === 'TK_WORD' && flags.mode === MODE.BlockStatement

--- a/js/test/beautify-javascript-tests.js
+++ b/js/test/beautify-javascript-tests.js
@@ -1924,6 +1924,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1938,6 +1939,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      '    throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       '    if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       '    object_literal = {\n' +
                       '        propertx: first_token + 12345678.99999E-6,\n' +
@@ -1956,6 +1958,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1972,6 +1975,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1990,6 +1994,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -2016,6 +2022,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
@@ -2041,6 +2049,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    throw between_throw_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_.okay();\n' +
@@ -2066,6 +2076,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2084,6 +2095,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap.but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2104,6 +2116,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
@@ -2131,6 +2145,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    .but_this_can\n' +
                       'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'throw between_throw_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
@@ -2157,6 +2173,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    throw between_throw_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_\n' +

--- a/js/test/beautify-javascript-tests.js
+++ b/js/test/beautify-javascript-tests.js
@@ -1923,6 +1923,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1936,6 +1937,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         wrap_input_2=('{\n' +
                       '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       '    object_literal = {\n' +
                       '        propertx: first_token + 12345678.99999E-6,\n' +
@@ -1953,6 +1955,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       /* expected */
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1968,6 +1971,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       /* expected */
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -1984,6 +1988,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -2007,6 +2013,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -2032,6 +2040,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_.okay();\n' +
                       '    object_literal = {\n' +
@@ -2055,6 +2065,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2072,6 +2083,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2090,6 +2102,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
@@ -2115,6 +2129,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
@@ -2139,6 +2155,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_\n' +

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -2041,6 +2041,7 @@ class TestJSBeautifier(unittest.TestCase):
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -2054,6 +2055,7 @@ class TestJSBeautifier(unittest.TestCase):
         wrap_input_2=('{\n' +
                       '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       '    object_literal = {\n' +
                       '        propertx: first_token + 12345678.99999E-6,\n' +
@@ -2071,6 +2073,7 @@ class TestJSBeautifier(unittest.TestCase):
                       # expected #
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -2086,6 +2089,7 @@ class TestJSBeautifier(unittest.TestCase):
                       # expected #
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -2102,6 +2106,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -2125,6 +2131,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -2151,6 +2159,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_.okay();\n' +
                       '    object_literal = {\n' +
@@ -2174,6 +2184,7 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2192,6 +2203,7 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -2210,6 +2222,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
@@ -2235,6 +2249,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
@@ -2259,6 +2275,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '    foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_\n' +

--- a/test/template/node-javascript.mustache
+++ b/test/template/node-javascript.mustache
@@ -591,6 +591,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         //.............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -604,6 +605,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         wrap_input_2=('{\n' +
                       '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       '    object_literal = {\n' +
                       '        propertx: first_token + 12345678.99999E-6,\n' +
@@ -621,6 +623,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       /* expected */
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -636,6 +639,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       /* expected */
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -652,6 +656,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -675,6 +681,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -700,6 +708,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_.okay();\n' +
                       '    object_literal = {\n' +
@@ -723,6 +733,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -740,6 +751,7 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -758,6 +770,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
@@ -783,6 +797,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
@@ -807,6 +823,8 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
                       '    foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_\n' +

--- a/test/template/python-javascript.mustache
+++ b/test/template/python-javascript.mustache
@@ -736,6 +736,7 @@ class TestJSBeautifier(unittest.TestCase):
         #..............1234567890123456789012345678901234567890123456789012345678901234567890
         wrap_input_1=('foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -749,6 +750,7 @@ class TestJSBeautifier(unittest.TestCase):
         wrap_input_2=('{\n' +
                       '    foo.bar().baz().cucumber((fat && "sassy") || (leans\n&& mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n.but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       '    if (wraps_can_occur && inside_an_if_block) that_is_\n.okay();\n' +
                       '    object_literal = {\n' +
                       '        propertx: first_token + 12345678.99999E-6,\n' +
@@ -766,6 +768,7 @@ class TestJSBeautifier(unittest.TestCase):
                       # expected #
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -781,6 +784,7 @@ class TestJSBeautifier(unittest.TestCase):
                       # expected #
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap.but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_.okay();\n' +
                       'object_literal = {\n' +
                       '    propertx: first_token + 12345678.99999E-6,\n' +
@@ -797,6 +801,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -820,6 +826,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_.okay();\n' +
@@ -846,6 +854,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
                       '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
+                      '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_.okay();\n' +
                       '    object_literal = {\n' +
@@ -869,6 +879,7 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -887,6 +898,7 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat && "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap.but_this_can\n' +
                       'if (wraps_can_occur && inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
                       'object_literal = {\n' +
@@ -905,6 +917,8 @@ class TestJSBeautifier(unittest.TestCase):
                       'foo.bar().baz().cucumber((fat &&\n' +
                       '    "sassy") || (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
                       '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
@@ -930,6 +944,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '    (leans && mean));\n' +
                       'Test_very_long_variable_name_this_should_never_wrap\n' +
                       '    .but_this_can\n' +
+                      'return between_return_and_expression_should_never_wrap\n' +
+                      '    .but_this_can\n' +
                       'if (wraps_can_occur &&\n' +
                       '    inside_an_if_block) that_is_\n' +
                       '    .okay();\n' +
@@ -954,6 +970,8 @@ class TestJSBeautifier(unittest.TestCase):
                       '    foo.bar().baz().cucumber((fat && "sassy") ||\n' +
                       '        (leans && mean));\n' +
                       '    Test_very_long_variable_name_this_should_never_wrap\n' +
+                      '        .but_this_can\n' +
+                      '    return between_return_and_expression_should_never_wrap\n' +
                       '        .but_this_can\n' +
                       '    if (wraps_can_occur &&\n' +
                       '        inside_an_if_block) that_is_\n' +


### PR DESCRIPTION
There cannot be a newline between the return keyword and the start of
the return value expression.