### PR TITLE
Resolving #810: ES6 Object Literal Shorthand Detection

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -739,7 +739,7 @@
             var next_token = get_token(1)
             var second_token = get_token(2)
             if (second_token && (
-                    (second_token.text === ':' && in_array(next_token.type, ['TK_STRING', 'TK_WORD', 'TK_RESERVED']))
+                    (in_array(second_token.text, [':', ',']) && in_array(next_token.type, ['TK_STRING', 'TK_WORD', 'TK_RESERVED']))
                     || (in_array(next_token.text, ['get', 'set']) && in_array(second_token.type, ['TK_WORD', 'TK_RESERVED']))
                 )) {
                 // We don't support TypeScript,but we didn't break it for a very long time.

--- a/js/test/beautify-javascript-tests.js
+++ b/js/test/beautify-javascript-tests.js
@@ -1277,6 +1277,32 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             'a.b("c",\n' +
             '    () => d.e\n' +
             ')');
+        
+        // Issue 810 - es6 object literal detection
+        bt(
+            'function badFormatting() {\n' +
+            '    return {\n' +
+            '        a,\n' +
+            '        b: c,\n' +
+            '        d: e,\n' +
+            '        f: g,\n' +
+            '        h,\n' +
+            '        i,\n' +
+            '        j: k\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            'function goodFormatting() {\n' +
+            '    return {\n' +
+            '        a: b,\n' +
+            '        c,\n' +
+            '        d: e,\n' +
+            '        f: g,\n' +
+            '        h,\n' +
+            '        i,\n' +
+            '        j: k\n' +
+            '    }\n' +
+            '}');
 
 
 

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -703,7 +703,7 @@ class Beautifier:
         next_token = self.get_token(1)
         second_token = self.get_token(2)
         if second_token != None and \
-            ((second_token.text == ':' and next_token.type in ['TK_STRING', 'TK_WORD', 'TK_RESERVED']) \
+            ((second_token.text in [':', ','] and next_token.type in ['TK_STRING', 'TK_WORD', 'TK_RESERVED']) \
                 or (next_token.text in ['get', 'set'] and second_token.type in ['TK_WORD', 'TK_RESERVED'])):
             # We don't support TypeScript,but we didn't break it for a very long time.
             # We'll try to keep not breaking it.

--- a/python/jsbeautifier/tests/testjsbeautifier.py
+++ b/python/jsbeautifier/tests/testjsbeautifier.py
@@ -23,7 +23,7 @@ class TestJSBeautifier(unittest.TestCase):
         bt('a = /\s+/')
         #bt('a = /\\x41/','a = /A/')
         bt('"\\u2022";a = /\s+/;"\\x41\\x42\\x43\\x01".match(/\\x41/);','"\\u2022";\na = /\s+/;\n"\\x41\\x42\\x43\\x01".match(/\\x41/);')
-        bt('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\x22\\x27", \'\\x22\\x27\', "\\x5c", \'\\x5c\', "\\xff and \\xzz", "unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"')
+        test_fragment('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\x22\\x27", \'\\x22\\x27\', "\\x5c", \'\\x5c\', "\\xff and \\xzz", "unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"')
 
         self.options.unescape_strings = True
 
@@ -31,7 +31,7 @@ class TestJSBeautifier(unittest.TestCase):
         bt('"\\u2022"', '"\\u2022"')
         bt('a = /\s+/')
         bt('"\\u2022";a = /\s+/;"\\x41\\x42\\x43\\x01".match(/\\x41/);','"\\u2022";\na = /\s+/;\n"ABC\\x01".match(/\\x41/);')
-        bt('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\"\'", \'"\\\'\', "\\\\", \'\\\\\', "\\xff and \\xzz", "unicode \\u0000 \\" \' \\\\ \\uffff \\uzzzz"')
+        test_fragment('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\"\'", \'"\\\'\', "\\\\", \'\\\\\', "\\xff and \\xzz", "unicode \\u0000 \\" \' \\\\ \\uffff \\uzzzz"')
 
         self.options.unescape_strings = False
 
@@ -1053,6 +1053,32 @@ class TestJSBeautifier(unittest.TestCase):
             'a.b("c",\n' +
             '    () => d.e\n' +
             ')')
+        
+        # Issue 810 - es6 object literal detection
+        bt(
+            'function badFormatting() {\n' +
+            '    return {\n' +
+            '        a,\n' +
+            '        b: c,\n' +
+            '        d: e,\n' +
+            '        f: g,\n' +
+            '        h,\n' +
+            '        i,\n' +
+            '        j: k\n' +
+            '    }\n' +
+            '}\n' +
+            '\n' +
+            'function goodFormatting() {\n' +
+            '    return {\n' +
+            '        a: b,\n' +
+            '        c,\n' +
+            '        d: e,\n' +
+            '        f: g,\n' +
+            '        h,\n' +
+            '        i,\n' +
+            '        j: k\n' +
+            '    }\n' +
+            '}')
 
         # Old tests
         bt('')

--- a/test/data/javascript.js
+++ b/test/data/javascript.js
@@ -1196,6 +1196,34 @@ exports.test_data = {
                     ')'
                 ]
             },
+            {
+                comment: "Issue 810 - es6 object literal detection",
+                unchanged: [
+                    'function badFormatting() {',
+                    '    return {',
+                    '        a,',
+                    '        b: c,',
+                    '        d: e,',
+                    '        f: g,',
+                    '        h,',
+                    '        i,',
+                    '        j: k',
+                    '    }',
+                    '}',
+                    '',
+                    'function goodFormatting() {',
+                    '    return {',
+                    '        a: b,',
+                    '        c,',
+                    '        d: e,',
+                    '        f: g,',
+                    '        h,',
+                    '        i,',
+                    '        j: k',
+                    '    }',
+                    '}'
+                ]
+            }
         ]
     },
 

--- a/test/template/python-javascript.mustache
+++ b/test/template/python-javascript.mustache
@@ -23,7 +23,7 @@ class TestJSBeautifier(unittest.TestCase):
         bt('a = /\s+/')
         #bt('a = /\\x41/','a = /A/')
         bt('"\\u2022";a = /\s+/;"\\x41\\x42\\x43\\x01".match(/\\x41/);','"\\u2022";\na = /\s+/;\n"\\x41\\x42\\x43\\x01".match(/\\x41/);')
-        bt('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\x22\\x27", \'\\x22\\x27\', "\\x5c", \'\\x5c\', "\\xff and \\xzz", "unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"')
+        test_fragment('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\x22\\x27", \'\\x22\\x27\', "\\x5c", \'\\x5c\', "\\xff and \\xzz", "unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"')
 
         self.options.unescape_strings = True
 
@@ -31,7 +31,7 @@ class TestJSBeautifier(unittest.TestCase):
         bt('"\\u2022"', '"\\u2022"')
         bt('a = /\s+/')
         bt('"\\u2022";a = /\s+/;"\\x41\\x42\\x43\\x01".match(/\\x41/);','"\\u2022";\na = /\s+/;\n"ABC\\x01".match(/\\x41/);')
-        bt('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\"\'", \'"\\\'\', "\\\\", \'\\\\\', "\\xff and \\xzz", "unicode \\u0000 \\" \' \\\\ \\uffff \\uzzzz"')
+        test_fragment('"\\x22\\x27",\'\\x22\\x27\',"\\x5c",\'\\x5c\',"\\xff and \\xzz","unicode \\u0000 \\u0022 \\u0027 \\u005c \\uffff \\uzzzz"', '"\\"\'", \'"\\\'\', "\\\\", \'\\\\\', "\\xff and \\xzz", "unicode \\u0000 \\" \' \\\\ \\uffff \\uzzzz"')
 
         self.options.unescape_strings = False
 


### PR DESCRIPTION
I had to update some of the decode tests - they no longer made sense once wrapped in the second part of the test and were failing. Let me know if this works for you.