### PR TITLE
Fix typo in the example javascript code of index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
             read_settings_from_cookie();
 
             var default_text =
-                "// This is just a sample script. Paste your real code (javascript or HTML) here.\n\nif ('this_is'==/an_example/){of_beautifer();}else{var a=b?(c%d):e[f];}";
+                "// This is just a sample script. Paste your real code (javascript or HTML) here.\n\nif ('this_is'==/an_example/){of_beautifier();}else{var a=b?(c%d):e[f];}";
             var textArea = $('#source')[0];
 
             if (the.use_codemirror && typeof CodeMirror !== 'undefined') {


### PR DESCRIPTION
I have had enough of this typo which I have seen for years now.