### PR TITLE
Resolve #784 Handlebars {{else}} tag not given a newline

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -831,6 +831,21 @@
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_HANDLEBARS_ELSE':
+                    // Don't add a newline if opening {{#if}} tag is on the current line
+                    var foundIfOnCurrentLine = false;		
+                    for (var lastCheckedOutput=multi_parser.output.length-1; lastCheckedOutput>=0; lastCheckedOutput--) {
+		        if (multi_parser.output[lastCheckedOutput] === '\n') {
+		            break;
+                        } else {
+                            if (multi_parser.output[lastCheckedOutput].match(/{{#if/)) {
+                                foundIfOnCurrentLine = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!foundIfOnCurrentLine) {
+                        multi_parser.print_newline(false, multi_parser.output);
+                    }
                     multi_parser.print_token(multi_parser.token_text);
                     if (multi_parser.indent_content) {
                         multi_parser.indent();

--- a/js/test/beautify-html-tests.js
+++ b/js/test/beautify-html-tests.js
@@ -212,11 +212,6 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         test_fragment('<div class="{{#if thingIs \'value\'}}{{field}}{{/if}}"></div>');
         test_fragment('<div class=\'{{#if thingIs "value"}}{{field}}{{/if}}\'></div>');
         test_fragment('<div class=\'{{#if thingIs \'value\'}}{{field}}{{/if}}\'></div>');
-        test_fragment('<div class=\'{{#if thingIs \'value\'}}{{field}}{{else}}{{field}}{{/if}}\'></div>');
-        test_fragment(
-            '{{#if condition}}<div></div>{{else}}<div></div>{{/if}}',
-            '{{#if condition}}\n    <div></div>\n{{else}}\n    <div></div>\n{{/if}}');
-        test_fragment('{{#if condition}}<span></span>{{else}}<span></span>{{/if}}');
     
         // Handlebars Indenting On - (content = "{{! comment}}")
         opts.indent_handlebars = true;
@@ -383,6 +378,15 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         test_fragment('<div class=\'{{#if thingIs "value"}}{{! \n mult-line\ncomment  \n     with spacing\n}}{{/if}}\'></div>');
         test_fragment('<div class=\'{{#if thingIs \'value\'}}{{! \n mult-line\ncomment  \n     with spacing\n}}{{/if}}\'></div>');
     
+
+
+        // Handlebars Else tag indenting
+        opts.indent_handlebars = true;
+        test_fragment(
+            '{{#if test}}<div></div>{{else}}<div></div>{{/if}}',
+            '{{#if test}}\n    <div></div>\n{{else}}\n    <div></div>\n{{/if}}');
+        test_fragment('{{#if test}}<span></span>{{else}}<span></span>{{/if}}');
+
 
 
         // Unclosed html elements

--- a/js/test/beautify-html-tests.js
+++ b/js/test/beautify-html-tests.js
@@ -212,6 +212,11 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         test_fragment('<div class="{{#if thingIs \'value\'}}{{field}}{{/if}}"></div>');
         test_fragment('<div class=\'{{#if thingIs "value"}}{{field}}{{/if}}\'></div>');
         test_fragment('<div class=\'{{#if thingIs \'value\'}}{{field}}{{/if}}\'></div>');
+        test_fragment('<div class=\'{{#if thingIs \'value\'}}{{field}}{{else}}{{field}}{{/if}}\'></div>');
+        test_fragment(
+            '{{#if condition}}<div></div>{{else}}<div></div>{{/if}}',
+            '{{#if condition}}\n    <div></div>\n{{else}}\n    <div></div>\n{{/if}}');
+        test_fragment('{{#if condition}}<span></span>{{else}}<span></span>{{/if}}');
     
         // Handlebars Indenting On - (content = "{{! comment}}")
         opts.indent_handlebars = true;

--- a/test/data/html.js
+++ b/test/data/html.js
@@ -377,6 +377,27 @@ exports.test_data = {
                 unchanged: '<div class=\\\'{{#if thingIs \\\'value\\\'}}^^^content$$${{/if}}\\\'></div>' }
         ],
     }, {
+        name: "Handlebars Else tag indenting",
+        description: "Handlebar Else tags should be newlined after formatted tags",
+	template: "^^^ $$$",
+        options: [ 
+            {name: "indent_handlebars", value: "true"} 
+	],
+        tests: [
+            { fragment: true,
+              input_:
+	      '{{#if test}}<div></div>{{else}}<div></div>{{/if}}',
+              output:
+              '{{#if test}}\n' +
+              '    <div></div>\n' +
+              '{{else}}\n' +
+              '    <div></div>\n' +
+              '{{/if}}' },
+            { fragment: true,
+              unchanged:
+	      '{{#if test}}<span></span>{{else}}<span></span>{{/if}}' }
+	]
+    }, {
         name: "Unclosed html elements",
         description: "Unclosed elements should not indent",
         options: [],


### PR DESCRIPTION
Solves the problem shown in the issue.

A newline will only be placed before an `{{else}}` tag when it's corresponding `{{#f}}` tag is on a separate line.

My method for finding whether or not an `{{#if}}` tag is on the same line is a bit lame/naive (checking back on previously-output tokens) and could be improved by someone who knows the code base better

N.B only fixed JS version. Python not touched