### PR TITLE
Do not use hardcoded directory for tests

### DIFF
--- a/python/jsbeautifier/tests/shell-smoke-test.sh
+++ b/python/jsbeautifier/tests/shell-smoke-test.sh
@@ -77,30 +77,35 @@ test_cli_js_beautify()
       exit 1
   }
 
-  rm -rf /tmp/js-beautify-mkdir
-  $CLI_SCRIPT -o /tmp/js-beautify-mkdir/js-beautify.js $SCRIPT_DIR/../../../js/bin/js-beautify.js && diff $SCRIPT_DIR/../../../js/bin/js-beautify.js /tmp/js-beautify-mkdir/js-beautify.js || {
-      echo "js-beautify output for $SCRIPT_DIR/../../../js/bin/js-beautify.js should have been created in /tmp/js-beautify-mkdir/js-beautify.js."
+  JS_BEAUTIFY_MKDIR=`mktemp --tmpdir -d js-beautify-mkdir-XXXX`
+  $CLI_SCRIPT -o $JS_BEAUTIFY_MKDIR/js-beautify.js $SCRIPT_DIR/../../../js/bin/js-beautify.js && diff $SCRIPT_DIR/../../../js/bin/js-beautify.js $JS_BEAUTIFY_MKDIR/js-beautify.js || {
+      echo "js-beautify output for $SCRIPT_DIR/../../../js/bin/js-beautify.js should have been created in $JS_BEAUTIFY_MKDIR/js-beautify.js."
       exit 1
   }
 
   # ensure unchanged files are not overwritten
-  cp -p /tmp/js-beautify-mkdir/js-beautify.js /tmp/js-beautify-mkdir/js-beautify-old.js
-  touch -A -05 /tmp/js-beautify-mkdir/js-beautify.js
-  touch -A -01 /tmp/js-beautify-mkdir/js-beautify-old.js
-  $CLI_SCRIPT -r /tmp/js-beautify-mkdir/js-beautify.js && test /tmp/js-beautify-mkdir/js-beautify.js -nt /tmp/js-beautify-mkdir/js-beautify-old.js && {
-      echo "js-beautify should not replace unchanged file /tmp/js-beautify-mkdir/js-beautify.js when using -r"
+  cp -p $JS_BEAUTIFY_MKDIR/js-beautify.js $JS_BEAUTIFY_MKDIR/js-beautify-old.js
+  touch -A -05 $JS_BEAUTIFY_MKDIR/js-beautify.js
+  touch -A -01 $JS_BEAUTIFY_MKDIR/js-beautify-old.js
+  $CLI_SCRIPT -r $JS_BEAUTIFY_MKDIR/js-beautify.js && test $JS_BEAUTIFY_MKDIR/js-beautify.js -nt $JS_BEAUTIFY_MKDIR/js-beautify-old.js && {
+      echo "js-beautify should not replace unchanged file $JS_BEAUTIFY_MKDIR/js-beautify.js when using -r"
+      rm -rf $JS_BEAUTIFY_MKDIR
       exit 1
   }
 
-  $CLI_SCRIPT -o /tmp/js-beautify-mkdir/js-beautify.js /tmp/js-beautify-mkdir/js-beautify.js && test /tmp/js-beautify-mkdir/js-beautify.js -nt /tmp/js-beautify-mkdir/js-beautify-old.js && {
-      echo "js-beautify should not replace unchanged file /tmp/js-beautify-mkdir/js-beautify.js when using -o and same file name"
+  $CLI_SCRIPT -o $JS_BEAUTIFY_MKDIR/js-beautify.js $JS_BEAUTIFY_MKDIR/js-beautify.js && test $JS_BEAUTIFY_MKDIR/js-beautify.js -nt $JS_BEAUTIFY_MKDIR/js-beautify-old.js && {
+      echo "js-beautify should not replace unchanged file $JS_BEAUTIFY_MKDIR/js-beautify.js when using -o and same file name"
+      rm -rf $JS_BEAUTIFY_MKDIR
       exit 1
   }
 
-  $CLI_SCRIPT -o /tmp/js-beautify-mkdir/js-beautify.js /tmp/js-beautify-mkdir/js-beautify-old.js && test /tmp/js-beautify-mkdir/js-beautify.js -nt /tmp/js-beautify-mkdir/js-beautify-old.js && {
-      echo "js-beautify should not replace unchanged file /tmp/js-beautify-mkdir/js-beautify.js when using -o and different file name"
+  $CLI_SCRIPT -o $JS_BEAUTIFY_MKDIR/js-beautify.js $JS_BEAUTIFY_MKDIR/js-beautify-old.js && test $JS_BEAUTIFY_MKDIR/js-beautify.js -nt $JS_BEAUTIFY_MKDIR/js-beautify-old.js && {
+      echo "js-beautify should not replace unchanged file $JS_BEAUTIFY_MKDIR/js-beautify.js when using -o and different file name"
+      rm -rf $JS_BEAUTIFY_MKDIR
       exit 1
   }
+
+  rm -rf $JS_BEAUTIFY_MKDIR
 
   $CLI_SCRIPT $SCRIPT_DIR/../../../js/bin/css-beautify.js | diff -q $SCRIPT_DIR/../../../js/bin/css-beautify.js - && {
       echo "js-beautify output for $SCRIPT_DIR/../../../js/bin/css-beautify.js was expected to be different."


### PR DESCRIPTION
The hardcoded /tmp/js-beautify-mkdir directory path is used for tests,
and this directory it not removed after tests.

This can cause multiplie issues on a build server:
- if multiple builds are running js-beautify tests concurrently, they may try
  to manipulate the directory at the same time, and step on each other's toes
- if multiple users are using the same build machine, since
  /tmp/js-beautify-mkdir is not removed after tests, the permissions on
  /tmp/js-beautify-mkdir will prevent another user to run tests