### PR TITLE
don't print unpacking errors on stdout (python)

### DIFF
--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -480,7 +480,6 @@ class Beautifier:
         try:
             return unpackers.run(source, evalcode)
         except unpackers.UnpackingError as error:
-            print('error:', error)
             return ''
 
     def is_special_word(self, s):


### PR DESCRIPTION
The current version of python jsbeautifier prints out on the stdout
unpacking errors. For example:

```
In [1]: import jsbeautifier
In [2]: s =
"eval(function(p,a,c,k,e,d){e=function(c){return(c<a?'':e(parseInt(c/a)))+((c=c%a)>35?String.fromCharCode(c+29):c.toString(36))};while(c--){if(k[c]){p=p.replace(new
RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c])}}return p}('L
J=\\'%D%e%7%a%3%p%4%1%4%B%p%0%h%m%4%0%H%4%n%K%6%r%6%e%7%a%3%p%4%m%I%8%f%o%5%7%4%3%2%5%1%6%a%0%v%7%2%2%c%3%0%e%v%0%5%6%j%b%0%9%k%i%8%u%8%g%r%6%a%1%7%2%2%c%3%0%t%5%6%j%b%0%9%1%h%1%k%5%6%r%3%z%6%4%2%a%d%7%2%2%c%3%0%t%5%6%j%b%0%9%i%1%A%1%4%a%o%0%1%w%1%f%6%b%e%0%s%8%8%g%3%f%1%k%4%B%p%0%2%f%1%5%6%r%3%z%6%4%2%a%d%7%2%2%c%3%0%t%5%6%j%b%0%9%1%h%h%1%m%o%5%9%0%f%3%5%0%9%m%1%F%F%1%C%7%2%2%c%3%0%t%5%6%j%b%0%9%i%8%g%u%1%8%g%g%9%2%7%o%E%0%5%4%d%7%2%2%c%3%0%h%m%4%0%e%4%7%2%2%c%3%0%m%s%8%g%g%7%2%2%c%3%0%t%5%6%j%b%0%9%1%h%1%k%9%2%7%o%E%0%5%4%d%7%2%2%c%3%0%d%3%5%9%0%H%Q%f%k%m%4%0%e%4%7%2%2%c%3%0%m%i%1%C%h%1%G%P%i%1%A%1%4%a%o%0%1%w%1%f%6%b%e%0%s%8%g%x%8%g%a%0%4%o%a%5%1%k%7%2%2%c%3%0%t%5%6%j%b%0%9%i%s%8%x%8%3%f%1%k%6%a%0%v%7%2%2%c%3%0%e%v%0%5%6%j%b%0%9%k%i%i%1%u%8%1%1%1%1%l%3%5%9%2%l%d%b%2%7%6%4%3%2%5%d%q%a%0%f%1%h%1%y%q%4%4%p%w%n%n%l%l%l%d%e%6%r%0%4%q%0%7%q%3%b%9%a%0%5%d%2%a%z%y%s%8%x%1%0%b%e%0%1%u%8%1%1%1%1%l%3%5%9%2%l%d%b%2%7%6%4%3%2%5%d%q%a%0%f%1%h%1%y%q%4%4%p%w%n%n%e%6%r%0%G%l%3%b%9%b%3%f%0%d%5%0%4%n%y%s%8%x%8%D%n%e%7%a%3%p%4%I\\';N.M(O(J));',53,53,'u0065|u0020|u006f|u0069|u0074|u006e|u0061|u0063|u000a|u0064|u0072|u006c|u006b|u002e|u0073|u0066|u0009|u003d|u0029|u0062|u0028|u0077|u0022|u002f|u0075|u0070|u0068|u0076|u003b|u0045|u007b|u005f|u003a|u007d|u0027|u0067|u003f|u0079|u0021|u003c|u006d|u0026|u002d|u0078|u003e|_escape|u006a|var|write|document|unescape|u0031|u004f'.split('|')))"
In [3]: jsbeautifier.beautify(s)
error: Unknown p.a.c.k.e.r. encoding.
```

This potentially breaks programs that use jsbeautifier as a library
rather than as a script.

This commit simply removes the print statement.