### PR TITLE
is_whitespace for loop incrementing wrong variable

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -171,7 +171,7 @@
 
             // Return true if the given text is composed entirely of whitespace.
             this.is_whitespace = function(text) {
-                for (var n = 0; n < text.length; text++) {
+                for (var n = 0; n < text.length; n++) {
                     if (!this.Utils.in_array(text.charAt(n), this.Utils.whitespace)) {
                         return false;
                     }


### PR DESCRIPTION
Without this fix `is_whitespace` only ever checks the first character. Called when the first token is text content; If that token has leading whitespace the whole token is ignored (content loss). Bug not present in python implementation.