### PR TITLE
Resolves #685: Permit ES7 decorators.

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -124,9 +124,13 @@
       // Test whether a given character code starts an identifier.
 
       var isIdentifierStart = exports.isIdentifierStart = function(code) {
-        if (code < 65) return code === 36;
+        // permit $ (36) and @ (64). @ is used in ES7 decorators.
+        if (code < 65) return code === 36 || code === 64;
+        // 65 through 91 are uppercase letters.
         if (code < 91) return true;
+        // permit _ (95).
         if (code < 97) return code === 95;
+        // 97 through 123 are lowercase letters.
         if (code < 123)return true;
         return code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code));
       };

--- a/js/test/beautify-javascript-tests.js
+++ b/js/test/beautify-javascript-tests.js
@@ -264,6 +264,16 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '};');
 
 
+
+        // ES7 Decorators
+        bt('@foo');
+        bt('@foo(bar)');
+        bt(
+            '@foo(function(k, v) {\n' +
+            '    implementation();\n' +
+            '})');
+
+
         // End With Newline - (eof = "\n")
         opts.end_with_newline = true;
         test_fragment('', '\n');

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -192,13 +192,13 @@ class Acorn:
     # Test whether a given character code starts an identifier.
     def isIdentifierStart(self, code):
         if code < 65:
-            return code == 36
+            return code in [36, 64] # permit $ (36) and @ (64). @ is used in ES7 decorators.
         if code < 91:
-            return True
+            return True # 65 through 91 are uppercase letters
         if code < 97:
-            return code == 95
+            return code == 95 # permit _ (95)
         if code < 123:
-            return True
+            return True # 97 through 123 are lowercase letters
         return code >= 0xaa and self.nonASCIIidentifierStart.match(self.six.unichr(code)) != None
 
     # Test whether a given character is part of an identifier.

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -60,6 +60,14 @@ class TestJSBeautifier(unittest.TestCase):
             '    ' + unicode_char(228) + 'rgerlich: true\n' +
             '};')
 
+        # ES7 Decorators
+        bt('@foo')
+        bt('@foo(bar)')
+        bt(
+            '@foo(function(k, v) {\n' +
+            '    implementation();\n' +
+            '})')
+
         # End With Newline - (eof = "\n")
         self.options.end_with_newline = true
         test_fragment('', '\n')

--- a/test/data/javascript.js
+++ b/test/data/javascript.js
@@ -22,6 +22,18 @@ exports.test_data = {
             }
         ],
     }, {
+        name: "ES7 Decorators",
+        description: "Permit ES7 decorators, which are invoked with a leading \"@\".",
+        tests: [
+          { unchanged: '@foo' },
+          { unchanged: '@foo(bar)' },
+          { unchanged: [
+            '@foo(function(k, v) {',
+            '    implementation();',
+            '})'
+          ]}
+        ]
+    }, {
         name: "End With Newline",
         description: "",
         matrix: [


### PR DESCRIPTION
Should resolve #685.

Although decorators are just a [proposal](https://github.com/wycats/javascript-decorators), they are already implemented in Babel, and used in some frameworks. Currently, js-beautifier adds a line break after the unexpected "@" character in the decorator invocation. With this commit, "@" will be an accepted identifier leader, like A-Z, a-z, $, and _.

Tests included and passing locally.