### PR TITLE
Fix incomplete list of non-positionable operators (python lib)

### DIFF
--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -2083,6 +2083,22 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
         reset_options();
         //============================================================
+        // Test non-positionable-ops
+        bt('a += 2;');
+        bt('a -= 2;');
+        bt('a *= 2;');
+        bt('a /= 2;');
+        bt('a %= 2;');
+        bt('a &= 2;');
+        bt('a ^= 2;');
+        bt('a |= 2;');
+        bt('a **= 2;');
+        bt('a <<= 2;');
+        bt('a >>= 2;');
+
+
+        reset_options();
+        //============================================================
         // Destructured and related
         opts.brace_style = 'collapse-preserve-inline';
         

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -1546,7 +1546,7 @@ class Tokenizer:
     positionable_operators = '!= !== % & && * ** + - / : < << <= == === > >= >> >>> ? ^ | ||'.split(' ')
     punct = (positionable_operators +
         # non-positionable operators - these do not follow operator position settings
-        '! %= &= *= ++ += , -- /= :: <<= = => >>= >>>= ^= |= ~'.split(' '))
+        '! %= &= *= **= ++ += , -- -= /= :: <<= = => >>= >>>= ^= |= ~'.split(' '))
 
     # Words which always should start on a new line
     line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',')

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -1908,6 +1908,22 @@ class TestJSBeautifier(unittest.TestCase):
 
         self.reset_options();
         #============================================================
+        # Test non-positionable-ops
+        bt('a += 2;')
+        bt('a -= 2;')
+        bt('a *= 2;')
+        bt('a /= 2;')
+        bt('a %= 2;')
+        bt('a &= 2;')
+        bt('a ^= 2;')
+        bt('a |= 2;')
+        bt('a **= 2;')
+        bt('a <<= 2;')
+        bt('a >>= 2;')
+
+
+        self.reset_options();
+        #============================================================
         # Destructured and related
         self.options.brace_style = 'collapse-preserve-inline'
         

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -1812,6 +1812,22 @@ exports.test_data = {
             },
         ]
     }, {
+        name: "Test non-positionable-ops",
+        description: "Ensure specific bugs do not recur",
+        tests: [
+            { unchanged: 'a += 2;' },
+            { unchanged: 'a -= 2;' },
+            { unchanged: 'a *= 2;' },
+            { unchanged: 'a /= 2;' },
+            { unchanged: 'a %= 2;' },
+            { unchanged: 'a &= 2;' },
+            { unchanged: 'a ^= 2;' },
+            { unchanged: 'a |= 2;' },
+            { unchanged: 'a **= 2;' },
+            { unchanged: 'a <<= 2;' },
+            { unchanged: 'a >>= 2;' },
+        ]
+    }, {
         name: "Destructured and related",
         description: "Ensure specific bugs do not recur",
         options: [{ name: "brace_style", value: "'collapse-preserve-inline'" }],


### PR DESCRIPTION
Now it is the same as the JS list:
js/lib/beautify.js:1746

This caused operations like 'a -= 2;' to be changed to
'a - = 2;', which breaks