### PR TITLE
package.json: Remove "preferGlobal" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.5.10",
   "description": "jsbeautifier.org for node",
   "main": "js/index.js",
-  "preferGlobal": true,
   "bin": {
     "css-beautify": "./js/bin/css-beautify.js",
     "html-beautify": "./js/bin/html-beautify.js",


### PR DESCRIPTION
We use `js-beautify` internally, as part of [`standard`](http://standardjs.com/). Our users get this warning whenever they `npm install standard`:

```
npm WARN prefer global js-beautify@1.5.10 should be installed with -g
```

It's no longer a best-practice to use `preferGlobal` for npm packages that merely contain a command line program. The command line program should be *the only* way to use the package.

Thoughts?