### PR TITLE
add option for space_around_selector_separator in css

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ CSS Beautifier Options:
   -t, --indent-with-tabs             Indent with tabs, overrides -s and -c
   -e, --eol                          Character(s) to use as line terminators. (default newline - "\\n")
   -n, --end-with-newline             End output with newline
+  --space_around_selector_separator  Add spaces around CSS selector separators (>+~)
   -L, --selector-separator-newline   Add a newline between multiple selectors
   -N, --newline-between-rules        Add a newline between CSS rules
 

--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -39,21 +39,23 @@
         css_beautify(source_text, options);
 
     The options are (default in brackets):
-        indent_size (4)                   — indentation size,
-        indent_char (space)               — character to indent with,
-        selector_separator_newline (true) - separate selectors with newline or
-                                            not (e.g. "a,\nbr" or "a, br")
-        end_with_newline (false)          - end with a newline
-        newline_between_rules (true)      - add a new line after every css rule
-
+        indent_size (4)                         — indentation size,
+        indent_char (space)                     — character to indent with,
+        selector_separator_newline (true)       - separate selectors with newline or
+                                                  not (e.g. "a,\nbr" or "a, br")
+        end_with_newline (false)                - end with a newline
+        newline_between_rules (true)            - add a new line after every css rule
+        space_around_selector_separator (false) - ensure space around selector separators:
+                                                  '>', '+', '~' (e.g. "a>b" -> "a > b")
     e.g
 
     css_beautify(css_source_text, {
       'indent_size': 1,
       'indent_char': '\t',
-      'selector_separator': ' ',
+      'selector_separator_newline': true,
       'end_with_newline': false,
       'newline_between_rules': true
+      'space_around_selector_separator': true
     });
 */
 
@@ -72,6 +74,7 @@
         var selectorSeparatorNewline = (options.selector_separator_newline === undefined) ? true : options.selector_separator_newline;
         var end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
         var newline_between_rules = (options.newline_between_rules === undefined) ? true : options.newline_between_rules;
+        var spaceAroundSelectorSeparator = (options.space_around_selector_separator === undefined) ? false : options.space_around_selector_separator;
         var eol = options.eol ? options.eol : '\n';
 
         // compatibility
@@ -84,8 +87,8 @@
             indentSize = 1;
         }
 
-        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
-
+        eol = eol.replace(/\\r/, '\r')
+            .replace(/\\n/, '\n');
 
         // tokenizer
         var whiteRe = /^\s+$/;
@@ -169,9 +172,9 @@
             return source_text.substring(start, pos) + ch;
         }
 
-
         function lookBack(str) {
-            return source_text.substring(pos - str.length, pos).toLowerCase() ===
+            return source_text.substring(pos - str.length, pos)
+                .toLowerCase() ===
                 str;
         }
 
@@ -201,7 +204,8 @@
 
         // printer
         var basebaseIndentString = source_text.match(/^[\t ]*/)[0];
-        var singleIndent = new Array(indentSize + 1).join(indentCharacter);
+        var singleIndent = new Array(indentSize + 1)
+            .join(indentCharacter);
         var indentLevel = 0;
         var nestedLevel = 0;
 
@@ -262,7 +266,6 @@
             }
         };
 
-
         var output = [];
         /*_____________________--------------------_____________________*/
 
@@ -315,7 +318,8 @@
                     if (variableOrRule.match(/[ :]$/)) {
                         // we have a variable or pseudo-class, add it and insert one space before continuing
                         next();
-                        variableOrRule = eatString(": ").replace(/\s$/, '');
+                        variableOrRule = eatString(": ")
+                            .replace(/\s$/, '');
                         output.push(variableOrRule);
                         print.singleSpace();
                     }
@@ -422,6 +426,15 @@
                 } else {
                     print.singleSpace();
                 }
+            } else if (ch === '>' || ch === '+' || ch === '~') {
+                //handl selector separator spacing
+                if (spaceAroundSelectorSeparator && !insidePropertyValue && parenLevel < 1) {
+                    print.singleSpace();
+                    output.push(ch);
+                    print.singleSpace();
+                } else {
+                    output.push(ch);
+                }
             } else if (ch === ']') {
                 output.push(ch);
             } else if (ch === '[') {
@@ -437,13 +450,13 @@
             }
         }
 
-
         var sweetCode = '';
         if (basebaseIndentString) {
             sweetCode += basebaseIndentString;
         }
 
-        sweetCode += output.join('').replace(/[\r\n\t ]+$/, '');
+        sweetCode += output.join('')
+            .replace(/[\r\n\t ]+$/, '');
 
         // establish end_with_newline
         if (end_with_newline) {

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -115,7 +115,8 @@
         indent_size = (options.indent_size === undefined) ? 4 : parseInt(options.indent_size, 10);
         indent_character = (options.indent_char === undefined) ? ' ' : options.indent_char;
         brace_style = (options.brace_style === undefined) ? 'collapse' : options.brace_style;
-        wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
+        wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250,
+            10);
         unformatted = options.unformatted || [
             // https://www.w3.org/TR/html5/dom.html#phrasing-content
             'a', 'abbr', 'area', 'audio', 'b', 'bdi', 'bdo', 'br', 'button', 'canvas', 'cite',
@@ -135,7 +136,8 @@
             0;
         indent_handlebars = (options.indent_handlebars === undefined) ? false : options.indent_handlebars;
         wrap_attributes = (options.wrap_attributes === undefined) ? 'auto' : options.wrap_attributes;
-        wrap_attributes_indent_size = (isNaN(parseInt(options.wrap_attributes_indent_size, 10))) ? indent_size : parseInt(options.wrap_attributes_indent_size, 10);
+        wrap_attributes_indent_size = (isNaN(parseInt(options.wrap_attributes_indent_size, 10))) ? indent_size : parseInt(
+            options.wrap_attributes_indent_size, 10);
         end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
         extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
             options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
@@ -147,7 +149,8 @@
             indent_size = 1;
         }
 
-        eol = eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
+        eol = eol.replace(/\\r/, '\r')
+            .replace(/\\n/, '\n');
 
         function Parser() {
 
@@ -457,7 +460,8 @@
                         break;
                     }
 
-                    if (indent_handlebars && tag_start_char === '{' && content.length > 2 && content[content.length - 2] === '}' && content[content.length - 1] === '}') {
+                    if (indent_handlebars && tag_start_char === '{' && content.length > 2 && content[content.length - 2] === '}' &&
+                        content[content.length - 1] === '}') {
                         break;
                     }
                 } while (input_char !== '>');
@@ -478,7 +482,8 @@
                 } else {
                     tag_offset = tag_complete.charAt(2) === '#' ? 3 : 2;
                 }
-                var tag_check = tag_complete.substring(tag_offset, tag_index).toLowerCase();
+                var tag_check = tag_complete.substring(tag_offset, tag_index)
+                    .toLowerCase();
                 if (tag_complete.charAt(tag_complete.length - 2) === '/' ||
                     this.Utils.in_array(tag_check, this.Utils.single_token)) { //if this tag name is a single tag type (either in the list or has a closing /)
                     if (!peek) {
@@ -499,7 +504,8 @@
                 } else if (tag_check === 'script' &&
                     (tag_complete.search('type') === -1 ||
                         (tag_complete.search('type') > -1 &&
-                            tag_complete.search(/\b(text|application)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json)/) > -1))) {
+                            tag_complete.search(/\b(text|application)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json)/) > -1)
+                    )) {
                     if (!peek) {
                         this.record_tag(tag_check);
                         this.tag_type = 'SCRIPT';
@@ -607,7 +613,8 @@
 
                 var add = function(str) {
                     var newToken = token + str.toLowerCase();
-                    token = newToken.length <= delimiter.length ? newToken : newToken.substr(newToken.length - delimiter.length, delimiter.length);
+                    token = newToken.length <= delimiter.length ? newToken : newToken.substr(newToken.length - delimiter.length,
+                        delimiter.length);
                 };
 
                 var doesNotMatch = function() {
@@ -621,7 +628,8 @@
             }
 
             this.get_unformatted = function(delimiter, orig_tag) { //function to return unformatted content in its entirety
-                if (orig_tag && orig_tag.toLowerCase().indexOf(delimiter) !== -1) {
+                if (orig_tag && orig_tag.toLowerCase()
+                    .indexOf(delimiter) !== -1) {
                     return '';
                 }
                 var input_char = '';
@@ -708,7 +716,8 @@
                     return '';
                 }
 
-                return Array(level + 1).join(this.indent_string);
+                return Array(level + 1)
+                    .join(this.indent_string);
             };
 
             this.is_unformatted = function(tag_check, unformatted) {
@@ -726,7 +735,8 @@
                 var next_tag = this.get_tag(true /* peek. */ );
 
                 // test next_tag to see if it is just html tag (no external content)
-                var tag = (next_tag || "").match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
+                var tag = (next_tag || "")
+                    .match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
 
                 // if next_tag comes back but is not an isolated tag, then
                 // let's treat the 'a' tag as having content
@@ -867,7 +877,8 @@
                             tag_extracted_from_last_output = multi_parser.output[multi_parser.output.length - 1].match(/(?:<|{{#)\s*(\w+)/);
                         }
                         if (tag_extracted_from_last_output === null ||
-                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted))) {
+                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[
+                                1], unformatted))) {
                             multi_parser.print_newline(false, multi_parser.output);
                         }
                     }
@@ -946,7 +957,8 @@
                         } else {
                             // simply indent the string otherwise
                             var white = text.match(/^\s*/)[0];
-                            var _level = white.match(/[^\n\r]*$/)[0].split(multi_parser.indent_string).length - 1;
+                            var _level = white.match(/[^\n\r]*$/)[0].split(multi_parser.indent_string)
+                                .length - 1;
                             var reindent = multi_parser.get_full_indent(script_indent_level - _level);
                             text = text.replace(/^\s*/, indentation)
                                 .replace(/\r\n|\r|\n/g, '\n' + reindent)
@@ -970,7 +982,8 @@
             multi_parser.last_token = multi_parser.token_type;
             multi_parser.last_text = multi_parser.token_text;
         }
-        var sweet_code = multi_parser.output.join('').replace(/[\r\n\t ]+$/, '');
+        var sweet_code = multi_parser.output.join('')
+            .replace(/[\r\n\t ]+$/, '');
 
         // establish end_with_newline
         if (end_with_newline) {

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -126,8 +126,10 @@ if (!Object.values) {
         // code point above 128.
 
         var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/; // jshint ignore:line
-        var nonASCIIidentifierStartChars = "\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc";
-        var nonASCIIidentifierChars = "\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f";
+        var nonASCIIidentifierStartChars =
+            "\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc";
+        var nonASCIIidentifierChars =
+            "\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f";
         var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
         var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
 
@@ -142,7 +144,6 @@ if (!Object.values) {
         // in python they are the same, different methods are called on them
         exports.lineBreak = new RegExp('\r\n|' + exports.newline.source);
         exports.allLineBreaks = new RegExp(exports.lineBreak.source, 'g');
-
 
         // Test whether a given character code starts an identifier.
 
@@ -319,7 +320,8 @@ if (!Object.values) {
         opt.eol = options.eol ? options.eol : 'auto';
         opt.preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
         opt.break_chained_methods = (options.break_chained_methods === undefined) ? false : options.break_chained_methods;
-        opt.max_preserve_newlines = (options.max_preserve_newlines === undefined) ? 0 : parseInt(options.max_preserve_newlines, 10);
+        opt.max_preserve_newlines = (options.max_preserve_newlines === undefined) ? 0 : parseInt(options.max_preserve_newlines,
+            10);
         opt.space_in_paren = (options.space_in_paren === undefined) ? false : options.space_in_paren;
         opt.space_in_empty_paren = (options.space_in_empty_paren === undefined) ? false : options.space_in_empty_paren;
         opt.jslint_happy = (options.jslint_happy === undefined) ? false : options.jslint_happy;
@@ -353,7 +355,8 @@ if (!Object.values) {
             }
         }
 
-        opt.eol = opt.eol.replace(/\\r/, '\r').replace(/\\n/, '\n');
+        opt.eol = opt.eol.replace(/\\r/, '\r')
+            .replace(/\\n/, '\n');
 
         //----------------------------------
         indent_string = '';
@@ -378,7 +381,6 @@ if (!Object.values) {
 
         // If testing the ignore directive, start with output disable set to true
         output.raw = opt.test_output_raw;
-
 
         // Stack of parsing/formatting states, including MODE.
         // We tokenize, parse, and output in an almost purely a forward-only stream of token input
@@ -491,7 +493,8 @@ if (!Object.values) {
             }
 
             var shouldPreserveOrForce = (opt.preserve_newlines && current_token.wanted_newline) || force_linewrap;
-            var operatorLogicApplies = in_array(flags.last_text, Tokenizer.positionable_operators) || in_array(current_token.text, Tokenizer.positionable_operators);
+            var operatorLogicApplies = in_array(flags.last_text, Tokenizer.positionable_operators) || in_array(current_token.text,
+                Tokenizer.positionable_operators);
 
             if (operatorLogicApplies) {
                 var shouldPrintOperatorNewline = (
@@ -617,15 +620,19 @@ if (!Object.values) {
 
         function start_of_object_property() {
             return flags.parent.mode === MODE.ObjectLiteral && flags.mode === MODE.Statement && (
-                (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['get', 'set'])));
+                (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, [
+                    'get', 'set'
+                ])));
         }
 
         function start_of_statement() {
             if (
-                (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type === 'TK_WORD') ||
+                (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type ===
+                    'TK_WORD') ||
                 (last_type === 'TK_RESERVED' && flags.last_text === 'do') ||
                 (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['return', 'throw']) && !current_token.wanted_newline) ||
-                (last_type === 'TK_RESERVED' && flags.last_text === 'else' && !(current_token.type === 'TK_RESERVED' && current_token.text === 'if')) ||
+                (last_type === 'TK_RESERVED' && flags.last_text === 'else' && !(current_token.type === 'TK_RESERVED' &&
+                    current_token.text === 'if')) ||
                 (last_type === 'TK_END_EXPR' && (previous_flags.mode === MODE.ForInitializer || previous_flags.mode === MODE.Conditional)) ||
                 (last_type === 'TK_WORD' && flags.mode === MODE.BlockStatement &&
                     !flags.in_case &&
@@ -633,13 +640,16 @@ if (!Object.values) {
                     last_last_text !== 'function' &&
                     current_token.type !== 'TK_WORD' && current_token.type !== 'TK_RESERVED') ||
                 (flags.mode === MODE.ObjectLiteral && (
-                    (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['get', 'set']))))
+                    (flags.last_text === ':' && flags.ternary_depth === 0) || (last_type === 'TK_RESERVED' && in_array(flags.last_text, [
+                        'get', 'set'
+                    ]))))
             ) {
 
                 set_mode(MODE.Statement);
                 indent();
 
-                if (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type === 'TK_WORD') {
+                if (last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const']) && current_token.type ===
+                    'TK_WORD') {
                     flags.declaration_statement = true;
                 }
 
@@ -736,11 +746,13 @@ if (!Object.values) {
 
             if (flags.last_text === ';' || last_type === 'TK_START_BLOCK') {
                 print_newline();
-            } else if (last_type === 'TK_END_EXPR' || last_type === 'TK_START_EXPR' || last_type === 'TK_END_BLOCK' || flags.last_text === '.') {
+            } else if (last_type === 'TK_END_EXPR' || last_type === 'TK_START_EXPR' || last_type === 'TK_END_BLOCK' || flags.last_text ===
+                '.') {
                 // TODO: Consider whether forcing this is required.  Review failing tests when removed.
                 allow_wrap_or_preserved_newline(current_token.wanted_newline);
                 // do nothing on (( and )( and ][ and ]( and .(
-            } else if (!(last_type === 'TK_RESERVED' && current_token.text === '(') && last_type !== 'TK_WORD' && last_type !== 'TK_OPERATOR') {
+            } else if (!(last_type === 'TK_RESERVED' && current_token.text === '(') && last_type !== 'TK_WORD' && last_type !==
+                'TK_OPERATOR') {
                 output.space_before_token = true;
             } else if ((last_type === 'TK_RESERVED' && (flags.last_word === 'function' || flags.last_word === 'typeof')) ||
                 (flags.last_text === '*' && last_last_text === 'function')) {
@@ -748,7 +760,8 @@ if (!Object.values) {
                 if (opt.space_after_anon_function) {
                     output.space_before_token = true;
                 }
-            } else if (last_type === 'TK_RESERVED' && (in_array(flags.last_text, Tokenizer.line_starters) || flags.last_text === 'catch')) {
+            } else if (last_type === 'TK_RESERVED' && (in_array(flags.last_text, Tokenizer.line_starters) || flags.last_text ===
+                    'catch')) {
                 if (opt.space_before_conditional) {
                     output.space_before_token = true;
                 }
@@ -860,7 +873,6 @@ if (!Object.values) {
             var empty_anonymous_function = empty_braces && flags.last_word === 'function' &&
                 last_type === 'TK_END_EXPR';
 
-
             if (opt.brace_style === "expand" ||
                 (opt.brace_style === "none" && current_token.wanted_newline)) {
                 if (last_type !== 'TK_OPERATOR' &&
@@ -963,7 +975,9 @@ if (!Object.values) {
             } else if (current_token.wanted_newline && !is_expression(flags.mode) &&
                 (last_type !== 'TK_OPERATOR' || (flags.last_text === '--' || flags.last_text === '++')) &&
                 last_type !== 'TK_EQUALS' &&
-                (opt.preserve_newlines || !(last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const', 'set', 'get'])))) {
+                (opt.preserve_newlines || !(last_type === 'TK_RESERVED' && in_array(flags.last_text, ['var', 'let', 'const', 'set',
+                    'get'
+                ])))) {
 
                 print_newline();
             }
@@ -999,7 +1013,8 @@ if (!Object.values) {
                 }
             }
 
-            if (current_token.type === 'TK_RESERVED' && (current_token.text === 'case' || (current_token.text === 'default' && flags.in_case_statement))) {
+            if (current_token.type === 'TK_RESERVED' && (current_token.text === 'case' || (current_token.text === 'default' &&
+                    flags.in_case_statement))) {
                 print_newline();
                 if (flags.case_body || opt.jslint_happy) {
                     // switch cases following one another
@@ -1013,7 +1028,9 @@ if (!Object.values) {
             }
 
             if (current_token.type === 'TK_RESERVED' && current_token.text === 'function') {
-                if (in_array(flags.last_text, ['}', ';']) || (output.just_added_newline() && !in_array(flags.last_text, ['[', '{', ':', '=', ',']))) {
+                if (in_array(flags.last_text, ['}', ';']) || (output.just_added_newline() && !in_array(flags.last_text, ['[', '{',
+                        ':', '=', ','
+                    ]))) {
                     // make sure there is a nice clean space of at least one blank line
                     // before a new function definition
                     if (!output.just_added_blankline() && !current_token.comments_before.length) {
@@ -1039,7 +1056,8 @@ if (!Object.values) {
                 }
             }
 
-            if (last_type === 'TK_COMMA' || last_type === 'TK_START_EXPR' || last_type === 'TK_EQUALS' || last_type === 'TK_OPERATOR') {
+            if (last_type === 'TK_COMMA' || last_type === 'TK_START_EXPR' || last_type === 'TK_EQUALS' || last_type ===
+                'TK_OPERATOR') {
                 if (!start_of_object_property()) {
                     allow_wrap_or_preserved_newline();
                 }
@@ -1088,7 +1106,8 @@ if (!Object.values) {
                 prefix = 'NEWLINE';
             }
 
-            if (current_token.type === 'TK_RESERVED' && in_array(current_token.text, Tokenizer.line_starters) && flags.last_text !== ')') {
+            if (current_token.type === 'TK_RESERVED' && in_array(current_token.text, Tokenizer.line_starters) && flags.last_text !==
+                ')') {
                 if (flags.last_text === 'else' || flags.last_text === 'export') {
                     prefix = 'SPACE';
                 } else {
@@ -1118,7 +1137,9 @@ if (!Object.values) {
                     // no newline between 'return nnn'
                     output.space_before_token = true;
                 } else if (last_type !== 'TK_END_EXPR') {
-                    if ((last_type !== 'TK_START_EXPR' || !(current_token.type === 'TK_RESERVED' && in_array(current_token.text, ['var', 'let', 'const']))) && flags.last_text !== ':') {
+                    if ((last_type !== 'TK_START_EXPR' || !(current_token.type === 'TK_RESERVED' && in_array(current_token.text, [
+                            'var', 'let', 'const'
+                        ]))) && flags.last_text !== ':') {
                         // no need to force newline on 'var': for (var x = 0...)
                         if (current_token.type === 'TK_RESERVED' && current_token.text === 'if' && flags.last_text === 'else') {
                             // no newline for } else if {
@@ -1127,7 +1148,8 @@ if (!Object.values) {
                             print_newline();
                         }
                     }
-                } else if (current_token.type === 'TK_RESERVED' && in_array(current_token.text, Tokenizer.line_starters) && flags.last_text !== ')') {
+                } else if (current_token.type === 'TK_RESERVED' && in_array(current_token.text, Tokenizer.line_starters) && flags.last_text !==
+                    ')') {
                     print_newline();
                 }
             } else if (flags.multiline_frame && is_array(flags.mode) && flags.last_text === ',' && last_last_text === '}') {
@@ -1175,7 +1197,8 @@ if (!Object.values) {
                 output.space_before_token = true;
             } else if (last_type === 'TK_RESERVED' || last_type === 'TK_WORD' || flags.inline_frame) {
                 output.space_before_token = true;
-            } else if (last_type === 'TK_COMMA' || last_type === 'TK_START_EXPR' || last_type === 'TK_EQUALS' || last_type === 'TK_OPERATOR') {
+            } else if (last_type === 'TK_COMMA' || last_type === 'TK_START_EXPR' || last_type === 'TK_EQUALS' || last_type ===
+                'TK_OPERATOR') {
                 if (!start_of_object_property()) {
                     allow_wrap_or_preserved_newline();
                 }
@@ -1275,7 +1298,8 @@ if (!Object.values) {
             var space_before = true;
             var space_after = true;
             var in_ternary = false;
-            var isGeneratorAsterisk = current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text === 'function';
+            var isGeneratorAsterisk = current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text ===
+                'function';
             var isUnary = in_array(current_token.text, ['-', '+']) && (
                 in_array(last_type, ['TK_START_BLOCK', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']) ||
                 in_array(flags.last_text, Tokenizer.line_starters) ||
@@ -1321,7 +1345,8 @@ if (!Object.values) {
                         output.space_before_token = true;
 
                         if (!isColon || isTernaryColon) {
-                            if (get_token(1).wanted_newline) {
+                            if (get_token(1)
+                                .wanted_newline) {
                                 print_newline(false, true);
                             } else {
                                 allow_wrap_or_preserved_newline();
@@ -1376,7 +1401,9 @@ if (!Object.values) {
                 } else if (last_type === 'TK_OPERATOR') {
                     // a++ + ++b;
                     // a - -b
-                    space_before = in_array(current_token.text, ['--', '-', '++', '+']) && in_array(flags.last_text, ['--', '-', '++', '+']);
+                    space_before = in_array(current_token.text, ['--', '-', '++', '+']) && in_array(flags.last_text, ['--', '-', '++',
+                        '+'
+                    ]);
                     // + and - are not unary when preceeded by -- or ++ operator
                     // a-- + b
                     // a * +b
@@ -1385,7 +1412,6 @@ if (!Object.values) {
                         space_after = true;
                     }
                 }
-
 
                 if (((flags.mode === MODE.BlockStatement && !flags.inline_frame) || flags.mode === MODE.Statement) &&
                     (flags.last_text === '{' || flags.last_text === ';')) {
@@ -1508,7 +1534,6 @@ if (!Object.values) {
         }
     }
 
-
     function OutputLine(parent) {
         var _character_count = 0;
         // use indent_count as a marker for lines that have preserved indentation
@@ -1604,7 +1629,6 @@ if (!Object.values) {
         // initialize
         this.add_outputline();
 
-
         this.get_line_number = function() {
             return lines.length;
         };
@@ -1626,7 +1650,8 @@ if (!Object.values) {
         };
 
         this.get_code = function() {
-            var sweet_code = lines.join('\n').replace(/[\r\n\t ]+$/, '');
+            var sweet_code = lines.join('\n')
+                .replace(/[\r\n\t ]+$/, '');
             return sweet_code;
         };
 
@@ -1719,7 +1744,6 @@ if (!Object.values) {
         };
     }
 
-
     var Token = function(type, text, newlines, whitespace_before, parent) {
         this.type = type;
         this.text = text;
@@ -1746,8 +1770,11 @@ if (!Object.values) {
             '! %= &= *= **= ++ += , -- -= /= :: <<= = => >>= >>>= ^= |= ~'.split(' '));
 
         // words which should always start on new line.
-        this.line_starters = 'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',');
-        var reserved_words = this.line_starters.concat(['do', 'in', 'else', 'get', 'set', 'new', 'catch', 'finally', 'typeof', 'yield', 'async', 'await', 'from', 'as']);
+        this.line_starters =
+            'continue,try,throw,return,var,let,const,if,switch,case,default,for,while,break,function,import,export'.split(',');
+        var reserved_words = this.line_starters.concat(['do', 'in', 'else', 'get', 'set', 'new', 'catch', 'finally',
+            'typeof', 'yield', 'async', 'await', 'from', 'as'
+        ]);
 
         //  /* ... */ comment ends with nearest */ or end of file
         var block_comment_pattern = /([\s\S]*?)((?:\*\/)|$)/g;
@@ -1851,7 +1878,6 @@ if (!Object.values) {
                 // For the sake of tokenizing we can pretend that there was on open brace to start
                 last_token = new Token('TK_START_BLOCK', '{');
             }
-
 
             var c = input.charAt(parser_pos);
             parser_pos += 1;
@@ -2007,16 +2033,22 @@ if (!Object.values) {
 
             }
 
-            var startXmlRegExp = /^<([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/;
+            var startXmlRegExp =
+                /^<([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/;
 
             if (c === '`' || c === "'" || c === '"' || // string
                 (
                     (c === '/') || // regexp
-                    (opts.e4x && c === "<" && input.slice(parser_pos - 1).match(startXmlRegExp)) // xml
+                    (opts.e4x && c === "<" && input.slice(parser_pos - 1)
+                        .match(startXmlRegExp)) // xml
                 ) && ( // regex and xml can only appear in specific locations during parsing
-                    (last_token.type === 'TK_RESERVED' && in_array(last_token.text, ['return', 'case', 'throw', 'else', 'do', 'typeof', 'yield'])) ||
+                    (last_token.type === 'TK_RESERVED' && in_array(last_token.text, ['return', 'case', 'throw', 'else', 'do',
+                        'typeof', 'yield'
+                    ])) ||
                     (last_token.type === 'TK_END_EXPR' && last_token.text === ')' &&
-                        last_token.parent && last_token.parent.type === 'TK_RESERVED' && in_array(last_token.parent.text, ['if', 'while', 'for'])) ||
+                        last_token.parent && last_token.parent.type === 'TK_RESERVED' && in_array(last_token.parent.text, ['if', 'while',
+                            'for'
+                        ])) ||
                     (in_array(last_token.type, ['TK_COMMENT', 'TK_START_EXPR', 'TK_START_BLOCK',
                         'TK_END_BLOCK', 'TK_OPERATOR', 'TK_EQUALS', 'TK_EOF', 'TK_SEMICOLON', 'TK_COMMA'
                     ]))
@@ -2054,7 +2086,8 @@ if (!Object.values) {
                     // handle e4x xml literals
                     //
 
-                    var xmlRegExp = /<(\/?)([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/g;
+                    var xmlRegExp =
+                        /<(\/?)([-a-zA-Z:0-9_.]+|{.+?}|!\[CDATA\[[\s\S]*?\]\])(\s+{.+?}|\s+[-a-zA-Z:0-9_.]+|\s+[-a-zA-Z:0-9_.]+\s*=\s*('[^']*'|"[^"]*"|{.+?}))*\s*(\/?)\s*>/g;
                     var xmlStr = input.slice(parser_pos - 1);
                     var match = xmlRegExp.exec(xmlStr);
                     if (match && match.index === 0) {
@@ -2168,8 +2201,6 @@ if (!Object.values) {
                     return [trim(resulting_string) + '\n', 'TK_UNKNOWN'];
                 }
 
-
-
                 // Spidermonkey-specific sharp variables for circular references
                 // https://developer.mozilla.org/En/Sharp_variables_in_JavaScript
                 // http://mxr.mozilla.org/mozilla-central/source/js/src/jsscan.cpp around line 1935
@@ -2246,7 +2277,6 @@ if (!Object.values) {
             return [c, 'TK_UNKNOWN'];
         }
 
-
         function unescape_string(s) {
             var esc = false,
                 out = '',
@@ -2312,11 +2342,12 @@ if (!Object.values) {
         }
     }
 
-
     if (typeof define === "function" && define.amd) {
         // Add support for AMD ( https://github.com/amdjs/amdjs-api/wiki/AMD#defineamd-property- )
         define([], function() {
-            return { js_beautify: js_beautify };
+            return {
+                js_beautify: js_beautify
+            };
         });
     } else if (typeof exports !== "undefined") {
         // Add support for CommonJS. Just put this file somewhere on your require.paths

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -70,6 +70,7 @@ var fs = require('fs'),
         // CSS-only
         "selector_separator_newline": Boolean,
         "newline_between_rules": Boolean,
+        "space_around_selector_separator": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
         "unformatted": [String, Array],
@@ -169,7 +170,8 @@ var interpret = exports.interpret = function(argv, slice) {
     var parsed = nopt(knownOpts, shortHands, argv, slice);
 
     if (parsed.version) {
-        console.log(require('../../package.json').version);
+        console.log(require('../../package.json')
+            .version);
         process.exit(0);
     } else if (parsed.help) {
         usage();
@@ -179,13 +181,14 @@ var interpret = exports.interpret = function(argv, slice) {
     var cfg;
     try {
         cfg = cc(
-            parsed,
-            cleanOptions(cc.env('jsbeautify_'), knownOpts),
-            parsed.config,
-            findRecursive(process.cwd(), '.jsbeautifyrc'),
-            verifyExists(path.join(getUserHome() || "", ".jsbeautifyrc")),
-            __dirname + '/../config/defaults.json'
-        ).snapshot;
+                parsed,
+                cleanOptions(cc.env('jsbeautify_'), knownOpts),
+                parsed.config,
+                findRecursive(process.cwd(), '.jsbeautifyrc'),
+                verifyExists(path.join(getUserHome() || "", ".jsbeautifyrc")),
+                __dirname + '/../config/defaults.json'
+            )
+            .snapshot;
     } catch (ex) {
         debug(cfg);
         // usage(ex);
@@ -222,7 +225,8 @@ if (require.main === module) {
 function usage(err) {
     var scriptName = getScriptName();
     var msg = [
-        scriptName + '@' + require('../../package.json').version,
+        scriptName + '@' + require('../../package.json')
+        .version,
         '',
         'CLI Options:',
         '  -f, --file       Input file(s) (Pass \'-\' for stdin)',
@@ -243,7 +247,8 @@ function usage(err) {
         '  -n, --end-with-newline        End output with newline'
     ];
 
-    switch (scriptName.split('-').shift()) {
+    switch (scriptName.split('-')
+        .shift()) {
         case "js":
             msg.push('  -l, --indent-level                Initial indentation level [0]');
             msg.push('  -p, --preserve-newlines           Preserve line-breaks (--no-preserve-newlines disables)');
@@ -252,7 +257,8 @@ function usage(err) {
             msg.push('  -E, --space-in-empty-paren        Add a single space inside empty paren, ie. f( )');
             msg.push('  -j, --jslint-happy                Enable jslint-stricter mode');
             msg.push('  -a, --space-after-anon-function   Add a space before an anonymous function\'s parens, ie. function ()');
-            msg.push('  -b, --brace-style                 [collapse|expand|collapse-preserve-inline|end-expand|none] ["collapse"]');
+            msg.push(
+                '  -b, --brace-style                 [collapse|expand|collapse-preserve-inline|end-expand|none] ["collapse"]');
             msg.push('  -B, --break-chained-methods       Break chained method calls across subsequent lines');
             msg.push('  -k, --keep-array-indentation      Preserve array indentation');
             msg.push('  -x, --unescape-strings            Decode printable characters encoded in xNN notation');
@@ -260,7 +266,9 @@ function usage(err) {
             msg.push('  -X, --e4x                         Pass E4X xml literals through untouched');
             msg.push('  --good-stuff                      Warm the cockles of Crockford\'s heart');
             msg.push('  -C, --comma-first                 Put commas at the beginning of new line instead of end');
-            msg.push('  -O, --operator-position           Set operator position (before-newline|after-newline|preserve-newline) [before-newline]');
+            msg.push(
+                '  -O, --operator-position           Set operator position (before-newline|after-newline|preserve-newline) [before-newline]'
+            );
             break;
         case "html":
             msg.push('  -b, --brace-style                 [collapse|expand|end-expand] ["collapse"]');
@@ -272,7 +280,9 @@ function usage(err) {
             msg.push('  -p, --preserve-newlines           Preserve line-breaks (--no-preserve-newlines disables)');
             msg.push('  -m, --max-preserve-newlines       Number of line-breaks to be preserved in one chunk [10]');
             msg.push('  -U, --unformatted                 List of tags (defaults to inline) that should not be reformatted');
-            msg.push('  -E, --extra_liners                List of tags (defaults to [head,body,/html] that should have an extra newline');
+            msg.push(
+                '  -E, --extra_liners                List of tags (defaults to [head,body,/html] that should have an extra newline'
+            );
             break;
         case "css":
             msg.push('  -L, --selector-separator-newline        Add a newline between multiple selectors.');
@@ -386,7 +396,8 @@ function onOutputError(err) {
 // turn "--foo_bar" into "foo-bar"
 
 function dasherizeFlag(str) {
-    return str.replace(/^\-+/, '').replace(/_/g, '-');
+    return str.replace(/^\-+/, '')
+        .replace(/_/g, '-');
 }
 
 // translate weird python underscored keys into dashed argv,
@@ -394,21 +405,23 @@ function dasherizeFlag(str) {
 
 function dasherizeShorthands(hash) {
     // operate in-place
-    Object.keys(hash).forEach(function(key) {
-        // each key value is an array
-        var val = hash[key][0];
-        // only dasherize one-character shorthands
-        if (key.length === 1 && val.indexOf('_') > -1) {
-            hash[dasherizeFlag(val)] = val;
-        }
-    });
+    Object.keys(hash)
+        .forEach(function(key) {
+            // each key value is an array
+            var val = hash[key][0];
+            // only dasherize one-character shorthands
+            if (key.length === 1 && val.indexOf('_') > -1) {
+                hash[dasherizeFlag(val)] = val;
+            }
+        });
 
     return hash;
 }
 
 function getOutputType(outfile, configType) {
     if (outfile && /\.(js|css|html)$/.test(outfile)) {
-        return outfile.split('.').pop();
+        return outfile.split('.')
+            .pop();
     }
     return configType;
 }
@@ -418,7 +431,9 @@ function getScriptName() {
 }
 
 function checkType(parsed) {
-    var scriptType = getScriptName().split('-').shift();
+    var scriptType = getScriptName()
+        .split('-')
+        .shift();
     debug("executable type:", scriptType);
 
     var parsedType = parsed.type;

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -285,6 +285,7 @@ function usage(err) {
             );
             break;
         case "css":
+            msg.push('  --space-around-selector-separator       Add spaces around CSS selector separators (>+~)');
             msg.push('  -L, --selector-separator-newline        Add a newline between multiple selectors.');
             msg.push('  -N, --newline-between-rules             Add a newline between CSS rules.');
     }

--- a/js/lib/unpackers/javascriptobfuscator_unpacker.js
+++ b/js/lib/unpackers/javascriptobfuscator_unpacker.js
@@ -66,7 +66,6 @@ var JavascriptObfuscator = {
         return strings;
     },
 
-
     _unescape: function(str) {
         // inefficient if used repeatedly or on small strings, but wonderful on single large chunk of text
         for (var i = 32; i < 128; i++) {
@@ -98,6 +97,5 @@ var JavascriptObfuscator = {
         t.expect('var _0x1234=["a","b"]', true);
         return t;
     }
-
 
 };

--- a/js/lib/unpackers/myobfuscate_unpacker.js
+++ b/js/lib/unpackers/myobfuscate_unpacker.js
@@ -86,5 +86,4 @@ var MyObfuscate = {
         return t;
     }
 
-
 };

--- a/js/lib/unpackers/p_a_c_k_e_r_unpacker.js
+++ b/js/lib/unpackers/p_a_c_k_e_r_unpacker.js
@@ -14,7 +14,8 @@
 
 var P_A_C_K_E_R = {
     detect: function(str) {
-        return (P_A_C_K_E_R.get_chunks(str).length > 0);
+        return (P_A_C_K_E_R.get_chunks(str)
+            .length > 0);
     },
 
     get_chunks: function(str) {
@@ -27,7 +28,8 @@ var P_A_C_K_E_R = {
             chunk;
         for (var i = 0; i < chunks.length; i++) {
             chunk = chunks[i].replace(/\n$/, '');
-            str = str.split(chunk).join(P_A_C_K_E_R.unpack_chunk(chunk));
+            str = str.split(chunk)
+                .join(P_A_C_K_E_R.unpack_chunk(chunk));
         }
         return str;
     },
@@ -56,12 +58,16 @@ var P_A_C_K_E_R = {
     run_tests: function(sanity_test) {
         var t = sanity_test || new SanityTest();
 
-        var pk1 = "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'var||a'.split('|'),0,{}))";
+        var pk1 =
+            "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'var||a'.split('|'),0,{}))";
         var unpk1 = 'var a=1';
-        var pk2 = "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'foo||b'.split('|'),0,{}))";
+        var pk2 =
+            "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'foo||b'.split('|'),0,{}))";
         var unpk2 = 'foo b=1';
-        var pk_broken = "eval(function(p,a,c,k,e,r){BORKBORK;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'var||a'.split('|'),0,{}))";
-        var pk3 = "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1{}))',3,3,'var||a'.split('|'),0,{}))";
+        var pk_broken =
+            "eval(function(p,a,c,k,e,r){BORKBORK;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1',3,3,'var||a'.split('|'),0,{}))";
+        var pk3 =
+            "eval(function(p,a,c,k,e,r){e=String;if(!''.replace(/^/,String)){while(c--)r[c]=k[c]||c;k=[function(e){return r[e]}];e=function(){return'\\\\w+'};c=1};while(c--)if(k[c])p=p.replace(new RegExp('\\\\b'+e(c)+'\\\\b','g'),k[c]);return p}('0 2=1{}))',3,3,'var||a'.split('|'),0,{}))";
         var unpk3 = 'var a=1{}))';
 
         t.test_function(P_A_C_K_E_R.detect, "P_A_C_K_E_R.detect");
@@ -74,10 +80,10 @@ var P_A_C_K_E_R = {
         t.expect(pk3, unpk3);
 
         var filler = '\nfiller\n';
-        t.expect(filler + pk1 + "\n" + pk_broken + filler + pk2 + filler, filler + unpk1 + "\n" + pk_broken + filler + unpk2 + filler);
+        t.expect(filler + pk1 + "\n" + pk_broken + filler + pk2 + filler, filler + unpk1 + "\n" + pk_broken + filler +
+            unpk2 + filler);
 
         return t;
     }
-
 
 };

--- a/js/lib/unpackers/urlencode_unpacker.js
+++ b/js/lib/unpackers/urlencode_unpacker.js
@@ -23,7 +23,8 @@ var Urlencoded = {
         // should be sufficient check for now.
         if (str.indexOf(' ') === -1) {
             if (str.indexOf('%2') !== -1) return true;
-            if (str.replace(/[^%]+/g, '').length > 3) return true;
+            if (str.replace(/[^%]+/g, '')
+                .length > 3) return true;
         }
         return false;
     },
@@ -40,8 +41,6 @@ var Urlencoded = {
         return str;
     },
 
-
-
     run_tests: function(sanity_test) {
         var t = sanity_test || new SanityTest();
         t.test_function(Urlencoded.detect, "Urlencoded.detect");
@@ -50,7 +49,8 @@ var Urlencoded = {
         t.expect('var%20a+=+b', true);
         t.expect('var%20a=b', true);
         t.expect('var%20%21%22', true);
-        t.expect('javascript:(function(){var%20whatever={init:function(){alert(%22a%22+%22b%22)}};whatever.init()})();', true);
+        t.expect('javascript:(function(){var%20whatever={init:function(){alert(%22a%22+%22b%22)}};whatever.init()})();',
+            true);
         t.test_function(Urlencoded.unpack, 'Urlencoded.unpack');
 
         t.expect('javascript:(function(){var%20whatever={init:function(){alert(%22a%22+%22b%22)}};whatever.init()})();',
@@ -64,7 +64,6 @@ var Urlencoded = {
         t.expect('var%20a=b%2b1', 'var a=b+1');
         return t;
     }
-
 
 };
 

--- a/js/test/amd-beautify-tests.js
+++ b/js/test/amd-beautify-tests.js
@@ -3,9 +3,12 @@
 var requirejs = require('requirejs'),
     SanityTest = require('./sanitytest'),
     Urlencoded = require('../lib/unpackers/urlencode_unpacker'),
-    run_javascript_tests = require('./generated/beautify-javascript-tests').run_javascript_tests,
-    run_css_tests = require('./generated/beautify-css-tests').run_css_tests,
-    run_html_tests = require('./generated/beautify-html-tests').run_html_tests;
+    run_javascript_tests = require('./generated/beautify-javascript-tests')
+    .run_javascript_tests,
+    run_css_tests = require('./generated/beautify-css-tests')
+    .run_css_tests,
+    run_html_tests = require('./generated/beautify-html-tests')
+    .run_html_tests;
 
 requirejs.config({
     paths: {
@@ -48,15 +51,19 @@ function amd_beautifier_tests(name, test_runner) {
     return results;
 }
 
-
-
 if (require.main === module) {
     process.exit(
-        amd_beautifier_tests('js-beautifier', run_javascript_tests).get_exitcode() +
-        amd_beautifier_index_tests('js-beautifier', run_javascript_tests).get_exitcode() +
-        amd_beautifier_tests('cs-beautifier', run_css_tests).get_exitcode() +
-        amd_beautifier_index_tests('css-beautifier', run_css_tests).get_exitcode() +
-        amd_beautifier_tests('html-beautifier', run_html_tests).get_exitcode() +
-        amd_beautifier_index_tests('html-beautifier', run_html_tests).get_exitcode()
+        amd_beautifier_tests('js-beautifier', run_javascript_tests)
+        .get_exitcode() +
+        amd_beautifier_index_tests('js-beautifier', run_javascript_tests)
+        .get_exitcode() +
+        amd_beautifier_tests('css-beautifier', run_css_tests)
+        .get_exitcode() +
+        amd_beautifier_index_tests('css-beautifier', run_css_tests)
+        .get_exitcode() +
+        amd_beautifier_tests('html-beautifier', run_html_tests)
+        .get_exitcode() +
+        amd_beautifier_index_tests('html-beautifier', run_html_tests)
+        .get_exitcode()
     );
 }

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -28,6 +28,7 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
     default_opts.selector_separator_newline = true;
     default_opts.end_with_newline = false;
     default_opts.newline_between_rules = false;
+    default_opts.space_around_selector_separator = false;
 
     function reset_options()
     {
@@ -115,6 +116,23 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         //============================================================
         // 
         t('#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity = 90);\n}', '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}');
+
+
+        reset_options();
+        //============================================================
+        // Space Around Selector Separator - (space = " ")
+        opts.space_around_selector_separator = true;
+        t('a>b{}', 'a > b {}');
+        t('a~b{}', 'a ~ b {}');
+        t('a+b{}', 'a + b {}');
+        t('a+b>c{}', 'a + b > c {}');
+
+        // Space Around Selector Separator - (space = "")
+        opts.space_around_selector_separator = false;
+        t('a>b{}', 'a>b {}');
+        t('a~b{}', 'a~b {}');
+        t('a+b{}', 'a+b {}');
+        t('a+b>c{}', 'a+b>c {}');
 
 
         reset_options();

--- a/js/test/node-beautify-html-perf-tests.js
+++ b/js/test/node-beautify-html-perf-tests.js
@@ -2,14 +2,16 @@
 /*jshint node:true */
 /*jshint unused:false */
 
-
 var fs = require('fs'),
     SanityTest = require('./sanitytest'),
     Benchmark = require('benchmark'),
     Urlencoded = require('../lib/unpackers/urlencode_unpacker'),
-    js_beautify = require('../index').js_beautify,
-    css_beautify = require('../index').css_beautify,
-    html_beautify = require('../index').html_beautify;
+    js_beautify = require('../index')
+    .js_beautify,
+    css_beautify = require('../index')
+    .css_beautify,
+    html_beautify = require('../index')
+    .html_beautify;
 
 function node_beautifier_html_tests() {
     console.log('Testing performance...');
@@ -42,9 +44,6 @@ function node_beautifier_html_tests() {
         .run();
     return 0;
 }
-
-
-
 
 if (require.main === module) {
     process.exit(node_beautifier_html_tests());

--- a/js/test/node-beautify-perf-tests.js
+++ b/js/test/node-beautify-perf-tests.js
@@ -6,9 +6,12 @@ var fs = require('fs'),
     SanityTest = require('./sanitytest'),
     Benchmark = require('benchmark'),
     Urlencoded = require('../lib/unpackers/urlencode_unpacker'),
-    js_beautify = require('../index').js_beautify,
-    css_beautify = require('../index').css_beautify,
-    html_beautify = require('../index').html_beautify;
+    js_beautify = require('../index')
+    .js_beautify,
+    css_beautify = require('../index')
+    .css_beautify,
+    html_beautify = require('../index')
+    .html_beautify;
 
 function node_beautifier_tests() {
     console.log('Testing performance...');
@@ -41,9 +44,6 @@ function node_beautifier_tests() {
         .run();
     return 0;
 }
-
-
-
 
 if (require.main === module) {
     process.exit(node_beautifier_tests());

--- a/js/test/node-beautify-tests.js
+++ b/js/test/node-beautify-tests.js
@@ -2,9 +2,12 @@
 
 var SanityTest = require('./sanitytest'),
     Urlencoded = require('../lib/unpackers/urlencode_unpacker'),
-    run_javascript_tests = require('./generated/beautify-javascript-tests').run_javascript_tests,
-    run_css_tests = require('./generated/beautify-css-tests').run_css_tests,
-    run_html_tests = require('./generated/beautify-html-tests').run_html_tests;
+    run_javascript_tests = require('./generated/beautify-javascript-tests')
+    .run_javascript_tests,
+    run_css_tests = require('./generated/beautify-css-tests')
+    .run_css_tests,
+    run_html_tests = require('./generated/beautify-html-tests')
+    .run_html_tests;
 
 function test_legacy_names() {
     var beautify = require('../index');
@@ -38,8 +41,11 @@ function node_beautifier_tests(name, test_runner) {
 if (require.main === module) {
     process.exit(
         test_legacy_names() +
-        node_beautifier_tests('js-beautifier', run_javascript_tests).get_exitcode() +
-        node_beautifier_tests('cs-beautifier', run_css_tests).get_exitcode() +
-        node_beautifier_tests('html-beautifier', run_html_tests).get_exitcode()
+        node_beautifier_tests('js-beautifier', run_javascript_tests)
+        .get_exitcode() +
+        node_beautifier_tests('cs-beautifier', run_css_tests)
+        .get_exitcode() +
+        node_beautifier_tests('html-beautifier', run_html_tests)
+        .get_exitcode()
     );
 }

--- a/js/test/sanitytest.js
+++ b/js/test/sanitytest.js
@@ -10,7 +10,6 @@
 // output_somewhere(t.results()); // good for <pre>, html safe-ish
 // alert(t.results_raw());        // html unescaped
 
-
 function SanityTest(func, name_of_test) {
 
     var test_func = func || function(x) {
@@ -37,14 +36,14 @@ function SanityTest(func, name_of_test) {
         // multi-parameter calls not supported (I don't need them now).
         var result = test_func(parameters);
         // proper array checking is a pain. i'll maybe do it later, compare strings representations instead
-        if ((result === expected_value) || (expected_value instanceof Array && result.join(', ') === expected_value.join(', '))) {
+        if ((result === expected_value) || (expected_value instanceof Array && result.join(', ') === expected_value.join(
+                ', '))) {
             n_succeeded += 1;
         } else {
             n_failed += 1;
             failures.push([test_name, parameters, expected_value, result]);
         }
     };
-
 
     this.results_raw = function() {
         var results = '';
@@ -70,11 +69,9 @@ function SanityTest(func, name_of_test) {
         return results;
     };
 
-
     this.results = function() {
         return this.lazy_escape(this.results_raw());
     };
-
 
     this.prettyprint = function(something, quote_strings) {
         var type = typeof something;
@@ -110,11 +107,11 @@ function SanityTest(func, name_of_test) {
         }
     };
 
-
     this.lazy_escape = function(str) {
-        return str.replace(/</g, '&lt;').replace(/\>/g, '&gt;').replace(/\n/g, '<br />');
+        return str.replace(/</g, '&lt;')
+            .replace(/\>/g, '&gt;')
+            .replace(/\n/g, '<br />');
     };
-
 
     this.log = function() {
         if (window.console) {

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -37,6 +37,7 @@ class BeautifierOptions:
         self.selector_separator_newline = True
         self.end_with_newline = False
         self.newline_between_rules = True
+        self.space_around_selector_separator = False
         self.eol = '\n'
 
 
@@ -48,8 +49,9 @@ indent_with_tabs = [%s]
 separate_selectors_newline = [%s]
 end_with_newline = [%s]
 newline_between_rules = [%s]
+space_around_selector_separator = [%s]
 """ % (self.indent_size, self.indent_char, self.indent_with_tabs,
-       self.selector_separator_newline, self.end_with_newline, self.newline_between_rules)
+       self.selector_separator_newline, self.end_with_newline, self.newline_between_rules, self.space_around_selector_separator)
 
 
 def default_options():
@@ -445,6 +447,13 @@ class Beautifier:
                     printer.newLine()
                 else:
                     printer.singleSpace()
+            elif self.ch == '>' or self.ch == '+' or self.ch == '~':
+                if not insidePropertyValue and self.opts.space_around_selector_separator and parenLevel < 1:
+                    printer.singleSpace()
+                    printer.push(self.ch)
+                    printer.singleSpace()
+                else:
+                    printer.push(self.ch)
             elif self.ch == ']':
                 printer.push(self.ch)
             elif self.ch == '[':

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -33,6 +33,7 @@ class CSSBeautifierTest(unittest.TestCase):
         default_options.selector_separator_newline = true
         default_options.end_with_newline = false
         default_options.newline_between_rules = false
+        default_options.space_around_selector_separator = false
 
         cls.default_options = default_options
 
@@ -78,6 +79,23 @@ class CSSBeautifierTest(unittest.TestCase):
         #============================================================
         # 
         t('#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity = 90);\n}', '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}')
+
+
+        self.reset_options();
+        #============================================================
+        # Space Around Selector Separator - (space = " ")
+        self.options.space_around_selector_separator = true
+        t('a>b{}', 'a > b {}')
+        t('a~b{}', 'a ~ b {}')
+        t('a+b{}', 'a + b {}')
+        t('a+b>c{}', 'a + b > c {}')
+
+        # Space Around Selector Separator - (space = "")
+        self.options.space_around_selector_separator = false
+        t('a>b{}', 'a>b {}')
+        t('a~b{}', 'a~b {}')
+        t('a+b{}', 'a+b {}')
+        t('a+b>c{}', 'a+b>c {}')
 
 
         self.reset_options();

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1,40 +1,74 @@
 exports.test_data = {
-    default_options: [
-        { name: "indent_size", value: "1" },
-        { name: "indent_char", value: "'\\t'" },
-        { name: "selector_separator_newline", value: "true" },
-        { name: "end_with_newline", value: "false" },
-        { name: "newline_between_rules", value: "false" },
-    ],
+    default_options: [{
+        name: "indent_size",
+        value: "1"
+    }, {
+        name: "indent_char",
+        value: "'\\t'"
+    }, {
+        name: "selector_separator_newline",
+        value: "true"
+    }, {
+        name: "end_with_newline",
+        value: "false"
+    }, {
+        name: "newline_between_rules",
+        value: "false"
+    }, {
+        name: "space_around_selector_separator",
+        value: "false"
+    }],
     groups: [{
         name: "End With Newline",
         description: "",
         matrix: [{
-            options: [
-                { name: "end_with_newline", value: "true" }
-            ],
+            options: [{
+                name: "end_with_newline",
+                value: "true"
+            }],
             eof: '\\n'
         }, {
-            options: [
-                { name: "end_with_newline", value: "false" }
-            ],
+            options: [{
+                name: "end_with_newline",
+                value: "false"
+            }],
             eof: ''
         }],
-        tests: [
-            { fragment: true, input: '', output: '{{eof}}' },
-            { fragment: true, input: '   .tabs{}', output: '   .tabs {}{{eof}}' },
-            { fragment: true, input: '   \n\n.tabs{}\n\n\n\n', output: '   .tabs {}{{eof}}' },
-            { fragment: true, input: '\n', output: '{{eof}}' }
-        ],
+        tests: [{
+            fragment: true,
+            input: '',
+            output: '{{eof}}'
+        }, {
+            fragment: true,
+            input: '   .tabs{}',
+            output: '   .tabs {}{{eof}}'
+        }, {
+            fragment: true,
+            input: '   \n\n.tabs{}\n\n\n\n',
+            output: '   .tabs {}{{eof}}'
+        }, {
+            fragment: true,
+            input: '\n',
+            output: '{{eof}}'
+        }],
     }, {
         name: "Empty braces",
         description: "",
-        tests: [
-            { input: '.tabs{}', output: '.tabs {}' },
-            { input: '.tabs { }', output: '.tabs {}' },
-            { input: '.tabs    {    }', output: '.tabs {}' },
+        tests: [{
+                input: '.tabs{}',
+                output: '.tabs {}'
+            }, {
+                input: '.tabs { }',
+                output: '.tabs {}'
+            }, {
+                input: '.tabs    {    }',
+                output: '.tabs {}'
+            },
             // When we support preserving newlines this will need to change
-            { input: '.tabs    \n{\n    \n  }', output: '.tabs {}' }
+            {
+                input: '.tabs    \n{\n    \n  }',
+                output: '.tabs {}'
+            }
         ],
     }, {
         name: "",
@@ -44,98 +78,194 @@ exports.test_data = {
             output: '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}'
         }, ],
     }, {
+        name: "Space Around Selector Separator",
+        description: "",
+        matrix: [{
+            options: [{
+                name: "space_around_selector_separator",
+                value: "true"
+            }],
+            space: ' '
+        }, {
+            options: [{
+                name: "space_around_selector_separator",
+                value: "false"
+            }],
+            space: ''
+        }],
+        tests: [{
+            input: 'a>b{}',
+            output: 'a{{space}}>{{space}}b {}'
+        }, {
+            input: 'a~b{}',
+            output: 'a{{space}}~{{space}}b {}'
+        }, {
+            input: 'a+b{}',
+            output: 'a{{space}}+{{space}}b {}'
+        }, {
+            input: 'a+b>c{}',
+            output: 'a{{space}}+{{space}}b{{space}}>{{space}}c {}'
+        }]
+    }, {
         name: 'Selector Separator',
         description: '',
         matrix: [{
-            options: [
-                { name: 'selector_separator_newline', value: 'false' },
-                { name: 'selector_separator', value: '" "' }
-            ],
+            options: [{
+                name: 'selector_separator_newline',
+                value: 'false'
+            }, {
+                name: 'selector_separator',
+                value: '" "'
+            }],
             separator: ' ',
             separator1: ' '
         }, {
-            options: [
-                { name: 'selector_separator_newline', value: 'false' },
-                { name: 'selector_separator', value: '"  "' }
-            ],
+            options: [{
+                name: 'selector_separator_newline',
+                value: 'false'
+            }, {
+                name: 'selector_separator',
+                value: '"  "'
+            }],
             // BUG: #713
             separator: ' ',
             separator1: ' '
         }, {
-            options: [
-                { name: 'selector_separator_newline', value: 'true' },
-                { name: 'selector_separator', value: '" "' }
-            ],
+            options: [{
+                name: 'selector_separator_newline',
+                value: 'true'
+            }, {
+                name: 'selector_separator',
+                value: '" "'
+            }],
             separator: '\\n',
             separator1: '\\n\\t'
         }, {
-            options: [
-                { name: 'selector_separator_newline', value: 'true' },
-                { name: 'selector_separator', value: '"  "' }
-            ],
+            options: [{
+                name: 'selector_separator_newline',
+                value: 'true'
+            }, {
+                name: 'selector_separator',
+                value: '"  "'
+            }],
             separator: '\\n',
             separator1: '\\n\\t'
         }],
-        tests: [
-            { input: '#bla, #foo{color:green}', output: '#bla,{{separator}}#foo {\n\tcolor: green\n}' },
-            { input: '@media print {.tab{}}', output: '@media print {\n\t.tab {}\n}' },
-            { input: '@media print {.tab,.bat{}}', output: '@media print {\n\t.tab,{{separator1}}.bat {}\n}' },
-            { input: '#bla, #foo{color:black}', output: '#bla,{{separator}}#foo {\n\tcolor: black\n}' }, {
-                input: 'a:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}',
-                output: 'a:first-child,{{separator}}a:first-child {\n\tcolor: red;\n\tdiv:first-child,{{separator1}}div:hover {\n\t\tcolor: black;\n\t}\n}'
-            }
-        ]
+        tests: [{
+            input: '#bla, #foo{color:green}',
+            output: '#bla,{{separator}}#foo {\n\tcolor: green\n}'
+        }, {
+            input: '@media print {.tab{}}',
+            output: '@media print {\n\t.tab {}\n}'
+        }, {
+            input: '@media print {.tab,.bat{}}',
+            output: '@media print {\n\t.tab,{{separator1}}.bat {}\n}'
+        }, {
+            input: '#bla, #foo{color:black}',
+            output: '#bla,{{separator}}#foo {\n\tcolor: black\n}'
+        }, {
+            input: 'a:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}',
+            output: 'a:first-child,{{separator}}a:first-child {\n\tcolor: red;\n\tdiv:first-child,{{separator1}}div:hover {\n\t\tcolor: black;\n\t}\n}'
+        }]
     }, {
         name: "Newline Between Rules",
         description: "",
         matrix: [{
-            options: [
-                { name: "newline_between_rules", value: "true" }
-            ],
+            options: [{
+                name: "newline_between_rules",
+                value: "true"
+            }],
             separator: '\\n'
         }, {
-            options: [
-                { name: "newline_between_rules", value: "false" }
-            ],
+            options: [{
+                name: "newline_between_rules",
+                value: "false"
+            }],
             separator: ''
         }],
-        tests: [
-            { input: '.div {}\n.span {}', output: '.div {}\n{{separator}}.span {}' },
-            { input: '.div{}\n   \n.span{}', output: '.div {}\n{{separator}}.span {}' },
-            { input: '.div {}    \n  \n.span { } \n', output: '.div {}\n{{separator}}.span {}' },
-            { input: '.div {\n    \n} \n  .span {\n }  ', output: '.div {}\n{{separator}}.span {}' },
-            { input: '.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}', output: '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-            { input: '.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}', output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-            { input: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', output: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-            { input: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}', output: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-            { input: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}', output: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n{{separator}}@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}' },
-            { input: 'a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}', output: 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-            { input: 'a:first-child{color:red;div:not(.peq){color:black;}}\n.div{height:15px;}', output: 'a:first-child {\n\tcolor: red;\n\tdiv:not(.peq) {\n\t\tcolor: black;\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}' },
-        ],
+        tests: [{
+            input: '.div {}\n.span {}',
+            output: '.div {}\n{{separator}}.span {}'
+        }, {
+            input: '.div{}\n   \n.span{}',
+            output: '.div {}\n{{separator}}.span {}'
+        }, {
+            input: '.div {}    \n  \n.span { } \n',
+            output: '.div {}\n{{separator}}.span {}'
+        }, {
+            input: '.div {\n    \n} \n  .span {\n }  ',
+            output: '.div {}\n{{separator}}.span {}'
+        }, {
+            input: '.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n.div{height:15px;}',
+            output: '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, {
+            input: '.tabs{width:10px;//end of line comment\nheight:10px;//another\n}\n.div{height:15px;}',
+            output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, {
+            input: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}',
+            output: '#foo {\n\tbackground-image: url(foo@2x.png);\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, {
+            input: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n.div{height:15px;}',
+            output: '@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo@2x.png);\n\t}\n\t@font-face {\n\t\tfont-family: "Bitstream Vera Serif Bold";\n\t\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, {
+            input: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}',
+            output: '@font-face {\n\tfont-family: "Bitstream Vera Serif Bold";\n\tsrc: url("http://developer.mozilla.org/@api/deki/files/2934/=VeraSeBd.ttf");\n}\n{{separator}}@media screen {\n\t#foo:hover {\n\t\tbackground-image: url(foo.png);\n\t}\n\t@media screen and (min-device-pixel-ratio: 2) {\n\t\t@font-face {\n\t\t\tfont-family: "Helvetica Neue"\n\t\t}\n\t\t#foo:hover {\n\t\t\tbackground-image: url(foo@2x.png);\n\t\t}\n\t}\n}'
+        }, {
+            input: 'a:first-child{color:red;div:first-child{color:black;}}\n.div{height:15px;}',
+            output: 'a:first-child {\n\tcolor: red;\n\tdiv:first-child {\n\t\tcolor: black;\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, {
+            input: 'a:first-child{color:red;div:not(.peq){color:black;}}\n.div{height:15px;}',
+            output: 'a:first-child {\n\tcolor: red;\n\tdiv:not(.peq) {\n\t\tcolor: black;\n\t}\n}\n{{separator}}.div {\n\theight: 15px;\n}'
+        }, ],
     }, {
         name: "Functions braces",
         description: "",
-        tests: [
-            { input: '.tabs(){}', output: '.tabs() {}' },
-            { input: '.tabs (){}', output: '.tabs () {}' },
-            { input: '.tabs (pa, pa(1,2)), .cols { }', output: '.tabs (pa, pa(1, 2)),\n.cols {}' },
-            { input: '.tabs(pa, pa(1,2)), .cols { }', output: '.tabs(pa, pa(1, 2)),\n.cols {}' },
-            { input: '.tabs (   )   {    }', output: '.tabs () {}' },
-            { input: '.tabs(   )   {    }', output: '.tabs() {}' },
-            { input: '.tabs  (t, t2)  \n{\n  key: val(p1  ,p2);  \n  }', output: '.tabs (t, t2) {\n\tkey: val(p1, p2);\n}' },
-            { input: '.box-shadow(@shadow: 0 1px 3px rgba(0, 0, 0, .25)) {\n\t-webkit-box-shadow: @shadow;\n\t-moz-box-shadow: @shadow;\n\tbox-shadow: @shadow;\n}' }
-        ],
+        tests: [{
+            input: '.tabs(){}',
+            output: '.tabs() {}'
+        }, {
+            input: '.tabs (){}',
+            output: '.tabs () {}'
+        }, {
+            input: '.tabs (pa, pa(1,2)), .cols { }',
+            output: '.tabs (pa, pa(1, 2)),\n.cols {}'
+        }, {
+            input: '.tabs(pa, pa(1,2)), .cols { }',
+            output: '.tabs(pa, pa(1, 2)),\n.cols {}'
+        }, {
+            input: '.tabs (   )   {    }',
+            output: '.tabs () {}'
+        }, {
+            input: '.tabs(   )   {    }',
+            output: '.tabs() {}'
+        }, {
+            input: '.tabs  (t, t2)  \n{\n  key: val(p1  ,p2);  \n  }',
+            output: '.tabs (t, t2) {\n\tkey: val(p1, p2);\n}'
+        }, {
+            input: '.box-shadow(@shadow: 0 1px 3px rgba(0, 0, 0, .25)) {\n\t-webkit-box-shadow: @shadow;\n\t-moz-box-shadow: @shadow;\n\tbox-shadow: @shadow;\n}'
+        }],
     }, {
         name: "Comments",
         description: "",
-        tests: [
-            { unchanged: '/* test */' },
-            { input: '.tabs{/* test */}', output: '.tabs {\n\t/* test */\n}' },
-            { input: '.tabs{/* test */}', output: '.tabs {\n\t/* test */\n}' },
-            { input: '/* header */.tabs {}', output: '/* header */\n\n.tabs {}' },
-            { input: '.tabs {\n/* non-header */\nwidth:10px;}', output: '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}' },
-            { unchanged: '/* header' },
-            { unchanged: '// comment' }, {
+        tests: [{
+                unchanged: '/* test */'
+            }, {
+                input: '.tabs{/* test */}',
+                output: '.tabs {\n\t/* test */\n}'
+            }, {
+                input: '.tabs{/* test */}',
+                output: '.tabs {\n\t/* test */\n}'
+            }, {
+                input: '/* header */.tabs {}',
+                output: '/* header */\n\n.tabs {}'
+            }, {
+                input: '.tabs {\n/* non-header */\nwidth:10px;}',
+                output: '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}'
+            }, {
+                unchanged: '/* header'
+            }, {
+                unchanged: '// comment'
+            }, {
                 input: '.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}',
                 output: '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}'
             },
@@ -144,65 +274,84 @@ exports.test_data = {
                 comment: "single line comment support (less/sass)",
                 input: '.tabs{\n// comment\nwidth:10px;\n}',
                 output: '.tabs {\n\t// comment\n\twidth: 10px;\n}'
-            },
-            { input: '.tabs{// comment\nwidth:10px;\n}', output: '.tabs {\n\t// comment\n\twidth: 10px;\n}' },
-            { input: '//comment\n.tabs{width:10px;}', output: '//comment\n.tabs {\n\twidth: 10px;\n}' },
-            { input: '.tabs{//comment\n//2nd single line comment\nwidth:10px;}', output: '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}' },
-            { input: '.tabs{width:10px;//end of line comment\n}', output: '.tabs {\n\twidth: 10px; //end of line comment\n}' },
-            { input: '.tabs{width:10px;//end of line comment\nheight:10px;}', output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}' },
-            { input: '.tabs{width:10px;//end of line comment\nheight:10px;//another\n}', output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}' }
+            }, {
+                input: '.tabs{// comment\nwidth:10px;\n}',
+                output: '.tabs {\n\t// comment\n\twidth: 10px;\n}'
+            }, {
+                input: '//comment\n.tabs{width:10px;}',
+                output: '//comment\n.tabs {\n\twidth: 10px;\n}'
+            }, {
+                input: '.tabs{//comment\n//2nd single line comment\nwidth:10px;}',
+                output: '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}'
+            }, {
+                input: '.tabs{width:10px;//end of line comment\n}',
+                output: '.tabs {\n\twidth: 10px; //end of line comment\n}'
+            }, {
+                input: '.tabs{width:10px;//end of line comment\nheight:10px;}',
+                output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}'
+            }, {
+                input: '.tabs{width:10px;//end of line comment\nheight:10px;//another\n}',
+                output: '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}'
+            }
         ],
     }, {
         name: "Handle LESS property name interpolation",
         description: "",
-        tests: [
-            { unchanged: 'tag {\n\t@{prop}: none;\n}' },
-            { input: 'tag{@{prop}:none;}', output: 'tag {\n\t@{prop}: none;\n}' },
-            { input: 'tag{ @{prop}: none;}', output: 'tag {\n\t@{prop}: none;\n}' },
-            {
-                comment: "can also be part of property name",
-                unchanged: 'tag {\n\tdynamic-@{prop}: none;\n}'
-            },
-            { input: 'tag{dynamic-@{prop}:none;}', output: 'tag {\n\tdynamic-@{prop}: none;\n}' },
-            { input: 'tag{ dynamic-@{prop}: none;}', output: 'tag {\n\tdynamic-@{prop}: none;\n}' },
-        ],
+        tests: [{
+            unchanged: 'tag {\n\t@{prop}: none;\n}'
+        }, {
+            input: 'tag{@{prop}:none;}',
+            output: 'tag {\n\t@{prop}: none;\n}'
+        }, {
+            input: 'tag{ @{prop}: none;}',
+            output: 'tag {\n\t@{prop}: none;\n}'
+        }, {
+            comment: "can also be part of property name",
+            unchanged: 'tag {\n\tdynamic-@{prop}: none;\n}'
+        }, {
+            input: 'tag{dynamic-@{prop}:none;}',
+            output: 'tag {\n\tdynamic-@{prop}: none;\n}'
+        }, {
+            input: 'tag{ dynamic-@{prop}: none;}',
+            output: 'tag {\n\tdynamic-@{prop}: none;\n}'
+        }, ],
     }, {
         name: "Handle LESS property name interpolation, test #631",
         description: "",
-        tests: [
-            { unchanged: '.generate-columns(@n, @i: 1) when (@i =< @n) {\n\t.column-@{i} {\n\t\twidth: (@i * 100% / @n);\n\t}\n\t.generate-columns(@n, (@i + 1));\n}' },
-            {
-                input: '.generate-columns(@n,@i:1) when (@i =< @n){.column-@{i}{width:(@i * 100% / @n);}.generate-columns(@n,(@i + 1));}',
-                output: '.generate-columns(@n, @i: 1) when (@i =< @n) {\n\t.column-@{i} {\n\t\twidth: (@i * 100% / @n);\n\t}\n\t.generate-columns(@n, (@i + 1));\n}'
-            }
-        ],
+        tests: [{
+            unchanged: '.generate-columns(@n, @i: 1) when (@i =< @n) {\n\t.column-@{i} {\n\t\twidth: (@i * 100% / @n);\n\t}\n\t.generate-columns(@n, (@i + 1));\n}'
+        }, {
+            input: '.generate-columns(@n,@i:1) when (@i =< @n){.column-@{i}{width:(@i * 100% / @n);}.generate-columns(@n,(@i + 1));}',
+            output: '.generate-columns(@n, @i: 1) when (@i =< @n) {\n\t.column-@{i} {\n\t\twidth: (@i * 100% / @n);\n\t}\n\t.generate-columns(@n, (@i + 1));\n}'
+        }],
     }, {
         name: "Psuedo-classes vs Variables",
         description: "",
-        tests: [
-            { unchanged: '@page :first {}' }, {
-                comment: "Assume the colon goes with the @name. If we're in LESS, this is required regardless of the at-string.",
-                input: '@page:first {}',
-                output: '@page: first {}'
-            },
-            { unchanged: '@page: first {}' }
-        ],
+        tests: [{
+            unchanged: '@page :first {}'
+        }, {
+            comment: "Assume the colon goes with the @name. If we're in LESS, this is required regardless of the at-string.",
+            input: '@page:first {}',
+            output: '@page: first {}'
+        }, {
+            unchanged: '@page: first {}'
+        }],
     }, {
         name: "SASS/SCSS",
         description: "",
         tests: [{
-                comment: "Basic Interpolation",
-                unchanged: 'p {\n\t$font-size: 12px;\n\t$line-height: 30px;\n\tfont: #{$font-size}/#{$line-height};\n}'
-            },
-            { unchanged: 'p.#{$name} {}' }, {
-                unchanged: [
-                    '@mixin itemPropertiesCoverItem($items, $margin) {',
-                    '\twidth: calc((100% - ((#{$items} - 1) * #{$margin}rem)) / #{$items});',
-                    '\tmargin: 1.6rem #{$margin}rem 1.6rem 0;',
-                    '}'
-                ]
-            }
-        ],
+            comment: "Basic Interpolation",
+            unchanged: 'p {\n\t$font-size: 12px;\n\t$line-height: 30px;\n\tfont: #{$font-size}/#{$line-height};\n}'
+        }, {
+            unchanged: 'p.#{$name} {}'
+        }, {
+            unchanged: [
+                '@mixin itemPropertiesCoverItem($items, $margin) {',
+                '\twidth: calc((100% - ((#{$items} - 1) * #{$margin}rem)) / #{$items});',
+                '\tmargin: 1.6rem #{$margin}rem 1.6rem 0;',
+                '}'
+            ]
+        }],
     }, {
 
     }]

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1,43 +1,71 @@
 exports.test_data = {
-    default_options: [
-        { name: "indent_size", value: "4" },
-        { name: "indent_char", value: "' '" },
-        { name: "indent_with_tabs", value: "false" },
-        { name: "preserve_newlines", value: "true" },
-        { name: "jslint_happy", value: "false" },
-        { name: "keep_array_indentation", value: "false" },
-        { name: "brace_style", value: "'collapse'" },
-        { name: "extra_liners", value: "['html', 'head', '/html']" }
-    ],
+    default_options: [{
+        name: "indent_size",
+        value: "4"
+    }, {
+        name: "indent_char",
+        value: "' '"
+    }, {
+        name: "indent_with_tabs",
+        value: "false"
+    }, {
+        name: "preserve_newlines",
+        value: "true"
+    }, {
+        name: "jslint_happy",
+        value: "false"
+    }, {
+        name: "keep_array_indentation",
+        value: "false"
+    }, {
+        name: "brace_style",
+        value: "'collapse'"
+    }, {
+        name: "extra_liners",
+        value: "['html', 'head', '/html']"
+    }],
     groups: [{
         name: "End With Newline",
         description: "",
         matrix: [{
-                options: [
-                    { name: "end_with_newline", value: "true" }
-                ],
+                options: [{
+                    name: "end_with_newline",
+                    value: "true"
+                }],
                 eof: '\\n'
             }, {
-                options: [
-                    { name: "end_with_newline", value: "false" }
-                ],
+                options: [{
+                    name: "end_with_newline",
+                    value: "false"
+                }],
                 eof: ''
             }
 
         ],
-        tests: [
-            { fragment: true, input: '', output: '{{eof}}' },
-            { fragment: true, input: '<div></div>', output: '<div></div>{{eof}}' },
+        tests: [{
+                fragment: true,
+                input: '',
+                output: '{{eof}}'
+            }, {
+                fragment: true,
+                input: '<div></div>',
+                output: '<div></div>{{eof}}'
+            },
             // { fragment: true, input: '   \n\n<div></div>\n\n\n\n', output: '   <div></div>{{eof}}' },
-            { fragment: true, input: '\n', output: '{{eof}}' }
+            {
+                fragment: true,
+                input: '\n',
+                output: '{{eof}}'
+            }
         ],
     }, {
         name: "Custom Extra Liners (empty)",
         description: "",
         matrix: [{
-                options: [
-                    { name: "extra_liners", value: "[]" }
-                ]
+                options: [{
+                    name: "extra_liners",
+                    value: "[]"
+                }]
             },
 
         ],
@@ -50,9 +78,10 @@ exports.test_data = {
         name: "Custom Extra Liners (default)",
         description: "",
         matrix: [{
-                options: [
-                    { name: "extra_liners", value: "null" }
-                ]
+                options: [{
+                    name: "extra_liners",
+                    value: "null"
+                }]
             },
 
         ],
@@ -65,9 +94,10 @@ exports.test_data = {
         name: "Custom Extra Liners (p, string)",
         description: "",
         matrix: [{
-                options: [
-                    { name: "extra_liners", value: "'p,/p'" }
-                ]
+                options: [{
+                    name: "extra_liners",
+                    value: "'p,/p'"
+                }]
             },
 
         ],
@@ -80,9 +110,10 @@ exports.test_data = {
         name: "Custom Extra Liners (p)",
         description: "",
         matrix: [{
-                options: [
-                    { name: "extra_liners", value: "['p', '/p']" }
-                ]
+                options: [{
+                    name: "extra_liners",
+                    value: "['p', '/p']"
+                }]
             },
 
         ],
@@ -228,46 +259,66 @@ exports.test_data = {
         name: "Attribute Wrap",
         description: "Wraps attributes inside of html tags",
         matrix: [{
-            options: [
-                { name: "wrap_attributes", value: "'force'" }
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'force'"
+            }],
             indent_attr: '\\n    ',
             indent_over80: '\\n    '
         }, {
-            options: [
-                { name: "wrap_attributes", value: "'force'" },
-                { name: "wrap_line_length", value: "80" }
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'force'"
+            }, {
+                name: "wrap_line_length",
+                value: "80"
+            }],
             indent_attr: '\\n    ',
             indent_over80: '\\n    '
         }, {
-            options: [
-                { name: "wrap_attributes", value: "'force'" },
-                { name: "wrap_attributes_indent_size", value: "8" },
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'force'"
+            }, {
+                name: "wrap_attributes_indent_size",
+                value: "8"
+            }, ],
             indent_attr: '\\n        ',
             indent_over80: '\\n        '
         }, {
-            options: [
-                { name: "wrap_attributes", value: "'auto'" },
-                { name: "wrap_line_length", value: "80" },
-                { name: "wrap_attributes_indent_size", value: "0" }
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'auto'"
+            }, {
+                name: "wrap_line_length",
+                value: "80"
+            }, {
+                name: "wrap_attributes_indent_size",
+                value: "0"
+            }],
             indent_attr: ' ',
             indent_over80: '\\n'
         }, {
-            options: [
-                { name: "wrap_attributes", value: "'auto'" },
-                { name: "wrap_line_length", value: "80" },
-                { name: "wrap_attributes_indent_size", value: "4" }
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'auto'"
+            }, {
+                name: "wrap_line_length",
+                value: "80"
+            }, {
+                name: "wrap_attributes_indent_size",
+                value: "4"
+            }],
             indent_attr: ' ',
             indent_over80: '\\n    '
         }, {
-            options: [
-                { name: "wrap_attributes", value: "'auto'" },
-                { name: "wrap_line_length", value: "0" }
-            ],
+            options: [{
+                name: "wrap_attributes",
+                value: "'auto'"
+            }, {
+                name: "wrap_line_length",
+                value: "0"
+            }],
             indent_attr: ' ',
             indent_over80: ' '
         }],
@@ -296,9 +347,10 @@ exports.test_data = {
         name: "Handlebars Indenting Off",
         description: "Test handlebar behavior when indenting is off",
         template: "^^^ $$$",
-        options: [
-            { name: "indent_handlebars", value: "false" }
-        ],
+        options: [{
+            name: "indent_handlebars",
+            value: "false"
+        }],
         tests: [{
                 fragment: true,
                 input_: '{{#if 0}}\n' +
@@ -327,31 +379,43 @@ exports.test_data = {
         description: "Test handlebar formatting",
         template: "^^^ $$$",
         matrix: [{
-            options: [
-                { name: "indent_handlebars", value: "true" }
-            ],
+            options: [{
+                name: "indent_handlebars",
+                value: "true"
+            }],
             content: '{{field}}'
         }, {
-            options: [
-                { name: "indent_handlebars", value: "true" }
-            ],
+            options: [{
+                name: "indent_handlebars",
+                value: "true"
+            }],
             content: '{{! comment}}'
         }, {
-            options: [
-                { name: "indent_handlebars", value: "true" }
-            ],
+            options: [{
+                name: "indent_handlebars",
+                value: "true"
+            }],
             content: '{pre{{field1}} {{field2}} {{field3}}post'
         }, {
-            options: [
-                { name: "indent_handlebars", value: "true" }
-            ],
+            options: [{
+                name: "indent_handlebars",
+                value: "true"
+            }],
             content: '{{! \\n mult-line\\ncomment  \\n     with spacing\\n}}'
         }],
-        tests: [
-            { fragment: true, unchanged: '{{page-title}}' },
-            { fragment: true, unchanged: '{{#if 0}}{{/if}}' },
-            { fragment: true, unchanged: '{{#if 0}}^^^content$$${{/if}}' },
-            { fragment: true, unchanged: '{{#if 0}}\n{{/if}}' }, {
+        tests: [{
+                fragment: true,
+                unchanged: '{{page-title}}'
+            }, {
+                fragment: true,
+                unchanged: '{{#if 0}}{{/if}}'
+            }, {
+                fragment: true,
+                unchanged: '{{#if 0}}^^^content$$${{/if}}'
+            }, {
+                fragment: true,
+                unchanged: '{{#if 0}}\n{{/if}}'
+            }, {
                 fragment: true,
                 input_: '{{#if     words}}{{/if}}',
                 output: '{{#if words}}{{/if}}'
@@ -513,9 +577,10 @@ exports.test_data = {
         name: "Handlebars Else tag indenting",
         description: "Handlebar Else tags should be newlined after formatted tags",
         template: "^^^ $$$",
-        options: [
-            { name: "indent_handlebars", value: "true" }
-        ],
+        options: [{
+            name: "indent_handlebars",
+            value: "true"
+        }],
         tests: [{
             fragment: true,
             input_: '{{#if test}}<div></div>{{else}}<div></div>{{/if}}',
@@ -532,56 +597,77 @@ exports.test_data = {
         name: "Unclosed html elements",
         description: "Unclosed elements should not indent",
         options: [],
-        tests: [
-            { fragment: true, unchanged: '<source>\n<source>' },
-            { fragment: true, unchanged: '<br>\n<br>' },
-            { fragment: true, unchanged: '<input>\n<input>' },
-            { fragment: true, unchanged: '<meta>\n<meta>' },
-            { fragment: true, unchanged: '<link>\n<link>' },
-            { fragment: true, unchanged: '<colgroup>\n    <col>\n    <col>\n</colgroup>' }
-        ]
+        tests: [{
+            fragment: true,
+            unchanged: '<source>\n<source>'
+        }, {
+            fragment: true,
+            unchanged: '<br>\n<br>'
+        }, {
+            fragment: true,
+            unchanged: '<input>\n<input>'
+        }, {
+            fragment: true,
+            unchanged: '<meta>\n<meta>'
+        }, {
+            fragment: true,
+            unchanged: '<link>\n<link>'
+        }, {
+            fragment: true,
+            unchanged: '<colgroup>\n    <col>\n    <col>\n</colgroup>'
+        }]
     }, {
         name: "Unformatted tags",
         description: "Unformatted tag behavior",
         options: [],
-        tests: [
-            { fragment: true, unchanged: '<ol>\n    <li>b<pre>c</pre></li>\n</ol>' },
-            { fragment: true, unchanged: '<ol>\n    <li>b<code>c</code></li>\n</ol>' },
-            { fragment: true, unchanged: '<ul>\n    <li>\n        <span class="octicon octicon-person"></span>\n        <a href="/contact/">Kontakt</a>\n    </li>\n</ul>' },
-            { fragment: true, unchanged: '<div class="searchform"><input type="text" value="" name="s" id="s" /><input type="submit" id="searchsubmit" value="Search" /></div>' },
-            { fragment: true, unchanged: '<div class="searchform"><input type="text" value="" name="s" id="s"><input type="submit" id="searchsubmit" value="Search"></div>' },
-        ]
+        tests: [{
+            fragment: true,
+            unchanged: '<ol>\n    <li>b<pre>c</pre></li>\n</ol>'
+        }, {
+            fragment: true,
+            unchanged: '<ol>\n    <li>b<code>c</code></li>\n</ol>'
+        }, {
+            fragment: true,
+            unchanged: '<ul>\n    <li>\n        <span class="octicon octicon-person"></span>\n        <a href="/contact/">Kontakt</a>\n    </li>\n</ul>'
+        }, {
+            fragment: true,
+            unchanged: '<div class="searchform"><input type="text" value="" name="s" id="s" /><input type="submit" id="searchsubmit" value="Search" /></div>'
+        }, {
+            fragment: true,
+            unchanged: '<div class="searchform"><input type="text" value="" name="s" id="s"><input type="submit" id="searchsubmit" value="Search"></div>'
+        }, ]
     }, {
         name: "Php formatting",
         description: "Php (<?php ... ?>) treated as comments.",
         options: [],
-        tests: [
-            { fragment: true, unchanged: '<h1 class="content-page-header"><?=$view["name"]; ?></h1>' }, {
-                fragment: true,
-                unchanged: [
-                    '<?php',
-                    'for($i = 1; $i <= 100; $i++;) {',
-                    '    #count to 100!',
-                    '    echo($i . "</br>");',
-                    '}',
-                    '?>'
-                ]
-            }, {
-                fragment: true,
-                unchanged: [
-                    '<?php ?>',
-                    '<!DOCTYPE html>',
-                    '',
-                    '<html>',
-                    '',
-                    '<head></head>',
-                    '',
-                    '<body></body>',
-                    '',
-                    '</html>'
-                ]
-            }
-        ]
+        tests: [{
+            fragment: true,
+            unchanged: '<h1 class="content-page-header"><?=$view["name"]; ?></h1>'
+        }, {
+            fragment: true,
+            unchanged: [
+                '<?php',
+                'for($i = 1; $i <= 100; $i++;) {',
+                '    #count to 100!',
+                '    echo($i . "</br>");',
+                '}',
+                '?>'
+            ]
+        }, {
+            fragment: true,
+            unchanged: [
+                '<?php ?>',
+                '<!DOCTYPE html>',
+                '',
+                '<html>',
+                '',
+                '<head></head>',
+                '',
+                '<body></body>',
+                '',
+                '</html>'
+            ]
+        }]
     }, {
         name: "underscore.js  formatting",
         description: "underscore.js templates (<% ... %>) treated as comments.",
@@ -600,9 +686,10 @@ exports.test_data = {
         name: "Indent with tabs",
         description: "Use one tab instead of several spaces for indentation",
         template: "^^^ $$$",
-        options: [
-            { name: "indent_with_tabs", value: "true" }
-        ],
+        options: [{
+            name: "indent_with_tabs",
+            value: "true"
+        }],
         tests: [{
             fragment: true,
             input_: '<div>\n' +
@@ -618,9 +705,10 @@ exports.test_data = {
         name: "Indent without tabs",
         description: "Use several spaces for indentation",
         template: "^^^ $$$",
-        options: [
-            { name: "indent_with_tabs", value: "false" }
-        ],
+        options: [{
+            name: "indent_with_tabs",
+            value: "false"
+        }],
         tests: [{
             fragment: true,
             input_: '<div>\n' +

--- a/test/data/javascript/inputlib.js
+++ b/test/data/javascript/inputlib.js
@@ -74,7 +74,6 @@ var operator_position = {
     ]
 };
 
-
 //---------//
 // Exports //
 //---------//

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -1,15 +1,28 @@
 var inputlib = require('./inputlib');
 
 exports.test_data = {
-    default_options: [
-        { name: "indent_size", value: "4" },
-        { name: "indent_char", value: "' '" },
-        { name: "preserve_newlines", value: "true" },
-        { name: "jslint_happy", value: "false" },
-        { name: "keep_array_indentation", value: "false" },
-        { name: "brace_style", value: "'collapse'" },
-        { name: "operator_position", value: "'before-newline'" }
-    ],
+    default_options: [{
+        name: "indent_size",
+        value: "4"
+    }, {
+        name: "indent_char",
+        value: "' '"
+    }, {
+        name: "preserve_newlines",
+        value: "true"
+    }, {
+        name: "jslint_happy",
+        value: "false"
+    }, {
+        name: "keep_array_indentation",
+        value: "false"
+    }, {
+        name: "brace_style",
+        value: "'collapse'"
+    }, {
+        name: "operator_position",
+        value: "'before-newline'"
+    }],
     groups: [{
         name: "Unicode Support",
         description: "",
@@ -25,56 +38,74 @@ exports.test_data = {
     }, {
         name: "Test template and continuation strings",
         description: "",
-        tests: [
-            { unchanged: '`This is a ${template} string.`' },
-            { unchanged: '`This\n  is\n  a\n  ${template}\n  string.`' },
-            { unchanged: 'a = `This is a continuation\\\nstring.`' },
-            { unchanged: 'a = "This is a continuation\\\nstring."' },
-            { unchanged: '`SELECT\n  nextval(\\\'${this.options.schema ? `${this.options.schema}.` : \\\'\\\'}"${this.tableName}_${this.autoIncrementField}_seq"\\\'::regclass\n  ) nextval;`' },
-        ]
+        tests: [{
+            unchanged: '`This is a ${template} string.`'
+        }, {
+            unchanged: '`This\n  is\n  a\n  ${template}\n  string.`'
+        }, {
+            unchanged: 'a = `This is a continuation\\\nstring.`'
+        }, {
+            unchanged: 'a = "This is a continuation\\\nstring."'
+        }, {
+            unchanged: '`SELECT\n  nextval(\\\'${this.options.schema ? `${this.options.schema}.` : \\\'\\\'}"${this.tableName}_${this.autoIncrementField}_seq"\\\'::regclass\n  ) nextval;`'
+        }, ]
     }, {
         name: "ES7 Decorators",
         description: "Permit ES7 decorators, which are invoked with a leading \"@\".",
-        tests: [
-            { unchanged: '@foo' },
-            { unchanged: '@foo(bar)' },
-            {
-                unchanged: [
-                    '@foo(function(k, v) {',
-                    '    implementation();',
-                    '})'
-                ]
-            }
-        ]
+        tests: [{
+            unchanged: '@foo'
+        }, {
+            unchanged: '@foo(bar)'
+        }, {
+            unchanged: [
+                '@foo(function(k, v) {',
+                '    implementation();',
+                '})'
+            ]
+        }]
     }, {
         name: "ES7 exponential",
         description: "ES7 exponential",
-        tests: [
-            { unchanged: 'x ** 2' },
-            { unchanged: 'x ** -2' }
-        ]
+        tests: [{
+            unchanged: 'x ** 2'
+        }, {
+            unchanged: 'x ** -2'
+        }]
     }, {
         name: "End With Newline",
         description: "",
         matrix: [{
-                options: [
-                    { name: "end_with_newline", value: "true" }
-                ],
+                options: [{
+                    name: "end_with_newline",
+                    value: "true"
+                }],
                 eof: '\\n'
             }, {
-                options: [
-                    { name: "end_with_newline", value: "false" }
-                ],
+                options: [{
+                    name: "end_with_newline",
+                    value: "false"
+                }],
                 eof: ''
             }
 
         ],
-        tests: [
-            { fragment: true, input: '', output: '{{eof}}' },
-            { fragment: true, input: '   return .5', output: '   return .5{{eof}}' },
-            { fragment: true, input: '   \n\nreturn .5\n\n\n\n', output: '   return .5{{eof}}' },
-            { fragment: true, input: '\n', output: '{{eof}}' }
-        ],
+        tests: [{
+            fragment: true,
+            input: '',
+            output: '{{eof}}'
+        }, {
+            fragment: true,
+            input: '   return .5',
+            output: '   return .5{{eof}}'
+        }, {
+            fragment: true,
+            input: '   \n\nreturn .5\n\n\n\n',
+            output: '   return .5{{eof}}'
+        }, {
+            fragment: true,
+            input: '\n',
+            output: '{{eof}}'
+        }],
     }, {
         name: "Brace style permutations",
         description: "",
@@ -82,9 +113,10 @@ exports.test_data = {
         matrix: [
             // collapse-preserve-inline variations
             {
-                options: [
-                    { name: "brace_style", value: "'collapse-preserve-inline'" }
-                ],
+                options: [{
+                    name: "brace_style",
+                    value: "'collapse-preserve-inline'"
+                }],
                 ibo: '',
                 iao: '',
                 ibc: '',
@@ -93,11 +125,11 @@ exports.test_data = {
                 oao: ' ',
                 obc: ' ',
                 oac: ' '
-            },
-            {
-                options: [
-                    { name: "brace_style", value: "'collapse-preserve-inline'" }
-                ],
+            }, {
+                options: [{
+                    name: "brace_style",
+                    value: "'collapse-preserve-inline'"
+                }],
                 ibo: '\\n',
                 iao: '\\n',
                 ibc: '\\n',
@@ -110,9 +142,10 @@ exports.test_data = {
 
             // collapse variations
             {
-                options: [
-                    { name: "brace_style", value: "'collapse'" }
-                ],
+                options: [{
+                    name: "brace_style",
+                    value: "'collapse'"
+                }],
                 ibo: '',
                 iao: '',
                 ibc: '',
@@ -121,11 +154,11 @@ exports.test_data = {
                 oao: '\\n    ',
                 obc: '\\n',
                 oac: ' '
-            },
-            {
-                options: [
-                    { name: "brace_style", value: "'collapse'" }
-                ],
+            }, {
+                options: [{
+                    name: "brace_style",
+                    value: "'collapse'"
+                }],
                 ibo: '\\n',
                 iao: '\\n',
                 ibc: '\\n',
@@ -147,12 +180,10 @@ exports.test_data = {
             {
                 input: '//case 1\nif (a == 1)<ibo>{}\n//case 2\nelse if (a == 2)<ibo>{}',
                 output: '//case 1\nif (a == 1)<obo>{}\n//case 2\nelse if (a == 2)<obo>{}'
-            },
-            {
+            }, {
                 input: 'if(1)<ibo>{<iao>2<ibc>}<iac>else<ibo>{<iao>3<ibc>}',
                 output: 'if (1)<obo>{<oao>2<obc>}<oac>else<obo>{<oao>3<obc>}'
-            },
-            {
+            }, {
                 input: 'try<ibo>{<iao>a();<ibc>}<iac>' +
                     'catch(b)<ibo>{<iao>c();<ibc>}<iac>' +
                     'catch(d)<ibo>{}<iac>' +
@@ -169,9 +200,10 @@ exports.test_data = {
         name: "Comma-first option",
         description: "Put commas at the start of lines instead of the end",
         matrix: [{
-            options: [
-                { name: "comma_first", value: "false" }
-            ],
+            options: [{
+                name: "comma_first",
+                value: "false"
+            }],
             c0: ',\\n',
             c1: ',\\n    ',
             c2: ',\\n        ',
@@ -179,9 +211,10 @@ exports.test_data = {
             // edge cases where engine bails
             f1: '    ,\\n    '
         }, {
-            options: [
-                { name: "comma_first", value: "true" }
-            ],
+            options: [{
+                name: "comma_first",
+                value: "true"
+            }],
             c0: '\\n, ',
             c1: '\\n    , ',
             c2: '\\n        , ',
@@ -189,42 +222,53 @@ exports.test_data = {
             // edge cases where engine bails
             f1: ', '
         }],
-        tests: [
-            { input: '{a:1, b:2}', output: "{\n    a: 1{{c1}}b: 2\n}" },
-            { input: 'var a=1, b=c[d], e=6;', output: 'var a = 1{{c1}}b = c[d]{{c1}}e = 6;' },
-            { input: "for(var a=1,b=2,c=3;d<3;d++)\ne", output: "for (var a = 1, b = 2, c = 3; d < 3; d++)\n    e" },
-            { input: "for(var a=1,b=2,\nc=3;d<3;d++)\ne", output: "for (var a = 1, b = 2{{c2}}c = 3; d < 3; d++)\n    e" },
-            { input: 'function foo() {\n    return [\n        "one"{{c2}}"two"\n    ];\n}' },
-            { input: 'a=[[1,2],[4,5],[7,8]]', output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}[7, 8]\n]" },
-            { input: 'a=[[1,2],[4,5],[7,8],]', output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}[7, 8]{{c0}}]" },
-            {
+        tests: [{
+                input: '{a:1, b:2}',
+                output: "{\n    a: 1{{c1}}b: 2\n}"
+            }, {
+                input: 'var a=1, b=c[d], e=6;',
+                output: 'var a = 1{{c1}}b = c[d]{{c1}}e = 6;'
+            }, {
+                input: "for(var a=1,b=2,c=3;d<3;d++)\ne",
+                output: "for (var a = 1, b = 2, c = 3; d < 3; d++)\n    e"
+            }, {
+                input: "for(var a=1,b=2,\nc=3;d<3;d++)\ne",
+                output: "for (var a = 1, b = 2{{c2}}c = 3; d < 3; d++)\n    e"
+            }, {
+                input: 'function foo() {\n    return [\n        "one"{{c2}}"two"\n    ];\n}'
+            }, {
+                input: 'a=[[1,2],[4,5],[7,8]]',
+                output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}[7, 8]\n]"
+            }, {
+                input: 'a=[[1,2],[4,5],[7,8],]',
+                output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}[7, 8]{{c0}}]"
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},[7,8]]',
                 output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}function() {}{{c1}}[7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},function(){},[7,8]]',
                 output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}function() {}{{c1}}function() {}{{c1}}[7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},[7,8]]',
                 output: "a = [\n    [1, 2]{{c1}}[4, 5]{{c1}}function() {}{{c1}}[7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[b,c,function(){},function(){},d]',
                 output: "a = [b, c, function() {}, function() {}, d]"
-            },
-            {
+            }, {
                 input: 'a=[b,c,\nfunction(){},function(){},d]',
                 output: "a = [b, c{{c1}}function() {}{{c1}}function() {}{{c1}}d\n]"
+            }, {
+                input: 'a=[a[1],b[4],c[d[7]]]',
+                output: "a = [a[1], b[4], c[d[7]]]"
+            }, {
+                input: '[1,2,[3,4,[5,6],7],8]',
+                output: "[1, 2, [3, 4, [5, 6], 7], 8]"
             },
-            { input: 'a=[a[1],b[4],c[d[7]]]', output: "a = [a[1], b[4], c[d[7]]]" },
-            { input: '[1,2,[3,4,[5,6],7],8]', output: "[1, 2, [3, 4, [5, 6], 7], 8]" },
 
             {
                 input: '[[["1","2"],["3","4"]],[["5","6","7"],["8","9","0"]],[["1","2","3"],["4","5","6","7"],["8","9","0"]]]',
                 output: '[\n    [\n        ["1", "2"]{{c2}}["3", "4"]\n    ]{{c1}}[\n        ["5", "6", "7"]{{c2}}["8", "9", "0"]\n    ]{{c1}}[\n        ["1", "2", "3"]{{c2}}["4", "5", "6", "7"]{{c2}}["8", "9", "0"]\n    ]\n]'
-            },
-            {
+            }, {
                 input: [
                     'changeCollection.add({',
                     '    name: "Jonathan" // New line inserted after this line on every save',
@@ -243,102 +287,115 @@ exports.test_data = {
         name: "Space in parens tests",
         description: "put space inside parens",
         matrix: [{
-            options: [
-                { name: "space_in_paren", value: "false" },
-                { name: "space_in_empty_paren", value: "false" },
-            ],
+            options: [{
+                name: "space_in_paren",
+                value: "false"
+            }, {
+                name: "space_in_empty_paren",
+                value: "false"
+            }, ],
             s: '',
             e: '',
         }, {
-            options: [
-                { name: "space_in_paren", value: "false" },
-                { name: "space_in_empty_paren", value: "true" },
-            ],
+            options: [{
+                name: "space_in_paren",
+                value: "false"
+            }, {
+                name: "space_in_empty_paren",
+                value: "true"
+            }, ],
             s: '',
             e: '',
         }, {
-            options: [
-                { name: "space_in_paren", value: "true" },
-                { name: "space_in_empty_paren", value: "false" },
-            ],
+            options: [{
+                name: "space_in_paren",
+                value: "true"
+            }, {
+                name: "space_in_empty_paren",
+                value: "false"
+            }, ],
             s: ' ',
             e: '',
         }, {
-            options: [
-                { name: "space_in_paren", value: "true" },
-                { name: "space_in_empty_paren", value: "true" },
-            ],
+            options: [{
+                name: "space_in_paren",
+                value: "true"
+            }, {
+                name: "space_in_empty_paren",
+                value: "true"
+            }, ],
             s: ' ',
             e: ' ',
         }],
         tests: [{
-                input: 'if(p) foo(a,b);',
-                output: 'if ({{s}}p{{s}}) foo({{s}}a, b{{s}});'
-            },
-            {
-                input: 'try{while(true){willThrow()}}catch(result)switch(result){case 1:++result }',
-                output: 'try {\n    while ({{s}}true{{s}}) {\n        willThrow({{e}})\n    }\n} catch ({{s}}result{{s}}) switch ({{s}}result{{s}}) {\n    case 1:\n        ++result\n}'
-            },
-            {
-                input: '((e/((a+(b)*c)-d))^2)*5;',
-                output: '({{s}}({{s}}e / ({{s}}({{s}}a + ({{s}}b{{s}}) * c{{s}}) - d{{s}}){{s}}) ^ 2{{s}}) * 5;'
-            },
-            {
-                input: 'function f(a,b) {if(a) b()}function g(a,b) {if(!a) b()}',
-                output: 'function f({{s}}a, b{{s}}) {\n    if ({{s}}a{{s}}) b({{e}})\n}\n\nfunction g({{s}}a, b{{s}}) {\n    if ({{s}}!a{{s}}) b({{e}})\n}'
-            },
-            {
-                input: 'a=[];',
-                output: 'a = [{{e}}];'
-            },
-            {
-                input: 'a=[b,c,d];',
-                output: 'a = [{{s}}b, c, d{{s}}];'
-            },
-            {
-                input: 'a= f[b];',
-                output: 'a = f[{{s}}b{{s}}];'
-            },
-            {
-                input: [
-                    '{',
-                    '    files: [ {',
-                    '        expand: true,',
-                    '        cwd: "www/gui/",',
-                    '        src: [ "im/design_standards/*.*" ],',
-                    '        dest: "www/gui/build"',
-                    '    } ]',
-                    '}'
-                ],
-                output: [
-                    '{',
-                    '    files: [{{s}}{',
-                    '        expand: true,',
-                    '        cwd: "www/gui/",',
-                    '        src: [{{s}}"im/design_standards/*.*"{{s}}],',
-                    '        dest: "www/gui/build"',
-                    '    }{{s}}]',
-                    '}'
-                ],
-            },
-        ],
+            input: 'if(p) foo(a,b);',
+            output: 'if ({{s}}p{{s}}) foo({{s}}a, b{{s}});'
+        }, {
+            input: 'try{while(true){willThrow()}}catch(result)switch(result){case 1:++result }',
+            output: 'try {\n    while ({{s}}true{{s}}) {\n        willThrow({{e}})\n    }\n} catch ({{s}}result{{s}}) switch ({{s}}result{{s}}) {\n    case 1:\n        ++result\n}'
+        }, {
+            input: '((e/((a+(b)*c)-d))^2)*5;',
+            output: '({{s}}({{s}}e / ({{s}}({{s}}a + ({{s}}b{{s}}) * c{{s}}) - d{{s}}){{s}}) ^ 2{{s}}) * 5;'
+        }, {
+            input: 'function f(a,b) {if(a) b()}function g(a,b) {if(!a) b()}',
+            output: 'function f({{s}}a, b{{s}}) {\n    if ({{s}}a{{s}}) b({{e}})\n}\n\nfunction g({{s}}a, b{{s}}) {\n    if ({{s}}!a{{s}}) b({{e}})\n}'
+        }, {
+            input: 'a=[];',
+            output: 'a = [{{e}}];'
+        }, {
+            input: 'a=[b,c,d];',
+            output: 'a = [{{s}}b, c, d{{s}}];'
+        }, {
+            input: 'a= f[b];',
+            output: 'a = f[{{s}}b{{s}}];'
+        }, {
+            input: [
+                '{',
+                '    files: [ {',
+                '        expand: true,',
+                '        cwd: "www/gui/",',
+                '        src: [ "im/design_standards/*.*" ],',
+                '        dest: "www/gui/build"',
+                '    } ]',
+                '}'
+            ],
+            output: [
+                '{',
+                '    files: [{{s}}{',
+                '        expand: true,',
+                '        cwd: "www/gui/",',
+                '        src: [{{s}}"im/design_standards/*.*"{{s}}],',
+                '        dest: "www/gui/build"',
+                '    }{{s}}]',
+                '}'
+            ],
+        }, ],
     }, {
         name: "operator_position option - ensure no neswlines if preserve_newlines is false",
         matrix: [{
-            options: [
-                { name: "operator_position", value: "'before-newline'" },
-                { name: "preserve_newlines", value: "false" }
-            ]
+            options: [{
+                name: "operator_position",
+                value: "'before-newline'"
+            }, {
+                name: "preserve_newlines",
+                value: "false"
+            }]
         }, {
-            options: [
-                { name: "operator_position", value: "'after-newline'" },
-                { name: "preserve_newlines", value: "false" }
-            ]
+            options: [{
+                name: "operator_position",
+                value: "'after-newline'"
+            }, {
+                name: "preserve_newlines",
+                value: "false"
+            }]
         }, {
-            options: [
-                { name: "operator_position", value: "'preserve-newline'" },
-                { name: "preserve_newlines", value: "false" }
-            ]
+            options: [{
+                name: "operator_position",
+                value: "'preserve-newline'"
+            }, {
+                name: "preserve_newlines",
+                value: "false"
+            }]
         }],
         tests: [{
             unchanged: inputlib.operator_position.sanity
@@ -544,52 +601,56 @@ exports.test_data = {
     }, {
         name: "Async / await tests",
         description: "ES7 async / await tests",
-        tests: [
-            { input: "async function foo() {}" },
-            { input: "let w = async function foo() {}" },
-            { input: "async function foo() {}\nvar x = await foo();" },
-            {
-                comment: "async function as an input to another function",
-                input: "wrapper(async function foo() {})"
-            },
-            {
-                comment: "await on inline anonymous function. should have a space after await",
-                input_: "async function() {\n    var w = await(async function() {\n        return await foo();\n    })();\n}",
-                output: "async function() {\n    var w = await (async function() {\n        return await foo();\n    })();\n}"
-            },
-            {
-                comment: "ensure that this doesn't break anyone with the async library",
-                input: "async.map(function(t) {})"
-            }
-        ]
+        tests: [{
+            input: "async function foo() {}"
+        }, {
+            input: "let w = async function foo() {}"
+        }, {
+            input: "async function foo() {}\nvar x = await foo();"
+        }, {
+            comment: "async function as an input to another function",
+            input: "wrapper(async function foo() {})"
+        }, {
+            comment: "await on inline anonymous function. should have a space after await",
+            input_: "async function() {\n    var w = await(async function() {\n        return await foo();\n    })();\n}",
+            output: "async function() {\n    var w = await (async function() {\n        return await foo();\n    })();\n}"
+        }, {
+            comment: "ensure that this doesn't break anyone with the async library",
+            input: "async.map(function(t) {})"
+        }]
     }, {
         name: "e4x - Test that e4x literals passed through when e4x-option is enabled",
         description: "",
-        options: [
-            { name: 'e4x', value: true }
-        ],
-        tests: [
-            { input: 'xml=<a b="c"><d/><e>\n foo</e>x</a>;', output: 'xml = <a b="c"><d/><e>\n foo</e>x</a>;' },
-            { unchanged: '<a b=\\\'This is a quoted "c".\\\'/>' },
-            { unchanged: '<a b="This is a quoted \\\'c\\\'."/>' },
-            { unchanged: '<a b="A quote \\\' inside string."/>' },
-            { unchanged: '<a b=\\\'A quote " inside string.\\\'/>' },
-            { unchanged: '<a b=\\\'Some """ quotes ""  inside string.\\\'/>' },
+        options: [{
+            name: 'e4x',
+            value: true
+        }],
+        tests: [{
+                input: 'xml=<a b="c"><d/><e>\n foo</e>x</a>;',
+                output: 'xml = <a b="c"><d/><e>\n foo</e>x</a>;'
+            }, {
+                unchanged: '<a b=\\\'This is a quoted "c".\\\'/>'
+            }, {
+                unchanged: '<a b="This is a quoted \\\'c\\\'."/>'
+            }, {
+                unchanged: '<a b="A quote \\\' inside string."/>'
+            }, {
+                unchanged: '<a b=\\\'A quote " inside string.\\\'/>'
+            }, {
+                unchanged: '<a b=\\\'Some """ quotes ""  inside string.\\\'/>'
+            },
 
             {
                 comment: 'Handles inline expressions',
                 input: 'xml=<{a} b="c"><d/><e v={z}>\n foo</e>x</{a}>;',
                 output: 'xml = <{a} b="c"><d/><e v={z}>\n foo</e>x</{a}>;'
-            },
-            {
+            }, {
                 input: 'xml=<{a} b="c">\n    <e v={z}>\n foo</e>x</{a}>;',
                 output: 'xml = <{a} b="c">\n    <e v={z}>\n foo</e>x</{a}>;'
-            },
-            {
+            }, {
                 comment: 'xml literals with special characters in elem names - see http://www.w3.org/TR/REC-xml/#NT-NameChar',
                 unchanged: 'xml = <_:.valid.xml- _:.valid.xml-="123"/>;'
-            },
-            {
+            }, {
                 comment: 'xml literals with attributes without equal sign',
                 unchanged: 'xml = <elem someAttr/>;'
             },
@@ -598,9 +659,13 @@ exports.test_data = {
                 comment: 'Handles CDATA',
                 input: 'xml=<![CDATA[ b="c"><d/><e v={z}>\n foo</e>x/]]>;',
                 output: 'xml = <![CDATA[ b="c"><d/><e v={z}>\n foo</e>x/]]>;'
+            }, {
+                input: 'xml=<![CDATA[]]>;',
+                output: 'xml = <![CDATA[]]>;'
+            }, {
+                input: 'xml=<a b="c"><![CDATA[d/></a></{}]]></a>;',
+                output: 'xml = <a b="c"><![CDATA[d/></a></{}]]></a>;'
             },
-            { input: 'xml=<![CDATA[]]>;', output: 'xml = <![CDATA[]]>;' },
-            { input: 'xml=<a b="c"><![CDATA[d/></a></{}]]></a>;', output: 'xml = <a b="c"><![CDATA[d/></a></{}]]></a>;' },
 
             {
                 comment: 'JSX - working jsx from http://prettydiff.com/unit_tests/beautification_javascript_jsx.txt',
@@ -617,8 +682,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var List = React.createClass({',
                     '    renderList: function() {',
@@ -634,8 +698,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var Mist = React.createClass({',
                     '    renderList: function() {',
@@ -645,8 +708,7 @@ exports.test_data = {
                     '    }',
                     '});',
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     '// JSX',
                     'var box = <Box>',
@@ -666,8 +728,7 @@ exports.test_data = {
                     '});',
                     'React.render(<HelloMessage name="John" />, mountNode);',
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var Timer = React.createClass({',
                     '    getInitialState: function() {',
@@ -694,8 +755,7 @@ exports.test_data = {
                     '});',
                     'React.render(<Timer />, mountNode);'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var TodoList = React.createClass({',
                     '    render: function() {',
@@ -706,8 +766,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var TodoApp = React.createClass({',
                     '    getInitialState: function() {',
@@ -745,8 +804,7 @@ exports.test_data = {
                     '});',
                     'React.render(<TodoApp />, mountNode);'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var converter = new Showdown.converter();',
                     'var MarkdownEditor = React.createClass({',
@@ -812,8 +870,7 @@ exports.test_data = {
                     '});',
                     'React.render(<MarkdownEditor />, mountNode);'
                 ]
-            },
-            {
+            }, {
                 comment: 'JSX - Not quite correct jsx formatting that still works',
                 input: [
                     'var content = (',
@@ -847,8 +904,7 @@ exports.test_data = {
                     'var qwer = <DropDown> A dropdown list <Menu> <MenuItem>Do Something</MenuItem> <MenuItem>Do Something Fun!</MenuItem> <MenuItem>Do Something Else</MenuItem> </Menu> </DropDown>;',
                     'render(dropdown);',
                 ]
-            },
-            {
+            }, {
                 comment: [
                     "Handles messed up tags, as long as it isn't the same name",
                     "as the root tag. Also handles tags of same name as root tag",
@@ -866,8 +922,7 @@ exports.test_data = {
                 fragment: true,
                 input_: 'xml=<a></b>\nc<b;',
                 output: 'xml = <a></b>\nc<b;'
-            },
-            {
+            }, {
                 comment: 'Issue #646 = whitespace is allowed in attribute declarations',
                 unchanged: [
                     'let a = React.createClass({',
@@ -880,8 +935,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'let a = React.createClass({',
                     '    render() {',
@@ -893,8 +947,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'let a = React.createClass({',
                     '    render() {',
@@ -906,8 +959,7 @@ exports.test_data = {
                     '    }',
                     '});'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'let a = React.createClass({',
                     '    render() {',
@@ -924,9 +976,10 @@ exports.test_data = {
     }, {
         name: "e4x disabled",
         description: "",
-        options: [
-            { name: 'e4x', value: false }
-        ],
+        options: [{
+            name: 'e4x',
+            value: false
+        }],
         tests: [{
             input_: 'xml=<a b="c"><d/><e>\n foo</e>x</a>;',
             output: 'xml = < a b = "c" > < d / > < e >\n    foo < /e>x</a > ;'
@@ -936,26 +989,28 @@ exports.test_data = {
         description: "",
         template: "^^^ $$$",
         options: [],
-        tests: [
-            { input: '{{}/z/}', output: '{\n    {}\n    /z/\n}' }
-        ]
+        tests: [{
+            input: '{{}/z/}',
+            output: '{\n    {}\n    /z/\n}'
+        }]
     }, {
         name: "Beautify preserve formatting",
         description: "Allow beautifier to preserve sections",
-        tests: [
-            { unchanged: "/* beautify preserve:start */\n/* beautify preserve:end */" },
-            { unchanged: "/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */" },
-            { unchanged: "var a = 1;\n/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */" },
-            { unchanged: "/* beautify preserve:start */     {asdklgh;y;;{}dd2d}/* beautify preserve:end */" },
-            {
+        tests: [{
+                unchanged: "/* beautify preserve:start */\n/* beautify preserve:end */"
+            }, {
+                unchanged: "/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */"
+            }, {
+                unchanged: "var a = 1;\n/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */"
+            }, {
+                unchanged: "/* beautify preserve:start */     {asdklgh;y;;{}dd2d}/* beautify preserve:end */"
+            }, {
                 input_: "var a =  1;\n/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */",
                 output: "var a = 1;\n/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */"
-            },
-            {
+            }, {
                 input_: "var a = 1;\n /* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */",
                 output: "var a = 1;\n/* beautify preserve:start */\n   var a = 1;\n/* beautify preserve:end */"
-            },
-            {
+            }, {
                 unchanged: [
                     'var a = {',
                     '    /* beautify preserve:start */',
@@ -966,8 +1021,7 @@ exports.test_data = {
                     '    /* beautify preserve:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/* beautify preserve:start */',
@@ -988,8 +1042,7 @@ exports.test_data = {
                     '/* beautify preserve:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 comment: 'one space before and after required, only single spaces inside.',
                 input: [
                     'var a = {',
@@ -1009,8 +1062,7 @@ exports.test_data = {
                     '    ten: 10',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/*beautify preserve:start*/',
@@ -1029,8 +1081,7 @@ exports.test_data = {
                     '    ten: 10',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/*beautify  preserve:start*/',
@@ -1054,19 +1105,19 @@ exports.test_data = {
             {
                 comment: 'Directive: ignore',
                 unchanged: "/* beautify ignore:start */\n/* beautify ignore:end */"
-            },
-            { unchanged: "/* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */" },
-            { unchanged: "var a = 1;\n/* beautify ignore:start */\n   var a = 1;\n/* beautify ignore:end */" },
-            { unchanged: "/* beautify ignore:start */     {asdklgh;y;+++;dd2d}/* beautify ignore:end */" },
-            {
+            }, {
+                unchanged: "/* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */"
+            }, {
+                unchanged: "var a = 1;\n/* beautify ignore:start */\n   var a = 1;\n/* beautify ignore:end */"
+            }, {
+                unchanged: "/* beautify ignore:start */     {asdklgh;y;+++;dd2d}/* beautify ignore:end */"
+            }, {
                 input_: "var a =  1;\n/* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */",
                 output: "var a = 1;\n/* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */"
-            },
-            {
+            }, {
                 input_: "var a = 1;\n /* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */",
                 output: "var a = 1;\n/* beautify ignore:start */\n   var a,,,{ 1;\n/* beautify ignore:end */"
-            },
-            {
+            }, {
                 unchanged: [
                     'var a = {',
                     '    /* beautify ignore:start */',
@@ -1077,8 +1128,7 @@ exports.test_data = {
                     '    /* beautify ignore:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/* beautify ignore:start */',
@@ -1099,8 +1149,7 @@ exports.test_data = {
                     '/* beautify ignore:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 comment: 'Directives - multiple and interacting',
                 input: [
                     'var a = {',
@@ -1128,8 +1177,7 @@ exports.test_data = {
                     '/* beautify preserve:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/* beautify ignore:start */',
@@ -1154,8 +1202,7 @@ exports.test_data = {
                     '/* beautify ignore:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 comment: 'Starts can occur together, ignore:end must occur alone.',
                 input: [
                     'var a = {',
@@ -1187,8 +1234,7 @@ exports.test_data = {
                     '/* beautify ignore:end */',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/* beautify ignore:start preserve:start */',
@@ -1215,8 +1261,7 @@ exports.test_data = {
                     '   // This is all preserved',
                     '};'
                 ]
-            },
-            {
+            }, {
                 input: [
                     'var a = {',
                     '/* beautify ignore:start preserve:start */',
@@ -1251,50 +1296,63 @@ exports.test_data = {
         name: "Template Formatting",
         description: "Php (<?php ... ?>) and underscore.js templating treated as strings.",
         options: [],
-        tests: [
-            { unchanged: '<?=$view["name"]; ?>' },
-            { unchanged: 'a = <?= external() ?>;' },
-            {
-                unchanged: [
-                    '<?php',
-                    'for($i = 1; $i <= 100; $i++;) {',
-                    '    #count to 100!',
-                    '    echo($i . "</br>");',
-                    '}',
-                    '?>'
-                ]
-            },
-            { unchanged: 'a = <%= external() %>;' }
-        ]
+        tests: [{
+            unchanged: '<?=$view["name"]; ?>'
+        }, {
+            unchanged: 'a = <?= external() ?>;'
+        }, {
+            unchanged: [
+                '<?php',
+                'for($i = 1; $i <= 100; $i++;) {',
+                '    #count to 100!',
+                '    echo($i . "</br>");',
+                '}',
+                '?>'
+            ]
+        }, {
+            unchanged: 'a = <%= external() %>;'
+        }]
     }, {
         name: "jslint and space after anon function",
         description: "jslint_happy and space_after_anon_function tests",
         matrix: [{
-                options: [
-                    { name: "jslint_happy", value: "true" },
-                    { name: "space_after_anon_function", value: "true" }
-                ],
+                options: [{
+                    name: "jslint_happy",
+                    value: "true"
+                }, {
+                    name: "space_after_anon_function",
+                    value: "true"
+                }],
                 f: ' ',
                 c: ''
             }, {
-                options: [
-                    { name: "jslint_happy", value: "true" },
-                    { name: "space_after_anon_function", value: "false" }
-                ],
+                options: [{
+                    name: "jslint_happy",
+                    value: "true"
+                }, {
+                    name: "space_after_anon_function",
+                    value: "false"
+                }],
                 f: ' ',
                 c: ''
             }, {
-                options: [
-                    { name: "jslint_happy", value: "false" },
-                    { name: "space_after_anon_function", value: "true" }
-                ],
+                options: [{
+                    name: "jslint_happy",
+                    value: "false"
+                }, {
+                    name: "space_after_anon_function",
+                    value: "true"
+                }],
                 f: ' ',
                 c: '    '
             }, {
-                options: [
-                    { name: "jslint_happy", value: "false" },
-                    { name: "space_after_anon_function", value: "false" }
-                ],
+                options: [{
+                    name: "jslint_happy",
+                    value: "false"
+                }, {
+                    name: "space_after_anon_function",
+                    value: "false"
+                }],
                 f: '',
                 c: '    '
             }
@@ -1304,16 +1362,13 @@ exports.test_data = {
         tests: [{
                 input_: 'a=typeof(x)',
                 output: 'a = typeof{{f}}(x)'
-            },
-            {
+            }, {
                 input_: 'x();\n\nfunction(){}',
                 output: 'x();\n\nfunction{{f}}() {}'
-            },
-            {
+            }, {
                 input_: 'x();\n\nvar x = {\nx: function(){}\n}',
                 output: 'x();\n\nvar x = {\n    x: function{{f}}() {}\n}'
-            },
-            {
+            }, {
                 input_: 'function () {\n    var a, b, c, d, e = [],\n        f;\n}',
                 output: 'function{{f}}() {\n    var a, b, c, d, e = [],\n        f;\n}'
             },
@@ -1321,12 +1376,10 @@ exports.test_data = {
             {
                 input_: 'switch(x) {case 0: case 1: a(); break; default: break}',
                 output: 'switch (x) {\n{{c}}case 0:\n{{c}}case 1:\n{{c}}    a();\n{{c}}    break;\n{{c}}default:\n{{c}}    break\n}'
-            },
-            {
+            }, {
                 input: 'switch(x){case -1:break;case !y:break;}',
                 output: 'switch (x) {\n{{c}}case -1:\n{{c}}    break;\n{{c}}case !y:\n{{c}}    break;\n}'
-            },
-            {
+            }, {
                 comment: 'typical greasemonkey start',
                 fragment: true,
                 unchanged: '// comment 2\n(function{{f}}()'
@@ -1335,502 +1388,483 @@ exports.test_data = {
             {
                 input_: 'var a2, b2, c2, d2 = 0, c = function() {}, d = \\\'\\\';',
                 output: 'var a2, b2, c2, d2 = 0,\n    c = function{{f}}() {},\n    d = \\\'\\\';'
-            },
-            {
+            }, {
                 input_: 'var a2, b2, c2, d2 = 0, c = function() {},\nd = \\\'\\\';',
                 output: 'var a2, b2, c2, d2 = 0,\n    c = function{{f}}() {},\n    d = \\\'\\\';'
-            },
-            {
+            }, {
                 input_: 'var o2=$.extend(a);function(){alert(x);}',
                 output: 'var o2 = $.extend(a);\n\nfunction{{f}}() {\n    alert(x);\n}'
+            }, {
+                input: 'function*() {\n    yield 1;\n}',
+                output: 'function*{{f}}() {\n    yield 1;\n}'
+            }, {
+                unchanged: 'function* x() {\n    yield 1;\n}'
             },
-            { input: 'function*() {\n    yield 1;\n}', output: 'function*{{f}}() {\n    yield 1;\n}' },
-            { unchanged: 'function* x() {\n    yield 1;\n}' },
         ]
     }, {
         name: "Regression tests",
         description: "Ensure specific bugs do not recur",
         options: [],
         tests: [{
-                comment: "Issue 241",
-                unchanged: [
-                    'obj',
-                    '    .last({',
-                    '        foo: 1,',
-                    '        bar: 2',
-                    '    });',
-                    'var test = 1;'
-                ]
-            },
-            {
-                unchanged: [
-                    'obj',
-                    '    .last(a, function() {',
-                    '        var test;',
-                    '    });',
-                    'var test = 1;'
-                ]
-            },
-            {
-                unchanged: [
-                    'obj.first()',
-                    '    .second()',
-                    '    .last(function(err, response) {',
-                    '        console.log(err);',
-                    '    });'
-                ]
-            },
-            {
-                comment: "Issue 268 and 275",
-                unchanged: [
-                    'obj.last(a, function() {',
-                    '    var test;',
-                    '});',
-                    'var test = 1;'
-                ]
-            },
-            {
-                unchanged: [
-                    'obj.last(a,',
-                    '    function() {',
-                    '        var test;',
-                    '    });',
-                    'var test = 1;'
-                ]
-            },
-            {
-                input: '(function() {if (!window.FOO) window.FOO || (window.FOO = function() {var b = {bar: "zort"};});})();',
-                output: [
-                    '(function() {',
-                    '    if (!window.FOO) window.FOO || (window.FOO = function() {',
-                    '        var b = {',
-                    '            bar: "zort"',
-                    '        };',
-                    '    });',
-                    '})();'
-                ]
-            },
-            {
-                comment: "Issue 281",
-                unchanged: [
-                    'define(["dojo/_base/declare", "my/Employee", "dijit/form/Button",',
-                    '    "dojo/_base/lang", "dojo/Deferred"',
-                    '], function(declare, Employee, Button, lang, Deferred) {',
-                    '    return declare(Employee, {',
-                    '        constructor: function() {',
-                    '            new Button({',
-                    '                onClick: lang.hitch(this, function() {',
-                    '                    new Deferred().then(lang.hitch(this, function() {',
-                    '                        this.salary * 0.25;',
-                    '                    }));',
-                    '                })',
-                    '            });',
-                    '        }',
-                    '    });',
-                    '});'
-                ]
-            },
-            {
-                unchanged: [
-                    'define(["dojo/_base/declare", "my/Employee", "dijit/form/Button",',
-                    '        "dojo/_base/lang", "dojo/Deferred"',
-                    '    ],',
-                    '    function(declare, Employee, Button, lang, Deferred) {',
-                    '        return declare(Employee, {',
-                    '            constructor: function() {',
-                    '                new Button({',
-                    '                    onClick: lang.hitch(this, function() {',
-                    '                        new Deferred().then(lang.hitch(this, function() {',
-                    '                            this.salary * 0.25;',
-                    '                        }));',
-                    '                    })',
-                    '                });',
-                    '            }',
-                    '        });',
-                    '    });'
-                ]
-            },
-            {
-                comment: "Issue 459",
-                unchanged: [
-                    '(function() {',
-                    '    return {',
-                    '        foo: function() {',
-                    '            return "bar";',
-                    '        },',
-                    '        bar: ["bar"]',
-                    '    };',
-                    '}());'
-                ]
-            },
-            {
-                comment: "Issue 505 - strings should end at newline unless continued by backslash",
-                unchanged: [
-                    'var name = "a;',
-                    'name = "b";'
-                ]
-            },
-            {
-                unchanged: [
-                    'var name = "a;\\\\',
-                    '    name = b";'
-                ]
-            },
-            {
-                comment: "Issue 514 - some operators require spaces to distinguish them",
-                unchanged: 'var c = "_ACTION_TO_NATIVEAPI_" + ++g++ + +new Date;'
-            },
-            {
-                unchanged: 'var c = "_ACTION_TO_NATIVEAPI_" - --g-- - -new Date;'
-            },
-            {
-                comment: "Issue 440 - reserved words can be used as object property names",
-                unchanged: [
-                    'a = {',
-                    '    function: {},',
-                    '    "function": {},',
-                    '    throw: {},',
-                    '    "throw": {},',
-                    '    var: {},',
-                    '    "var": {},',
-                    '    set: {},',
-                    '    "set": {},',
-                    '    get: {},',
-                    '    "get": {},',
-                    '    if: {},',
-                    '    "if": {},',
-                    '    then: {},',
-                    '    "then": {},',
-                    '    else: {},',
-                    '    "else": {},',
-                    '    yay: {}',
-                    '};'
-                ]
-            },
-            {
-                comment: "Issue 331 - if-else with braces edge case",
-                input: 'if(x){a();}else{b();}if(y){c();}',
-                output: [
-                    'if (x) {',
-                    '    a();',
-                    '} else {',
-                    '    b();',
-                    '}',
-                    'if (y) {',
-                    '    c();',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 485 - ensure function declarations behave the same in arrays as elsewhere",
-                unchanged: [
-                    'var v = ["a",',
-                    '    function() {',
-                    '        return;',
-                    '    }, {',
-                    '        id: 1',
-                    '    }',
-                    '];'
-                ]
-            },
-            {
-                unchanged: [
-                    'var v = ["a", function() {',
-                    '    return;',
-                    '}, {',
-                    '    id: 1',
-                    '}];'
-                ]
-            },
-            {
-                comment: "Issue 382 - initial totally cursory support for es6 module export",
-                unchanged: [
-                    'module "Even" {',
-                    '    import odd from "Odd";',
-                    '    export function sum(x, y) {',
-                    '        return x + y;',
-                    '    }',
-                    '    export var pi = 3.141593;',
-                    '    export default moduleName;',
-                    '}'
-                ]
-            },
-            {
-                unchanged: [
-                    'module "Even" {',
-                    '    export default function div(x, y) {}',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 508",
-                unchanged: 'set["name"]'
-            },
-            {
-                unchanged: 'get["name"]'
-            },
-            {
-                fragmeent: true,
-                unchanged: [
-                    'a = {',
-                    '    set b(x) {},',
-                    '    c: 1,',
-                    '    d: function() {}',
-                    '};'
-                ]
-            },
-            {
-                fragmeent: true,
-                unchanged: [
-                    'a = {',
-                    '    get b() {',
-                    '        retun 0;',
-                    '    },',
-                    '    c: 1,',
-                    '    d: function() {}',
-                    '};'
-                ]
-            },
-            {
-                comment: "Issue 298 - do not under indent if/while/for condtionals experesions",
-                unchanged: [
-                    '\\\'use strict\\\';',
-                    'if ([].some(function() {',
-                    '        return false;',
-                    '    })) {',
-                    '    console.log("hello");',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 298 - do not under indent if/while/for condtionals experesions",
-                unchanged: [
-                    '\\\'use strict\\\';',
-                    'if ([].some(function() {',
-                    '        return false;',
-                    '    })) {',
-                    '    console.log("hello");',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 552 - Typescript?  Okay... we didn't break it before, so try not to break it now.",
-                unchanged: [
-                    'class Test {',
-                    '    blah: string[];',
-                    '    foo(): number {',
-                    '        return 0;',
-                    '    }',
-                    '    bar(): number {',
-                    '        return 0;',
-                    '    }',
-                    '}'
-                ]
-            },
-            {
-                unchanged: [
-                    'interface Test {',
-                    '    blah: string[];',
-                    '    foo(): number {',
-                    '        return 0;',
-                    '    }',
-                    '    bar(): number {',
-                    '        return 0;',
-                    '    }',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 583 - Functions with comments after them should still indent correctly.",
-                unchanged: [
-                    'function exit(code) {',
-                    '    setTimeout(function() {',
-                    '        phantom.exit(code);',
-                    '    }, 0);',
-                    '    phantom.onError = function() {};',
-                    '}',
-                    '// Comment'
-                ]
-            },
-            {
-                comment: "Issue 806 - newline arrow functions",
-                unchanged: [
-                    'a.b("c",',
-                    '    () => d.e',
-                    ')'
-                ]
-            },
-            {
-                comment: "Issue 810 - es6 object literal detection",
-                unchanged: [
-                    'function badFormatting() {',
-                    '    return {',
-                    '        a,',
-                    '        b: c,',
-                    '        d: e,',
-                    '        f: g,',
-                    '        h,',
-                    '        i,',
-                    '        j: k',
-                    '    }',
-                    '}',
-                    '',
-                    'function goodFormatting() {',
-                    '    return {',
-                    '        a: b,',
-                    '        c,',
-                    '        d: e,',
-                    '        f: g,',
-                    '        h,',
-                    '        i,',
-                    '        j: k',
-                    '    }',
-                    '}'
-                ]
-            },
-            {
-                comment: "Issue 602 - ES6 object literal shorthand functions",
-                unchanged: [
-                    'return {',
-                    '    fn1() {},',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'throw {',
-                    '    fn1() {},',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'foo({',
-                    '    fn1(a) {}',
-                    '    fn2(a) {}',
-                    '})'
-                ]
-            }, {
-                unchanged: [
-                    'foo("text", {',
-                    '    fn1(a) {}',
-                    '    fn2(a) {}',
-                    '})'
-                ]
-            }, {
-                unchanged: [
-                    'oneArg = {',
-                    '    fn1(a) {',
-                    '        do();',
-                    '    },',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'multiArg = {',
-                    '    fn1(a, b, c) {',
-                    '        do();',
-                    '    },',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'noArgs = {',
-                    '    fn1() {',
-                    '        do();',
-                    '    },',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'emptyFn = {',
-                    '    fn1() {},',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'nested = {',
-                    '    fns: {',
-                    '        fn1() {},',
-                    '        fn2() {}',
-                    '    }',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'array = [{',
-                    '    fn1() {},',
-                    '    prop: val,',
-                    '    fn2() {}',
-                    '}]'
-                ]
-            }, {
-                unchanged: [
-                    'expr = expr ? expr : {',
-                    '    fn1() {},',
-                    '    fn2() {}',
-                    '}'
-                ]
-            }, {
-                unchanged: [
-                    'strange = valid + {',
-                    '    fn1() {},',
-                    '    fn2() {',
-                    '        return 1;',
-                    '    }',
-                    '}.fn2()'
-                ]
-            },
-            {
-                comment: "Issue 854 - Arrow function with statement block",
-                unchanged: [
-                    'test(() => {',
-                    '    var a = {}',
-                    '',
-                    '    a.what = () => true ? 1 : 2',
-                    '',
-                    '    a.thing = () => {',
-                    '        b();',
-                    '    }',
-                    '})'
-                ]
-            },
-            {
-                comment: "Issue 406 - Multiline array",
-                unchanged: [
-                    'var tempName = [',
-                    '    "temp",',
-                    '    process.pid,',
-                    '    (Math.random() * 0x1000000000).toString(36),',
-                    '    new Date().getTime()',
-                    '].join("-");'
-                ]
-            },
-        ]
+            comment: "Issue 241",
+            unchanged: [
+                'obj',
+                '    .last({',
+                '        foo: 1,',
+                '        bar: 2',
+                '    });',
+                'var test = 1;'
+            ]
+        }, {
+            unchanged: [
+                'obj',
+                '    .last(a, function() {',
+                '        var test;',
+                '    });',
+                'var test = 1;'
+            ]
+        }, {
+            unchanged: [
+                'obj.first()',
+                '    .second()',
+                '    .last(function(err, response) {',
+                '        console.log(err);',
+                '    });'
+            ]
+        }, {
+            comment: "Issue 268 and 275",
+            unchanged: [
+                'obj.last(a, function() {',
+                '    var test;',
+                '});',
+                'var test = 1;'
+            ]
+        }, {
+            unchanged: [
+                'obj.last(a,',
+                '    function() {',
+                '        var test;',
+                '    });',
+                'var test = 1;'
+            ]
+        }, {
+            input: '(function() {if (!window.FOO) window.FOO || (window.FOO = function() {var b = {bar: "zort"};});})();',
+            output: [
+                '(function() {',
+                '    if (!window.FOO) window.FOO || (window.FOO = function() {',
+                '        var b = {',
+                '            bar: "zort"',
+                '        };',
+                '    });',
+                '})();'
+            ]
+        }, {
+            comment: "Issue 281",
+            unchanged: [
+                'define(["dojo/_base/declare", "my/Employee", "dijit/form/Button",',
+                '    "dojo/_base/lang", "dojo/Deferred"',
+                '], function(declare, Employee, Button, lang, Deferred) {',
+                '    return declare(Employee, {',
+                '        constructor: function() {',
+                '            new Button({',
+                '                onClick: lang.hitch(this, function() {',
+                '                    new Deferred().then(lang.hitch(this, function() {',
+                '                        this.salary * 0.25;',
+                '                    }));',
+                '                })',
+                '            });',
+                '        }',
+                '    });',
+                '});'
+            ]
+        }, {
+            unchanged: [
+                'define(["dojo/_base/declare", "my/Employee", "dijit/form/Button",',
+                '        "dojo/_base/lang", "dojo/Deferred"',
+                '    ],',
+                '    function(declare, Employee, Button, lang, Deferred) {',
+                '        return declare(Employee, {',
+                '            constructor: function() {',
+                '                new Button({',
+                '                    onClick: lang.hitch(this, function() {',
+                '                        new Deferred().then(lang.hitch(this, function() {',
+                '                            this.salary * 0.25;',
+                '                        }));',
+                '                    })',
+                '                });',
+                '            }',
+                '        });',
+                '    });'
+            ]
+        }, {
+            comment: "Issue 459",
+            unchanged: [
+                '(function() {',
+                '    return {',
+                '        foo: function() {',
+                '            return "bar";',
+                '        },',
+                '        bar: ["bar"]',
+                '    };',
+                '}());'
+            ]
+        }, {
+            comment: "Issue 505 - strings should end at newline unless continued by backslash",
+            unchanged: [
+                'var name = "a;',
+                'name = "b";'
+            ]
+        }, {
+            unchanged: [
+                'var name = "a;\\\\',
+                '    name = b";'
+            ]
+        }, {
+            comment: "Issue 514 - some operators require spaces to distinguish them",
+            unchanged: 'var c = "_ACTION_TO_NATIVEAPI_" + ++g++ + +new Date;'
+        }, {
+            unchanged: 'var c = "_ACTION_TO_NATIVEAPI_" - --g-- - -new Date;'
+        }, {
+            comment: "Issue 440 - reserved words can be used as object property names",
+            unchanged: [
+                'a = {',
+                '    function: {},',
+                '    "function": {},',
+                '    throw: {},',
+                '    "throw": {},',
+                '    var: {},',
+                '    "var": {},',
+                '    set: {},',
+                '    "set": {},',
+                '    get: {},',
+                '    "get": {},',
+                '    if: {},',
+                '    "if": {},',
+                '    then: {},',
+                '    "then": {},',
+                '    else: {},',
+                '    "else": {},',
+                '    yay: {}',
+                '};'
+            ]
+        }, {
+            comment: "Issue 331 - if-else with braces edge case",
+            input: 'if(x){a();}else{b();}if(y){c();}',
+            output: [
+                'if (x) {',
+                '    a();',
+                '} else {',
+                '    b();',
+                '}',
+                'if (y) {',
+                '    c();',
+                '}'
+            ]
+        }, {
+            comment: "Issue 485 - ensure function declarations behave the same in arrays as elsewhere",
+            unchanged: [
+                'var v = ["a",',
+                '    function() {',
+                '        return;',
+                '    }, {',
+                '        id: 1',
+                '    }',
+                '];'
+            ]
+        }, {
+            unchanged: [
+                'var v = ["a", function() {',
+                '    return;',
+                '}, {',
+                '    id: 1',
+                '}];'
+            ]
+        }, {
+            comment: "Issue 382 - initial totally cursory support for es6 module export",
+            unchanged: [
+                'module "Even" {',
+                '    import odd from "Odd";',
+                '    export function sum(x, y) {',
+                '        return x + y;',
+                '    }',
+                '    export var pi = 3.141593;',
+                '    export default moduleName;',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'module "Even" {',
+                '    export default function div(x, y) {}',
+                '}'
+            ]
+        }, {
+            comment: "Issue 508",
+            unchanged: 'set["name"]'
+        }, {
+            unchanged: 'get["name"]'
+        }, {
+            fragmeent: true,
+            unchanged: [
+                'a = {',
+                '    set b(x) {},',
+                '    c: 1,',
+                '    d: function() {}',
+                '};'
+            ]
+        }, {
+            fragmeent: true,
+            unchanged: [
+                'a = {',
+                '    get b() {',
+                '        retun 0;',
+                '    },',
+                '    c: 1,',
+                '    d: function() {}',
+                '};'
+            ]
+        }, {
+            comment: "Issue 298 - do not under indent if/while/for condtionals experesions",
+            unchanged: [
+                '\\\'use strict\\\';',
+                'if ([].some(function() {',
+                '        return false;',
+                '    })) {',
+                '    console.log("hello");',
+                '}'
+            ]
+        }, {
+            comment: "Issue 298 - do not under indent if/while/for condtionals experesions",
+            unchanged: [
+                '\\\'use strict\\\';',
+                'if ([].some(function() {',
+                '        return false;',
+                '    })) {',
+                '    console.log("hello");',
+                '}'
+            ]
+        }, {
+            comment: "Issue 552 - Typescript?  Okay... we didn't break it before, so try not to break it now.",
+            unchanged: [
+                'class Test {',
+                '    blah: string[];',
+                '    foo(): number {',
+                '        return 0;',
+                '    }',
+                '    bar(): number {',
+                '        return 0;',
+                '    }',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'interface Test {',
+                '    blah: string[];',
+                '    foo(): number {',
+                '        return 0;',
+                '    }',
+                '    bar(): number {',
+                '        return 0;',
+                '    }',
+                '}'
+            ]
+        }, {
+            comment: "Issue 583 - Functions with comments after them should still indent correctly.",
+            unchanged: [
+                'function exit(code) {',
+                '    setTimeout(function() {',
+                '        phantom.exit(code);',
+                '    }, 0);',
+                '    phantom.onError = function() {};',
+                '}',
+                '// Comment'
+            ]
+        }, {
+            comment: "Issue 806 - newline arrow functions",
+            unchanged: [
+                'a.b("c",',
+                '    () => d.e',
+                ')'
+            ]
+        }, {
+            comment: "Issue 810 - es6 object literal detection",
+            unchanged: [
+                'function badFormatting() {',
+                '    return {',
+                '        a,',
+                '        b: c,',
+                '        d: e,',
+                '        f: g,',
+                '        h,',
+                '        i,',
+                '        j: k',
+                '    }',
+                '}',
+                '',
+                'function goodFormatting() {',
+                '    return {',
+                '        a: b,',
+                '        c,',
+                '        d: e,',
+                '        f: g,',
+                '        h,',
+                '        i,',
+                '        j: k',
+                '    }',
+                '}'
+            ]
+        }, {
+            comment: "Issue 602 - ES6 object literal shorthand functions",
+            unchanged: [
+                'return {',
+                '    fn1() {},',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'throw {',
+                '    fn1() {},',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'foo({',
+                '    fn1(a) {}',
+                '    fn2(a) {}',
+                '})'
+            ]
+        }, {
+            unchanged: [
+                'foo("text", {',
+                '    fn1(a) {}',
+                '    fn2(a) {}',
+                '})'
+            ]
+        }, {
+            unchanged: [
+                'oneArg = {',
+                '    fn1(a) {',
+                '        do();',
+                '    },',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'multiArg = {',
+                '    fn1(a, b, c) {',
+                '        do();',
+                '    },',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'noArgs = {',
+                '    fn1() {',
+                '        do();',
+                '    },',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'emptyFn = {',
+                '    fn1() {},',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'nested = {',
+                '    fns: {',
+                '        fn1() {},',
+                '        fn2() {}',
+                '    }',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'array = [{',
+                '    fn1() {},',
+                '    prop: val,',
+                '    fn2() {}',
+                '}]'
+            ]
+        }, {
+            unchanged: [
+                'expr = expr ? expr : {',
+                '    fn1() {},',
+                '    fn2() {}',
+                '}'
+            ]
+        }, {
+            unchanged: [
+                'strange = valid + {',
+                '    fn1() {},',
+                '    fn2() {',
+                '        return 1;',
+                '    }',
+                '}.fn2()'
+            ]
+        }, {
+            comment: "Issue 854 - Arrow function with statement block",
+            unchanged: [
+                'test(() => {',
+                '    var a = {}',
+                '',
+                '    a.what = () => true ? 1 : 2',
+                '',
+                '    a.thing = () => {',
+                '        b();',
+                '    }',
+                '})'
+            ]
+        }, {
+            comment: "Issue 406 - Multiline array",
+            unchanged: [
+                'var tempName = [',
+                '    "temp",',
+                '    process.pid,',
+                '    (Math.random() * 0x1000000000).toString(36),',
+                '    new Date().getTime()',
+                '].join("-");'
+            ]
+        }, ]
     }, {
         name: "Test non-positionable-ops",
         description: "Ensure specific bugs do not recur",
-        tests: [
-            { unchanged: 'a += 2;' },
-            { unchanged: 'a -= 2;' },
-            { unchanged: 'a *= 2;' },
-            { unchanged: 'a /= 2;' },
-            { unchanged: 'a %= 2;' },
-            { unchanged: 'a &= 2;' },
-            { unchanged: 'a ^= 2;' },
-            { unchanged: 'a |= 2;' },
-            { unchanged: 'a **= 2;' },
-            { unchanged: 'a <<= 2;' },
-            { unchanged: 'a >>= 2;' },
-        ]
+        tests: [{
+            unchanged: 'a += 2;'
+        }, {
+            unchanged: 'a -= 2;'
+        }, {
+            unchanged: 'a *= 2;'
+        }, {
+            unchanged: 'a /= 2;'
+        }, {
+            unchanged: 'a %= 2;'
+        }, {
+            unchanged: 'a &= 2;'
+        }, {
+            unchanged: 'a ^= 2;'
+        }, {
+            unchanged: 'a |= 2;'
+        }, {
+            unchanged: 'a **= 2;'
+        }, {
+            unchanged: 'a <<= 2;'
+        }, {
+            unchanged: 'a >>= 2;'
+        }, ]
     }, {
         name: "Destructured and related",
         description: "Ensure specific bugs do not recur",
-        options: [{ name: "brace_style", value: "'collapse-preserve-inline'" }],
+        options: [{
+            name: "brace_style",
+            value: "'collapse-preserve-inline'"
+        }],
         tests: [{
                 comment: "Issue 382 - import destructured ",
                 unchanged: [
@@ -1838,8 +1872,7 @@ exports.test_data = {
                     '    import { odd, oddly } from "Odd";',
                     '}'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'import defaultMember from "module-name";',
                     'import * as name from "module-name";',
@@ -1851,8 +1884,7 @@ exports.test_data = {
                     'import defaultMember, * as name from "module-name";',
                     'import "module-name";'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 858 - from is a keyword only after import",
                 unchanged: [
                     'if (from < to) {',
@@ -1861,8 +1893,7 @@ exports.test_data = {
                     '    from--;',
                     '}'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 511 - destrutured",
                 unchanged: [
                     'var { b, c } = require("../stores");',
@@ -1872,14 +1903,12 @@ exports.test_data = {
                     '    console.log("inner prop", prop)',
                     '}'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 315 - Short objects",
                 unchanged: [
                     'var a = { b: { c: { d: e } } };'
                 ]
-            },
-            {
+            }, {
                 unchanged: [
                     'var a = {',
                     '    b: {',
@@ -1889,8 +1918,7 @@ exports.test_data = {
                     '    b2: { c: { d: e } }',
                     '};'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 370 - Short objects in array",
                 unchanged: [
                     'var methods = [',
@@ -1901,8 +1929,7 @@ exports.test_data = {
                     '    { name: "max" }',
                     '];'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 838 - Short objects in array",
                 unchanged: [
                     'function(url, callback) {',
@@ -1913,8 +1940,7 @@ exports.test_data = {
                     '    else script.onload = callback;',
                     '}'
                 ]
-            },
-            {
+            }, {
                 comment: "Issue 578 - Odd indenting after function",
                 unchanged: [
                     'function bindAuthEvent(eventName) {',
@@ -1924,8 +1950,7 @@ exports.test_data = {
                     '}',
                     '["logged_in", "logged_out", "signed_up", "updated_user"].forEach(bindAuthEvent);',
                 ]
-            },
-            {
+            }, {
                 comment: "Issue #487 - some short expressions examples",
                 unchanged: [
                     'if (a == 1) { a++; }',
@@ -1957,219 +1982,517 @@ exports.test_data = {
         name: "Old tests",
         description: "Largely unorganized pile of tests",
         options: [],
-        tests: [
-            { unchanged: '' },
-            { fragment: true, unchanged: '   return .5' },
-            { fragment: true, unchanged: '   return .5;\n   a();' },
-            { fragment: true, unchanged: '    return .5;\n    a();' },
-            { fragment: true, unchanged: '     return .5;\n     a();' },
-            { fragment: true, unchanged: '   < div' },
-            { input: 'a        =          1', output: 'a = 1' },
-            { input: 'a=1', output: 'a = 1' },
-            { unchanged: '(3) / 2' },
-            { input: '["a", "b"].join("")' },
-            { unchanged: 'a();\n\nb();' },
-            { input: 'var a = 1 var b = 2', output: 'var a = 1\nvar b = 2' },
-            { input: 'var a=1, b=c[d], e=6;', output: 'var a = 1,\n    b = c[d],\n    e = 6;' },
-            { unchanged: 'var a,\n    b,\n    c;' },
-            { input: 'let a = 1 let b = 2', output: 'let a = 1\nlet b = 2' },
-            { input: 'let a=1, b=c[d], e=6;', output: 'let a = 1,\n    b = c[d],\n    e = 6;' },
-            { unchanged: 'let a,\n    b,\n    c;' },
-            { input: 'const a = 1 const b = 2', output: 'const a = 1\nconst b = 2' },
-            { input: 'const a=1, b=c[d], e=6;', output: 'const a = 1,\n    b = c[d],\n    e = 6;' },
-            { unchanged: 'const a,\n    b,\n    c;' },
-            { unchanged: 'a = " 12345 "' },
-            { unchanged: "a = \\' 12345 \\'" },
-            { unchanged: 'if (a == 1) b = 2;' },
-            { input: 'if(1){2}else{3}', output: 'if (1) {\n    2\n} else {\n    3\n}' },
-            { input: 'if(1||2);', output: 'if (1 || 2);' },
-            { input: '(a==1)||(b==2)', output: '(a == 1) || (b == 2)' },
-            { input: 'var a = 1 if (2) 3;', output: 'var a = 1\nif (2) 3;' },
-            { unchanged: 'a = a + 1' },
-            { unchanged: 'a = a == 1' },
-            { input: '/12345[^678]*9+/.match(a)' },
-            { unchanged: 'a /= 5' },
-            { unchanged: 'a = 0.5 * 3' },
-            { unchanged: 'a *= 10.55' },
-            { unchanged: 'a < .5' },
-            { unchanged: 'a <= .5' },
-            { input: 'a<.5', output: 'a < .5' },
-            { input: 'a<=.5', output: 'a <= .5' },
+        tests: [{
+                unchanged: ''
+            }, {
+                fragment: true,
+                unchanged: '   return .5'
+            }, {
+                fragment: true,
+                unchanged: '   return .5;\n   a();'
+            }, {
+                fragment: true,
+                unchanged: '    return .5;\n    a();'
+            }, {
+                fragment: true,
+                unchanged: '     return .5;\n     a();'
+            }, {
+                fragment: true,
+                unchanged: '   < div'
+            }, {
+                input: 'a        =          1',
+                output: 'a = 1'
+            }, {
+                input: 'a=1',
+                output: 'a = 1'
+            }, {
+                unchanged: '(3) / 2'
+            }, {
+                input: '["a", "b"].join("")'
+            }, {
+                unchanged: 'a();\n\nb();'
+            }, {
+                input: 'var a = 1 var b = 2',
+                output: 'var a = 1\nvar b = 2'
+            }, {
+                input: 'var a=1, b=c[d], e=6;',
+                output: 'var a = 1,\n    b = c[d],\n    e = 6;'
+            }, {
+                unchanged: 'var a,\n    b,\n    c;'
+            }, {
+                input: 'let a = 1 let b = 2',
+                output: 'let a = 1\nlet b = 2'
+            }, {
+                input: 'let a=1, b=c[d], e=6;',
+                output: 'let a = 1,\n    b = c[d],\n    e = 6;'
+            }, {
+                unchanged: 'let a,\n    b,\n    c;'
+            }, {
+                input: 'const a = 1 const b = 2',
+                output: 'const a = 1\nconst b = 2'
+            }, {
+                input: 'const a=1, b=c[d], e=6;',
+                output: 'const a = 1,\n    b = c[d],\n    e = 6;'
+            }, {
+                unchanged: 'const a,\n    b,\n    c;'
+            }, {
+                unchanged: 'a = " 12345 "'
+            }, {
+                unchanged: "a = \\' 12345 \\'"
+            }, {
+                unchanged: 'if (a == 1) b = 2;'
+            }, {
+                input: 'if(1){2}else{3}',
+                output: 'if (1) {\n    2\n} else {\n    3\n}'
+            }, {
+                input: 'if(1||2);',
+                output: 'if (1 || 2);'
+            }, {
+                input: '(a==1)||(b==2)',
+                output: '(a == 1) || (b == 2)'
+            }, {
+                input: 'var a = 1 if (2) 3;',
+                output: 'var a = 1\nif (2) 3;'
+            }, {
+                unchanged: 'a = a + 1'
+            }, {
+                unchanged: 'a = a == 1'
+            }, {
+                input: '/12345[^678]*9+/.match(a)'
+            }, {
+                unchanged: 'a /= 5'
+            }, {
+                unchanged: 'a = 0.5 * 3'
+            }, {
+                unchanged: 'a *= 10.55'
+            }, {
+                unchanged: 'a < .5'
+            }, {
+                unchanged: 'a <= .5'
+            }, {
+                input: 'a<.5',
+                output: 'a < .5'
+            }, {
+                input: 'a<=.5',
+                output: 'a <= .5'
+            },
 
             {
                 comment: 'exponent literals',
                 unchanged: 'a = 1e10'
+            }, {
+                unchanged: 'a = 1.3e10'
+            }, {
+                unchanged: 'a = 1.3e-10'
+            }, {
+                unchanged: 'a = -12345.3e-10'
+            }, {
+                unchanged: 'a = .12345e-10'
+            }, {
+                unchanged: 'a = 06789e-10'
+            }, {
+                unchanged: 'a = e - 10'
+            }, {
+                unchanged: 'a = 1.3e+10'
+            }, {
+                unchanged: 'a = -12345.3e+10'
+            }, {
+                unchanged: 'a = .12345e+10'
+            }, {
+                unchanged: 'a = 06789e+10'
+            }, {
+                unchanged: 'a = e + 10'
+            }, {
+                input: 'a=0e-12345.3e-10',
+                output: 'a = 0e-12345 .3e-10'
+            }, {
+                input: 'a=0.e-12345.3e-10',
+                output: 'a = 0. e - 12345.3e-10'
+            }, {
+                input: 'a=0x.e-12345.3e-10',
+                output: 'a = 0x.e - 12345.3e-10'
+            }, {
+                input: 'a=0x0.e-12345.3e-10',
+                output: 'a = 0x0.e - 12345.3e-10'
+            }, {
+                input: 'a=0x0.0e-12345.3e-10',
+                output: 'a = 0x0 .0e-12345 .3e-10'
+            }, {
+                input: 'a=0g-12345.3e-10',
+                output: 'a = 0 g - 12345.3e-10'
+            }, {
+                input: 'a=0.g-12345.3e-10',
+                output: 'a = 0. g - 12345.3e-10'
+            }, {
+                input: 'a=0x.g-12345.3e-10',
+                output: 'a = 0x.g - 12345.3e-10'
+            }, {
+                input: 'a=0x0.g-12345.3e-10',
+                output: 'a = 0x0.g - 12345.3e-10'
+            }, {
+                input: 'a=0x0.0g-12345.3e-10',
+                output: 'a = 0x0 .0 g - 12345.3e-10'
             },
-            { unchanged: 'a = 1.3e10' },
-            { unchanged: 'a = 1.3e-10' },
-            { unchanged: 'a = -12345.3e-10' },
-            { unchanged: 'a = .12345e-10' },
-            { unchanged: 'a = 06789e-10' },
-            { unchanged: 'a = e - 10' },
-            { unchanged: 'a = 1.3e+10' },
-            { unchanged: 'a = -12345.3e+10' },
-            { unchanged: 'a = .12345e+10' },
-            { unchanged: 'a = 06789e+10' },
-            { unchanged: 'a = e + 10' },
-            { input: 'a=0e-12345.3e-10', output: 'a = 0e-12345 .3e-10' },
-            { input: 'a=0.e-12345.3e-10', output: 'a = 0. e - 12345.3e-10' },
-            { input: 'a=0x.e-12345.3e-10', output: 'a = 0x.e - 12345.3e-10' },
-            { input: 'a=0x0.e-12345.3e-10', output: 'a = 0x0.e - 12345.3e-10' },
-            { input: 'a=0x0.0e-12345.3e-10', output: 'a = 0x0 .0e-12345 .3e-10' },
-            { input: 'a=0g-12345.3e-10', output: 'a = 0 g - 12345.3e-10' },
-            { input: 'a=0.g-12345.3e-10', output: 'a = 0. g - 12345.3e-10' },
-            { input: 'a=0x.g-12345.3e-10', output: 'a = 0x.g - 12345.3e-10' },
-            { input: 'a=0x0.g-12345.3e-10', output: 'a = 0x0.g - 12345.3e-10' },
-            { input: 'a=0x0.0g-12345.3e-10', output: 'a = 0x0 .0 g - 12345.3e-10' },
 
             {
                 comment: 'Decimal literals',
                 unchanged: 'a = 0123456789;'
+            }, {
+                unchanged: 'a = 9876543210;'
+            }, {
+                unchanged: 'a = 5647308291;'
+            }, {
+                input: 'a=030e-5',
+                output: 'a = 030e-5'
+            }, {
+                input: 'a=00+4',
+                output: 'a = 00 + 4'
+            }, {
+                input: 'a=32+4',
+                output: 'a = 32 + 4'
+            }, {
+                input: 'a=0.6g+4',
+                output: 'a = 0.6 g + 4'
+            }, {
+                input: 'a=01.10',
+                output: 'a = 01.10'
+            }, {
+                input: 'a=a.10',
+                output: 'a = a .10'
+            }, {
+                input: 'a=00B0x0',
+                output: 'a = 00 B0x0'
+            }, {
+                input: 'a=00B0xb0',
+                output: 'a = 00 B0xb0'
+            }, {
+                input: 'a=00B0x0b0',
+                output: 'a = 00 B0x0b0'
+            }, {
+                input: 'a=0090x0',
+                output: 'a = 0090 x0'
+            }, {
+                input: 'a=0g0b0o0',
+                output: 'a = 0 g0b0o0'
             },
-            { unchanged: 'a = 9876543210;' },
-            { unchanged: 'a = 5647308291;' },
-            { input: 'a=030e-5', output: 'a = 030e-5' },
-            { input: 'a=00+4', output: 'a = 00 + 4' },
-            { input: 'a=32+4', output: 'a = 32 + 4' },
-            { input: 'a=0.6g+4', output: 'a = 0.6 g + 4' },
-            { input: 'a=01.10', output: 'a = 01.10' },
-            { input: 'a=a.10', output: 'a = a .10' },
-            { input: 'a=00B0x0', output: 'a = 00 B0x0' },
-            { input: 'a=00B0xb0', output: 'a = 00 B0xb0' },
-            { input: 'a=00B0x0b0', output: 'a = 00 B0x0b0' },
-            { input: 'a=0090x0', output: 'a = 0090 x0' },
-            { input: 'a=0g0b0o0', output: 'a = 0 g0b0o0' },
 
             {
                 comment: 'Hexadecimal literals',
                 unchanged: 'a = 0x0123456789abcdef;'
+            }, {
+                unchanged: 'a = 0X0123456789ABCDEF;'
+            }, {
+                unchanged: 'a = 0xFeDcBa9876543210;'
+            }, {
+                input: 'a=0x30e-5',
+                output: 'a = 0x30e - 5'
+            }, {
+                input: 'a=0xF0+4',
+                output: 'a = 0xF0 + 4'
+            }, {
+                input: 'a=0Xff+4',
+                output: 'a = 0Xff + 4'
+            }, {
+                input: 'a=0Xffg+4',
+                output: 'a = 0Xff g + 4'
+            }, {
+                input: 'a=0x01.10',
+                output: 'a = 0x01 .10'
+            }, {
+                unchanged: 'a = 0xb0ce;'
+            }, {
+                unchanged: 'a = 0x0b0;'
+            }, {
+                input: 'a=0x0B0x0',
+                output: 'a = 0x0B0 x0'
+            }, {
+                input: 'a=0x0B0xb0',
+                output: 'a = 0x0B0 xb0'
+            }, {
+                input: 'a=0x0B0x0b0',
+                output: 'a = 0x0B0 x0b0'
+            }, {
+                input: 'a=0X090x0',
+                output: 'a = 0X090 x0'
+            }, {
+                input: 'a=0Xg0b0o0',
+                output: 'a = 0X g0b0o0'
             },
-            { unchanged: 'a = 0X0123456789ABCDEF;' },
-            { unchanged: 'a = 0xFeDcBa9876543210;' },
-            { input: 'a=0x30e-5', output: 'a = 0x30e - 5' },
-            { input: 'a=0xF0+4', output: 'a = 0xF0 + 4' },
-            { input: 'a=0Xff+4', output: 'a = 0Xff + 4' },
-            { input: 'a=0Xffg+4', output: 'a = 0Xff g + 4' },
-            { input: 'a=0x01.10', output: 'a = 0x01 .10' },
-            { unchanged: 'a = 0xb0ce;' },
-            { unchanged: 'a = 0x0b0;' },
-            { input: 'a=0x0B0x0', output: 'a = 0x0B0 x0' },
-            { input: 'a=0x0B0xb0', output: 'a = 0x0B0 xb0' },
-            { input: 'a=0x0B0x0b0', output: 'a = 0x0B0 x0b0' },
-            { input: 'a=0X090x0', output: 'a = 0X090 x0' },
-            { input: 'a=0Xg0b0o0', output: 'a = 0X g0b0o0' },
 
             {
                 comment: 'Octal literals',
                 unchanged: 'a = 0o01234567;'
+            }, {
+                unchanged: 'a = 0O01234567;'
+            }, {
+                unchanged: 'a = 0o34120675;'
+            }, {
+                input: 'a=0o30e-5',
+                output: 'a = 0o30 e - 5'
+            }, {
+                input: 'a=0o70+4',
+                output: 'a = 0o70 + 4'
+            }, {
+                input: 'a=0O77+4',
+                output: 'a = 0O77 + 4'
+            }, {
+                input: 'a=0O778+4',
+                output: 'a = 0O77 8 + 4'
+            }, {
+                input: 'a=0O77a+4',
+                output: 'a = 0O77 a + 4'
+            }, {
+                input: 'a=0o01.10',
+                output: 'a = 0o01 .10'
+            }, {
+                input: 'a=0o0B0x0',
+                output: 'a = 0o0 B0x0'
+            }, {
+                input: 'a=0o0B0xb0',
+                output: 'a = 0o0 B0xb0'
+            }, {
+                input: 'a=0o0B0x0b0',
+                output: 'a = 0o0 B0x0b0'
+            }, {
+                input: 'a=0O090x0',
+                output: 'a = 0O0 90 x0'
+            }, {
+                input: 'a=0Og0b0o0',
+                output: 'a = 0O g0b0o0'
             },
-            { unchanged: 'a = 0O01234567;' },
-            { unchanged: 'a = 0o34120675;' },
-            { input: 'a=0o30e-5', output: 'a = 0o30 e - 5' },
-            { input: 'a=0o70+4', output: 'a = 0o70 + 4' },
-            { input: 'a=0O77+4', output: 'a = 0O77 + 4' },
-            { input: 'a=0O778+4', output: 'a = 0O77 8 + 4' },
-            { input: 'a=0O77a+4', output: 'a = 0O77 a + 4' },
-            { input: 'a=0o01.10', output: 'a = 0o01 .10' },
-            { input: 'a=0o0B0x0', output: 'a = 0o0 B0x0' },
-            { input: 'a=0o0B0xb0', output: 'a = 0o0 B0xb0' },
-            { input: 'a=0o0B0x0b0', output: 'a = 0o0 B0x0b0' },
-            { input: 'a=0O090x0', output: 'a = 0O0 90 x0' },
-            { input: 'a=0Og0b0o0', output: 'a = 0O g0b0o0' },
 
             {
                 comment: 'Binary literals',
                 unchanged: 'a = 0b010011;'
-            },
-            { unchanged: 'a = 0B010011;' },
-            { unchanged: 'a = 0b01001100001111;' },
-            { input: 'a=0b10e-5', output: 'a = 0b10 e - 5' },
-            { input: 'a=0b10+4', output: 'a = 0b10 + 4' },
-            { input: 'a=0B11+4', output: 'a = 0B11 + 4' },
-            { input: 'a=0B112+4', output: 'a = 0B11 2 + 4' },
-            { input: 'a=0B11a+4', output: 'a = 0B11 a + 4' },
-            { input: 'a=0b01.10', output: 'a = 0b01 .10' },
-            { input: 'a=0b0B0x0', output: 'a = 0b0 B0x0' },
-            { input: 'a=0b0B0xb0', output: 'a = 0b0 B0xb0' },
-            { input: 'a=0b0B0x0b0', output: 'a = 0b0 B0x0b0' },
-            { input: 'a=0B090x0', output: 'a = 0B0 90 x0' },
-            { input: 'a=0Bg0b0o0', output: 'a = 0B g0b0o0' },
-            { unchanged: 'a = [1, 2, 3, 4]' },
-            { input: 'F*(g/=f)*g+b', output: 'F * (g /= f) * g + b' },
-            { input: 'a.b({c:d})', output: 'a.b({\n    c: d\n})' },
-            { input: 'a.b\n(\n{\nc:\nd\n}\n)', output: 'a.b({\n    c: d\n})' },
-            { input: 'a.b({c:"d"})', output: 'a.b({\n    c: "d"\n})' },
-            { input: 'a.b\n(\n{\nc:\n"d"\n}\n)', output: 'a.b({\n    c: "d"\n})' },
-            { input: 'a=!b', output: 'a = !b' },
-            { input: 'a=!!b', output: 'a = !!b' },
-            { input: 'a?b:c', output: 'a ? b : c' },
-            { input: 'a?1:2', output: 'a ? 1 : 2' },
-            { input: 'a?(b):c', output: 'a ? (b) : c' },
-            { input: 'x={a:1,b:w=="foo"?x:y,c:z}', output: 'x = {\n    a: 1,\n    b: w == "foo" ? x : y,\n    c: z\n}' },
-            { input: 'x=a?b?c?d:e:f:g;', output: 'x = a ? b ? c ? d : e : f : g;' },
-            { input: 'x=a?b?c?d:{e1:1,e2:2}:f:g;', output: 'x = a ? b ? c ? d : {\n    e1: 1,\n    e2: 2\n} : f : g;' },
-            { input: 'function void(void) {}' },
-            { input: 'if(!a)foo();', output: 'if (!a) foo();' },
-            { input: 'a=~a', output: 'a = ~a' },
-            { input: 'a;/*comment*/b;', output: "a; /*comment*/\nb;" },
-            { input: 'a;/* comment */b;', output: "a; /* comment */\nb;" },
-            { fragment: true, input: 'a;/*\ncomment\n*/b;', output: "a;\n/*\ncomment\n*/\nb;", comment: "simple comments don't get touched at all" },
-            { input: 'a;/**\n* javadoc\n*/b;', output: "a;\n/**\n * javadoc\n */\nb;" },
-            { fragment: true, input: 'a;/**\n\nno javadoc\n*/b;', output: "a;\n/**\n\nno javadoc\n*/\nb;" },
-            { input: 'a;/*\n* javadoc\n*/b;', output: "a;\n/*\n * javadoc\n */\nb;", comment: 'comment blocks detected and reindented even w/o javadoc starter' },
-            { input: 'if(a)break;', output: "if (a) break;" },
-            { input: 'if(a){break}', output: "if (a) {\n    break\n}" },
-            { input: 'if((a))foo();', output: 'if ((a)) foo();' },
-            { input: 'for(var i=0;;) a', output: 'for (var i = 0;;) a' },
-            { input: 'for(var i=0;;)\na', output: 'for (var i = 0;;)\n    a' },
-            { unchanged: 'a++;' },
-            { input: 'for(;;i++)a()', output: 'for (;; i++) a()' },
-            { input: 'for(;;i++)\na()', output: 'for (;; i++)\n    a()' },
-            { input: 'for(;;++i)a', output: 'for (;; ++i) a' },
-            { input: 'return(1)', output: 'return (1)' },
-            { input: 'try{a();}catch(b){c();}finally{d();}', output: "try {\n    a();\n} catch (b) {\n    c();\n} finally {\n    d();\n}" },
-            { input: '(xx)()', comment: ' magic function call' },
-            { input: 'a[1]()', comment: 'another magic function call' },
-            { input: 'if(a){b();}else if(c) foo();', output: "if (a) {\n    b();\n} else if (c) foo();" },
-            { input: 'switch(x) {case 0: case 1: a(); break; default: break}', output: "switch (x) {\n    case 0:\n    case 1:\n        a();\n        break;\n    default:\n        break\n}" },
-            { input: 'switch(x){case -1:break;case !y:break;}', output: 'switch (x) {\n    case -1:\n        break;\n    case !y:\n        break;\n}' },
-            { input: 'a !== b' },
-            { input: 'if (a) b(); else c();', output: "if (a) b();\nelse c();" },
-            { input: "// comment\n(function something() {})", comment: 'typical greasemonkey start' },
-            { input: "{\n\n    x();\n\n}", comment: 'duplicating newlines' },
-            { input: 'if (a in b) foo();' },
-            {
+            }, {
+                unchanged: 'a = 0B010011;'
+            }, {
+                unchanged: 'a = 0b01001100001111;'
+            }, {
+                input: 'a=0b10e-5',
+                output: 'a = 0b10 e - 5'
+            }, {
+                input: 'a=0b10+4',
+                output: 'a = 0b10 + 4'
+            }, {
+                input: 'a=0B11+4',
+                output: 'a = 0B11 + 4'
+            }, {
+                input: 'a=0B112+4',
+                output: 'a = 0B11 2 + 4'
+            }, {
+                input: 'a=0B11a+4',
+                output: 'a = 0B11 a + 4'
+            }, {
+                input: 'a=0b01.10',
+                output: 'a = 0b01 .10'
+            }, {
+                input: 'a=0b0B0x0',
+                output: 'a = 0b0 B0x0'
+            }, {
+                input: 'a=0b0B0xb0',
+                output: 'a = 0b0 B0xb0'
+            }, {
+                input: 'a=0b0B0x0b0',
+                output: 'a = 0b0 B0x0b0'
+            }, {
+                input: 'a=0B090x0',
+                output: 'a = 0B0 90 x0'
+            }, {
+                input: 'a=0Bg0b0o0',
+                output: 'a = 0B g0b0o0'
+            }, {
+                unchanged: 'a = [1, 2, 3, 4]'
+            }, {
+                input: 'F*(g/=f)*g+b',
+                output: 'F * (g /= f) * g + b'
+            }, {
+                input: 'a.b({c:d})',
+                output: 'a.b({\n    c: d\n})'
+            }, {
+                input: 'a.b\n(\n{\nc:\nd\n}\n)',
+                output: 'a.b({\n    c: d\n})'
+            }, {
+                input: 'a.b({c:"d"})',
+                output: 'a.b({\n    c: "d"\n})'
+            }, {
+                input: 'a.b\n(\n{\nc:\n"d"\n}\n)',
+                output: 'a.b({\n    c: "d"\n})'
+            }, {
+                input: 'a=!b',
+                output: 'a = !b'
+            }, {
+                input: 'a=!!b',
+                output: 'a = !!b'
+            }, {
+                input: 'a?b:c',
+                output: 'a ? b : c'
+            }, {
+                input: 'a?1:2',
+                output: 'a ? 1 : 2'
+            }, {
+                input: 'a?(b):c',
+                output: 'a ? (b) : c'
+            }, {
+                input: 'x={a:1,b:w=="foo"?x:y,c:z}',
+                output: 'x = {\n    a: 1,\n    b: w == "foo" ? x : y,\n    c: z\n}'
+            }, {
+                input: 'x=a?b?c?d:e:f:g;',
+                output: 'x = a ? b ? c ? d : e : f : g;'
+            }, {
+                input: 'x=a?b?c?d:{e1:1,e2:2}:f:g;',
+                output: 'x = a ? b ? c ? d : {\n    e1: 1,\n    e2: 2\n} : f : g;'
+            }, {
+                input: 'function void(void) {}'
+            }, {
+                input: 'if(!a)foo();',
+                output: 'if (!a) foo();'
+            }, {
+                input: 'a=~a',
+                output: 'a = ~a'
+            }, {
+                input: 'a;/*comment*/b;',
+                output: "a; /*comment*/\nb;"
+            }, {
+                input: 'a;/* comment */b;',
+                output: "a; /* comment */\nb;"
+            }, {
+                fragment: true,
+                input: 'a;/*\ncomment\n*/b;',
+                output: "a;\n/*\ncomment\n*/\nb;",
+                comment: "simple comments don't get touched at all"
+            }, {
+                input: 'a;/**\n* javadoc\n*/b;',
+                output: "a;\n/**\n * javadoc\n */\nb;"
+            }, {
+                fragment: true,
+                input: 'a;/**\n\nno javadoc\n*/b;',
+                output: "a;\n/**\n\nno javadoc\n*/\nb;"
+            }, {
+                input: 'a;/*\n* javadoc\n*/b;',
+                output: "a;\n/*\n * javadoc\n */\nb;",
+                comment: 'comment blocks detected and reindented even w/o javadoc starter'
+            }, {
+                input: 'if(a)break;',
+                output: "if (a) break;"
+            }, {
+                input: 'if(a){break}',
+                output: "if (a) {\n    break\n}"
+            }, {
+                input: 'if((a))foo();',
+                output: 'if ((a)) foo();'
+            }, {
+                input: 'for(var i=0;;) a',
+                output: 'for (var i = 0;;) a'
+            }, {
+                input: 'for(var i=0;;)\na',
+                output: 'for (var i = 0;;)\n    a'
+            }, {
+                unchanged: 'a++;'
+            }, {
+                input: 'for(;;i++)a()',
+                output: 'for (;; i++) a()'
+            }, {
+                input: 'for(;;i++)\na()',
+                output: 'for (;; i++)\n    a()'
+            }, {
+                input: 'for(;;++i)a',
+                output: 'for (;; ++i) a'
+            }, {
+                input: 'return(1)',
+                output: 'return (1)'
+            }, {
+                input: 'try{a();}catch(b){c();}finally{d();}',
+                output: "try {\n    a();\n} catch (b) {\n    c();\n} finally {\n    d();\n}"
+            }, {
+                input: '(xx)()',
+                comment: ' magic function call'
+            }, {
+                input: 'a[1]()',
+                comment: 'another magic function call'
+            }, {
+                input: 'if(a){b();}else if(c) foo();',
+                output: "if (a) {\n    b();\n} else if (c) foo();"
+            }, {
+                input: 'switch(x) {case 0: case 1: a(); break; default: break}',
+                output: "switch (x) {\n    case 0:\n    case 1:\n        a();\n        break;\n    default:\n        break\n}"
+            }, {
+                input: 'switch(x){case -1:break;case !y:break;}',
+                output: 'switch (x) {\n    case -1:\n        break;\n    case !y:\n        break;\n}'
+            }, {
+                input: 'a !== b'
+            }, {
+                input: 'if (a) b(); else c();',
+                output: "if (a) b();\nelse c();"
+            }, {
+                input: "// comment\n(function something() {})",
+                comment: 'typical greasemonkey start'
+            }, {
+                input: "{\n\n    x();\n\n}",
+                comment: 'duplicating newlines'
+            }, {
+                input: 'if (a in b) foo();'
+            }, {
                 input: 'if(X)if(Y)a();else b();else c();',
                 output: "if (X)\n    if (Y) a();\n    else b();\nelse c();"
+            }, {
+                input: 'if (foo) bar();\nelse break'
+            }, {
+                unchanged: 'var a, b;'
+            }, {
+                unchanged: 'var a = new function();'
+            }, {
+                fragment: true,
+                unchanged: 'new function'
+            }, {
+                unchanged: 'var a, b'
+            }, {
+                input: '{a:1, b:2}',
+                output: "{\n    a: 1,\n    b: 2\n}"
+            }, {
+                input: 'a={1:[-1],2:[+1]}',
+                output: 'a = {\n    1: [-1],\n    2: [+1]\n}'
+            }, {
+                input: "var l = {\\'a\\':\\'1\\', \\'b\\':\\'2\\'}",
+                output: "var l = {\n    \\'a\\': \\'1\\',\n    \\'b\\': \\'2\\'\n}"
+            }, {
+                input: 'if (template.user[n] in bk) foo();'
+            }, {
+                unchanged: 'return 45'
+            }, {
+                unchanged: 'return this.prevObject ||\n\n    this.constructor(null);'
+            }, {
+                unchanged: 'If[1]'
+            }, {
+                unchanged: 'Then[1]'
+            }, {
+                input: "a = 1;// comment",
+                output: "a = 1; // comment"
+            }, {
+                unchanged: "a = 1; // comment"
+            }, {
+                input: "a = 1;\n // comment",
+                output: "a = 1;\n// comment"
+            }, {
+                unchanged: 'a = [-1, -1, -1]'
             },
-            { input: 'if (foo) bar();\nelse break' },
-            { unchanged: 'var a, b;' },
-            { unchanged: 'var a = new function();' },
-            { fragment: true, unchanged: 'new function' },
-            { unchanged: 'var a, b' },
-            { input: '{a:1, b:2}', output: "{\n    a: 1,\n    b: 2\n}" },
-            { input: 'a={1:[-1],2:[+1]}', output: 'a = {\n    1: [-1],\n    2: [+1]\n}' },
-            { input: "var l = {\\'a\\':\\'1\\', \\'b\\':\\'2\\'}", output: "var l = {\n    \\'a\\': \\'1\\',\n    \\'b\\': \\'2\\'\n}" },
-            { input: 'if (template.user[n] in bk) foo();' },
-            { unchanged: 'return 45' },
-            { unchanged: 'return this.prevObject ||\n\n    this.constructor(null);' },
-            { unchanged: 'If[1]' },
-            { unchanged: 'Then[1]' },
-            { input: "a = 1;// comment", output: "a = 1; // comment" },
-            { unchanged: "a = 1; // comment" },
-            { input: "a = 1;\n // comment", output: "a = 1;\n// comment" },
-            { unchanged: 'a = [-1, -1, -1]' },
 
 
             {
                 comment: 'The exact formatting these should have is open for discussion, but they are at least reasonable',
                 unchanged: 'a = [ // comment\n    -1, -1, -1\n]'
+            }, {
+                unchanged: 'var a = [ // comment\n    -1, -1, -1\n]'
+            }, {
+                unchanged: 'a = [ // comment\n    -1, // comment\n    -1, -1\n]'
+            }, {
+                unchanged: 'var a = [ // comment\n    -1, // comment\n    -1, -1\n]'
             },
-            { unchanged: 'var a = [ // comment\n    -1, -1, -1\n]' },
-            { unchanged: 'a = [ // comment\n    -1, // comment\n    -1, -1\n]' },
-            { unchanged: 'var a = [ // comment\n    -1, // comment\n    -1, -1\n]' },
 
-            { input: 'o = [{a:b},{c:d}]', output: 'o = [{\n    a: b\n}, {\n    c: d\n}]' },
+            {
+                input: 'o = [{a:b},{c:d}]',
+                output: 'o = [{\n    a: b\n}, {\n    c: d\n}]'
+            },
 
             {
                 comment: 'was: extra space appended',
@@ -2180,30 +2503,69 @@ exports.test_data = {
                 comment: 'if/else statement with empty body',
                 input: "if (a) {\n// comment\n}else{\n// comment\n}",
                 output: "if (a) {\n    // comment\n} else {\n    // comment\n}"
+            }, {
+                comment: 'multiple comments indentation',
+                input: "if (a) {\n// comment\n// comment\n}",
+                output: "if (a) {\n    // comment\n    // comment\n}"
+            }, {
+                input: "if (a) b() else c();",
+                output: "if (a) b()\nelse c();"
+            }, {
+                input: "if (a) b() else if c() d();",
+                output: "if (a) b()\nelse if c() d();"
             },
-            { comment: 'multiple comments indentation', input: "if (a) {\n// comment\n// comment\n}", output: "if (a) {\n    // comment\n    // comment\n}" },
-            { input: "if (a) b() else c();", output: "if (a) b()\nelse c();" },
-            { input: "if (a) b() else if c() d();", output: "if (a) b()\nelse if c() d();" },
 
-            { unchanged: "{}" },
-            { unchanged: "{\n\n}" },
-            { input: "do { a(); } while ( 1 );", output: "do {\n    a();\n} while (1);" },
-            { unchanged: "do {} while (1);" },
-            { input: "do {\n} while (1);", output: "do {} while (1);" },
-            { unchanged: "do {\n\n} while (1);" },
-            { unchanged: "var a = x(a, b, c)" },
-            { input: "delete x if (a) b();", output: "delete x\nif (a) b();" },
-            { input: "delete x[x] if (a) b();", output: "delete x[x]\nif (a) b();" },
-            { input: "for(var a=1,b=2)d", output: "for (var a = 1, b = 2) d" },
-            { input: "for(var a=1,b=2,c=3) d", output: "for (var a = 1, b = 2, c = 3) d" },
-            { input: "for(var a=1,b=2,c=3;d<3;d++)\ne", output: "for (var a = 1, b = 2, c = 3; d < 3; d++)\n    e" },
-            { input: "function x(){(a||b).c()}", output: "function x() {\n    (a || b).c()\n}" },
-            { input: "function x(){return - 1}", output: "function x() {\n    return -1\n}" },
-            { input: "function x(){return ! a}", output: "function x() {\n    return !a\n}" },
-            { unchanged: "x => x" },
-            { unchanged: "(x) => x" },
-            { input: "x => { x }", output: "x => {\n    x\n}" },
-            { input: "(x) => { x }", output: "(x) => {\n    x\n}" },
+            {
+                unchanged: "{}"
+            }, {
+                unchanged: "{\n\n}"
+            }, {
+                input: "do { a(); } while ( 1 );",
+                output: "do {\n    a();\n} while (1);"
+            }, {
+                unchanged: "do {} while (1);"
+            }, {
+                input: "do {\n} while (1);",
+                output: "do {} while (1);"
+            }, {
+                unchanged: "do {\n\n} while (1);"
+            }, {
+                unchanged: "var a = x(a, b, c)"
+            }, {
+                input: "delete x if (a) b();",
+                output: "delete x\nif (a) b();"
+            }, {
+                input: "delete x[x] if (a) b();",
+                output: "delete x[x]\nif (a) b();"
+            }, {
+                input: "for(var a=1,b=2)d",
+                output: "for (var a = 1, b = 2) d"
+            }, {
+                input: "for(var a=1,b=2,c=3) d",
+                output: "for (var a = 1, b = 2, c = 3) d"
+            }, {
+                input: "for(var a=1,b=2,c=3;d<3;d++)\ne",
+                output: "for (var a = 1, b = 2, c = 3; d < 3; d++)\n    e"
+            }, {
+                input: "function x(){(a||b).c()}",
+                output: "function x() {\n    (a || b).c()\n}"
+            }, {
+                input: "function x(){return - 1}",
+                output: "function x() {\n    return -1\n}"
+            }, {
+                input: "function x(){return ! a}",
+                output: "function x() {\n    return !a\n}"
+            }, {
+                unchanged: "x => x"
+            }, {
+                unchanged: "(x) => x"
+            }, {
+                input: "x => { x }",
+                output: "x => {\n    x\n}"
+            }, {
+                input: "(x) => { x }",
+                output: "(x) => {\n    x\n}"
+            },
 
             {
                 comment: 'a common snippet in jQuery plugins',
@@ -2212,91 +2574,228 @@ exports.test_data = {
             },
 
             // reserved words used as property names
-            { unchanged: "$http().then().finally().default()" },
-            { input: "$http()\n.then()\n.finally()\n.default()", output: "$http()\n    .then()\n    .finally()\n    .default()" },
-            { unchanged: "$http().when.in.new.catch().throw()" },
-            { input: "$http()\n.when\n.in\n.new\n.catch()\n.throw()", output: "$http()\n    .when\n    .in\n    .new\n    .catch()\n    .throw()" },
+            {
+                unchanged: "$http().then().finally().default()"
+            }, {
+                input: "$http()\n.then()\n.finally()\n.default()",
+                output: "$http()\n    .then()\n    .finally()\n    .default()"
+            }, {
+                unchanged: "$http().when.in.new.catch().throw()"
+            }, {
+                input: "$http()\n.when\n.in\n.new\n.catch()\n.throw()",
+                output: "$http()\n    .when\n    .in\n    .new\n    .catch()\n    .throw()"
+            },
 
-            { input: '{xxx;}()', output: '{\n    xxx;\n}()' },
+            {
+                input: '{xxx;}()',
+                output: '{\n    xxx;\n}()'
+            },
 
-            { unchanged: "a = \\'a\\'\nb = \\'b\\'" },
-            { unchanged: "a = /reg/exp" },
-            { unchanged: "a = /reg/" },
-            { unchanged: '/abc/.test()' },
-            { unchanged: '/abc/i.test()' },
-            { input: "{/abc/i.test()}", output: "{\n    /abc/i.test()\n}" },
-            { input: 'var x=(a)/a;', output: 'var x = (a) / a;' },
+            {
+                unchanged: "a = \\'a\\'\nb = \\'b\\'"
+            }, {
+                unchanged: "a = /reg/exp"
+            }, {
+                unchanged: "a = /reg/"
+            }, {
+                unchanged: '/abc/.test()'
+            }, {
+                unchanged: '/abc/i.test()'
+            }, {
+                input: "{/abc/i.test()}",
+                output: "{\n    /abc/i.test()\n}"
+            }, {
+                input: 'var x=(a)/a;',
+                output: 'var x = (a) / a;'
+            },
 
-            { unchanged: 'x != -1' },
+            {
+                unchanged: 'x != -1'
+            },
 
-            { input: 'for (; s-->0;)t', output: 'for (; s-- > 0;) t' },
-            { input: 'for (; s++>0;)u', output: 'for (; s++ > 0;) u' },
-            { input: 'a = s++>s--;', output: 'a = s++ > s--;' },
-            { input: 'a = s++>--s;', output: 'a = s++ > --s;' },
+            {
+                input: 'for (; s-->0;)t',
+                output: 'for (; s-- > 0;) t'
+            }, {
+                input: 'for (; s++>0;)u',
+                output: 'for (; s++ > 0;) u'
+            }, {
+                input: 'a = s++>s--;',
+                output: 'a = s++ > s--;'
+            }, {
+                input: 'a = s++>--s;',
+                output: 'a = s++ > --s;'
+            },
 
-            { input: '{x=#1=[]}', output: '{\n    x = #1=[]\n}' },
-            { input: '{a:#1={}}', output: '{\n    a: #1={}\n}' },
-            { input: '{a:#1#}', output: '{\n    a: #1#\n}' },
+            {
+                input: '{x=#1=[]}',
+                output: '{\n    x = #1=[]\n}'
+            }, {
+                input: '{a:#1={}}',
+                output: '{\n    a: #1={}\n}'
+            }, {
+                input: '{a:#1#}',
+                output: '{\n    a: #1#\n}'
+            },
 
-            { fragment: true, unchanged: '"incomplete-string' },
-            { fragment: true, unchanged: "\\'incomplete-string" },
-            { fragment: true, unchanged: '/incomplete-regex' },
-            { fragment: true, unchanged: '`incomplete-template-string' },
+            {
+                fragment: true,
+                unchanged: '"incomplete-string'
+            }, {
+                fragment: true,
+                unchanged: "\\'incomplete-string"
+            }, {
+                fragment: true,
+                unchanged: '/incomplete-regex'
+            }, {
+                fragment: true,
+                unchanged: '`incomplete-template-string'
+            },
 
-            { fragment: true, input: '{a:1},{a:2}', output: '{\n    a: 1\n}, {\n    a: 2\n}' },
-            { fragment: true, input: 'var ary=[{a:1}, {a:2}];', output: 'var ary = [{\n    a: 1\n}, {\n    a: 2\n}];' },
+            {
+                fragment: true,
+                input: '{a:1},{a:2}',
+                output: '{\n    a: 1\n}, {\n    a: 2\n}'
+            }, {
+                fragment: true,
+                input: 'var ary=[{a:1}, {a:2}];',
+                output: 'var ary = [{\n    a: 1\n}, {\n    a: 2\n}];'
+            },
 
-            { comment: 'incomplete', fragment: true, input: '{a:#1', output: '{\n    a: #1' },
-            { comment: 'incomplete', fragment: true, input: '{a:#', output: '{\n    a: #' },
+            {
+                comment: 'incomplete',
+                fragment: true,
+                input: '{a:#1',
+                output: '{\n    a: #1'
+            }, {
+                comment: 'incomplete',
+                fragment: true,
+                input: '{a:#',
+                output: '{\n    a: #'
+            },
 
-            { comment: 'incomplete', fragment: true, input: '}}}', output: '}\n}\n}' },
+            {
+                comment: 'incomplete',
+                fragment: true,
+                input: '}}}',
+                output: '}\n}\n}'
+            },
 
-            { fragment: true, unchanged: '<!--\nvoid();\n// -->' },
+            {
+                fragment: true,
+                unchanged: '<!--\nvoid();\n// -->'
+            },
 
-            { comment: 'incomplete regexp', fragment: true, input: 'a=/regexp', output: 'a = /regexp' },
+            {
+                comment: 'incomplete regexp',
+                fragment: true,
+                input: 'a=/regexp',
+                output: 'a = /regexp'
+            },
 
-            { input: '{a:#1=[],b:#1#,c:#999999#}', output: '{\n    a: #1=[],\n    b: #1#,\n    c: #999999#\n}' },
+            {
+                input: '{a:#1=[],b:#1#,c:#999999#}',
+                output: '{\n    a: #1=[],\n    b: #1#,\n    c: #999999#\n}'
+            },
 
-            { input: "do{x()}while(a>1)", output: "do {\n    x()\n} while (a > 1)" },
+            {
+                input: "do{x()}while(a>1)",
+                output: "do {\n    x()\n} while (a > 1)"
+            },
 
-            { input: "x(); /reg/exp.match(something)", output: "x();\n/reg/exp.match(something)" },
+            {
+                input: "x(); /reg/exp.match(something)",
+                output: "x();\n/reg/exp.match(something)"
+            },
 
-            { fragment: true, input: "something();(", output: "something();\n(" },
-            { fragment: true, input: "#!she/bangs, she bangs\nf=1", output: "#!she/bangs, she bangs\n\nf = 1" },
-            { fragment: true, input: "#!she/bangs, she bangs\n\nf=1", output: "#!she/bangs, she bangs\n\nf = 1" },
-            { fragment: true, unchanged: "#!she/bangs, she bangs\n\n/* comment */" },
-            { fragment: true, unchanged: "#!she/bangs, she bangs\n\n\n/* comment */" },
-            { fragment: true, unchanged: "#" },
-            { fragment: true, unchanged: "#!" },
+            {
+                fragment: true,
+                input: "something();(",
+                output: "something();\n("
+            }, {
+                fragment: true,
+                input: "#!she/bangs, she bangs\nf=1",
+                output: "#!she/bangs, she bangs\n\nf = 1"
+            }, {
+                fragment: true,
+                input: "#!she/bangs, she bangs\n\nf=1",
+                output: "#!she/bangs, she bangs\n\nf = 1"
+            }, {
+                fragment: true,
+                unchanged: "#!she/bangs, she bangs\n\n/* comment */"
+            }, {
+                fragment: true,
+                unchanged: "#!she/bangs, she bangs\n\n\n/* comment */"
+            }, {
+                fragment: true,
+                unchanged: "#"
+            }, {
+                fragment: true,
+                unchanged: "#!"
+            },
 
-            { input: "function namespace::something()" },
+            {
+                input: "function namespace::something()"
+            },
 
-            { fragment: true, unchanged: "<!--\nsomething();\n-->" },
-            { fragment: true, input: "<!--\nif(i<0){bla();}\n-->", output: "<!--\nif (i < 0) {\n    bla();\n}\n-->" },
+            {
+                fragment: true,
+                unchanged: "<!--\nsomething();\n-->"
+            }, {
+                fragment: true,
+                input: "<!--\nif(i<0){bla();}\n-->",
+                output: "<!--\nif (i < 0) {\n    bla();\n}\n-->"
+            },
 
-            { input: '{foo();--bar;}', output: '{\n    foo();\n    --bar;\n}' },
-            { input: '{foo();++bar;}', output: '{\n    foo();\n    ++bar;\n}' },
-            { input: '{--bar;}', output: '{\n    --bar;\n}' },
-            { input: '{++bar;}', output: '{\n    ++bar;\n}' },
-            { input: 'if(true)++a;', output: 'if (true) ++a;' },
-            { input: 'if(true)\n++a;', output: 'if (true)\n    ++a;' },
-            { input: 'if(true)--a;', output: 'if (true) --a;' },
-            { input: 'if(true)\n--a;', output: 'if (true)\n    --a;' },
-            { unchanged: 'elem[array]++;' },
-            { unchanged: 'elem++ * elem[array]++;' },
-            { unchanged: 'elem-- * -elem[array]++;' },
-            { unchanged: 'elem-- + elem[array]++;' },
-            { unchanged: 'elem-- - elem[array]++;' },
-            { unchanged: 'elem-- - -elem[array]++;' },
-            { unchanged: 'elem-- - +elem[array]++;' },
+            {
+                input: '{foo();--bar;}',
+                output: '{\n    foo();\n    --bar;\n}'
+            }, {
+                input: '{foo();++bar;}',
+                output: '{\n    foo();\n    ++bar;\n}'
+            }, {
+                input: '{--bar;}',
+                output: '{\n    --bar;\n}'
+            }, {
+                input: '{++bar;}',
+                output: '{\n    ++bar;\n}'
+            }, {
+                input: 'if(true)++a;',
+                output: 'if (true) ++a;'
+            }, {
+                input: 'if(true)\n++a;',
+                output: 'if (true)\n    ++a;'
+            }, {
+                input: 'if(true)--a;',
+                output: 'if (true) --a;'
+            }, {
+                input: 'if(true)\n--a;',
+                output: 'if (true)\n    --a;'
+            }, {
+                unchanged: 'elem[array]++;'
+            }, {
+                unchanged: 'elem++ * elem[array]++;'
+            }, {
+                unchanged: 'elem-- * -elem[array]++;'
+            }, {
+                unchanged: 'elem-- + elem[array]++;'
+            }, {
+                unchanged: 'elem-- - elem[array]++;'
+            }, {
+                unchanged: 'elem-- - -elem[array]++;'
+            }, {
+                unchanged: 'elem-- - +elem[array]++;'
+            },
 
 
             {
                 comment: 'Handling of newlines around unary ++ and -- operators',
                 input: '{foo\n++bar;}',
                 output: '{\n    foo\n    ++bar;\n}'
+            }, {
+                input: '{foo++\nbar;}',
+                output: '{\n    foo++\n    bar;\n}'
             },
-            { input: '{foo++\nbar;}', output: '{\n    foo++\n    bar;\n}' },
 
             {
                 comment: 'This is invalid, but harder to guard against. Issue #203.',
@@ -2308,75 +2807,109 @@ exports.test_data = {
                 comment: 'regexps',
                 input: 'a(/abc\\\\/\\\\/def/);b()',
                 output: "a(/abc\\\\/\\\\/def/);\nb()"
+            }, {
+                input: 'a(/a[b\\\\[\\\\]c]d/);b()',
+                output: "a(/a[b\\\\[\\\\]c]d/);\nb()"
+            }, {
+                comment: 'incomplete char class',
+                fragment: true,
+                unchanged: 'a(/a[b\\\\['
             },
-            { input: 'a(/a[b\\\\[\\\\]c]d/);b()', output: "a(/a[b\\\\[\\\\]c]d/);\nb()" },
-            { comment: 'incomplete char class', fragment: true, unchanged: 'a(/a[b\\\\[' },
 
             {
                 comment: 'allow unescaped / in char classes',
                 input: 'a(/[a/b]/);b()',
                 output: "a(/[a/b]/);\nb()"
+            }, {
+                unchanged: 'typeof /foo\\\\//;'
+            }, {
+                unchanged: 'yield /foo\\\\//;'
+            }, {
+                unchanged: 'throw /foo\\\\//;'
+            }, {
+                unchanged: 'do /foo\\\\//;'
+            }, {
+                unchanged: 'return /foo\\\\//;'
+            }, {
+                unchanged: 'switch (a) {\n    case /foo\\\\//:\n        b\n}'
+            }, {
+                unchanged: 'if (a) /foo\\\\//\nelse /foo\\\\//;'
             },
-            { unchanged: 'typeof /foo\\\\//;' },
-            { unchanged: 'yield /foo\\\\//;' },
-            { unchanged: 'throw /foo\\\\//;' },
-            { unchanged: 'do /foo\\\\//;' },
-            { unchanged: 'return /foo\\\\//;' },
-            { unchanged: 'switch (a) {\n    case /foo\\\\//:\n        b\n}' },
-            { unchanged: 'if (a) /foo\\\\//\nelse /foo\\\\//;' },
 
-            { unchanged: 'if (foo) /regex/.test();' },
-            { unchanged: "for (index in [1, 2, 3]) /^test$/i.test(s)" },
-            { unchanged: 'result = yield pgClient.query_(queryString);' },
-
-            { unchanged: 'function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}' },
-            { input: 'a=[[1,2],[4,5],[7,8]]', output: "a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]" },
             {
+                unchanged: 'if (foo) /regex/.test();'
+            }, {
+                unchanged: "for (index in [1, 2, 3]) /^test$/i.test(s)"
+            }, {
+                unchanged: 'result = yield pgClient.query_(queryString);'
+            },
+
+            {
+                unchanged: 'function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}'
+            }, {
+                input: 'a=[[1,2],[4,5],[7,8]]',
+                output: "a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]"
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},[7,8]]',
                 output: "a = [\n    [1, 2],\n    [4, 5],\n    function() {},\n    [7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},function(){},[7,8]]',
                 output: "a = [\n    [1, 2],\n    [4, 5],\n    function() {},\n    function() {},\n    [7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[[1,2],[4,5],function(){},[7,8]]',
                 output: "a = [\n    [1, 2],\n    [4, 5],\n    function() {},\n    [7, 8]\n]"
-            },
-            {
+            }, {
                 input: 'a=[b,c,function(){},function(){},d]',
                 output: "a = [b, c, function() {}, function() {}, d]"
-            },
-            {
+            }, {
                 input: 'a=[b,c,\nfunction(){},function(){},d]',
                 output: "a = [b, c,\n    function() {},\n    function() {},\n    d\n]"
+            }, {
+                input: 'a=[a[1],b[4],c[d[7]]]',
+                output: "a = [a[1], b[4], c[d[7]]]"
+            }, {
+                input: '[1,2,[3,4,[5,6],7],8]',
+                output: "[1, 2, [3, 4, [5, 6], 7], 8]"
             },
-            { input: 'a=[a[1],b[4],c[d[7]]]', output: "a = [a[1], b[4], c[d[7]]]" },
-            { input: '[1,2,[3,4,[5,6],7],8]', output: "[1, 2, [3, 4, [5, 6], 7], 8]" },
 
             {
                 input: '[[["1","2"],["3","4"]],[["5","6","7"],["8","9","0"]],[["1","2","3"],["4","5","6","7"],["8","9","0"]]]',
                 output: '[\n    [\n        ["1", "2"],\n        ["3", "4"]\n    ],\n    [\n        ["5", "6", "7"],\n        ["8", "9", "0"]\n    ],\n    [\n        ["1", "2", "3"],\n        ["4", "5", "6", "7"],\n        ["8", "9", "0"]\n    ]\n]'
             },
 
-            { input: '{[x()[0]];indent;}', output: '{\n    [x()[0]];\n    indent;\n}' },
-            { unchanged: '/*\n foo trailing space    \n * bar trailing space   \n**/' },
-            { unchanged: '{\n    /*\n    foo    \n    * bar    \n    */\n}' },
+            {
+                input: '{[x()[0]];indent;}',
+                output: '{\n    [x()[0]];\n    indent;\n}'
+            }, {
+                unchanged: '/*\n foo trailing space    \n * bar trailing space   \n**/'
+            }, {
+                unchanged: '{\n    /*\n    foo    \n    * bar    \n    */\n}'
+            },
 
-            { unchanged: 'return ++i' },
-            { unchanged: 'return !!x' },
-            { unchanged: 'return !x' },
-            { input: 'return [1,2]', output: 'return [1, 2]' },
-            { unchanged: 'return;' },
-            { unchanged: 'return\nfunc' },
-            { input: 'catch(e)', output: 'catch (e)' },
-            { unchanged: 'yield [1, 2]' },
+            {
+                unchanged: 'return ++i'
+            }, {
+                unchanged: 'return !!x'
+            }, {
+                unchanged: 'return !x'
+            }, {
+                input: 'return [1,2]',
+                output: 'return [1, 2]'
+            }, {
+                unchanged: 'return;'
+            }, {
+                unchanged: 'return\nfunc'
+            }, {
+                input: 'catch(e)',
+                output: 'catch (e)'
+            }, {
+                unchanged: 'yield [1, 2]'
+            },
 
             {
                 input: 'var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;',
                 output: 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    }, c = 4;'
-            },
-            {
+            }, {
                 input: 'var a=1,b={foo:2,bar:3},{baz:4,wham:5},\nc=4;',
                 output: 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;'
             },
@@ -2391,33 +2924,64 @@ exports.test_data = {
                 comment: 'javadoc comment',
                 input: '/**\n* foo\n*/',
                 output: '/**\n * foo\n */'
+            }, {
+                input: '{\n/**\n* foo\n*/\n}',
+                output: '{\n    /**\n     * foo\n     */\n}'
             },
-            { input: '{\n/**\n* foo\n*/\n}', output: '{\n    /**\n     * foo\n     */\n}' },
 
             {
                 comment: 'starless block comment',
                 unchanged: '/**\nfoo\n*/'
+            }, {
+                unchanged: '/**\nfoo\n**/'
+            }, {
+                unchanged: '/**\nfoo\nbar\n**/'
+            }, {
+                unchanged: '/**\nfoo\n\nbar\n**/'
+            }, {
+                unchanged: '/**\nfoo\n    bar\n**/'
+            }, {
+                input: '{\n/**\nfoo\n*/\n}',
+                output: '{\n    /**\n    foo\n    */\n}'
+            }, {
+                input: '{\n/**\nfoo\n**/\n}',
+                output: '{\n    /**\n    foo\n    **/\n}'
+            }, {
+                input: '{\n/**\nfoo\nbar\n**/\n}',
+                output: '{\n    /**\n    foo\n    bar\n    **/\n}'
+            }, {
+                input: '{\n/**\nfoo\n\nbar\n**/\n}',
+                output: '{\n    /**\n    foo\n\n    bar\n    **/\n}'
+            }, {
+                input: '{\n/**\nfoo\n    bar\n**/\n}',
+                output: '{\n    /**\n    foo\n        bar\n    **/\n}'
+            }, {
+                unchanged: '{\n    /**\n    foo\nbar\n    **/\n}'
             },
-            { unchanged: '/**\nfoo\n**/' },
-            { unchanged: '/**\nfoo\nbar\n**/' },
-            { unchanged: '/**\nfoo\n\nbar\n**/' },
-            { unchanged: '/**\nfoo\n    bar\n**/' },
-            { input: '{\n/**\nfoo\n*/\n}', output: '{\n    /**\n    foo\n    */\n}' },
-            { input: '{\n/**\nfoo\n**/\n}', output: '{\n    /**\n    foo\n    **/\n}' },
-            { input: '{\n/**\nfoo\nbar\n**/\n}', output: '{\n    /**\n    foo\n    bar\n    **/\n}' },
-            { input: '{\n/**\nfoo\n\nbar\n**/\n}', output: '{\n    /**\n    foo\n\n    bar\n    **/\n}' },
-            { input: '{\n/**\nfoo\n    bar\n**/\n}', output: '{\n    /**\n    foo\n        bar\n    **/\n}' },
-            { unchanged: '{\n    /**\n    foo\nbar\n    **/\n}' },
 
-            { input: 'var a,b,c=1,d,e,f=2;', output: 'var a, b, c = 1,\n    d, e, f = 2;' },
-            { input: 'var a,b,c=[],d,e,f=2;', output: 'var a, b, c = [],\n    d, e, f = 2;' },
-            { unchanged: 'function() {\n    var a, b, c, d, e = [],\n        f;\n}' },
+            {
+                input: 'var a,b,c=1,d,e,f=2;',
+                output: 'var a, b, c = 1,\n    d, e, f = 2;'
+            }, {
+                input: 'var a,b,c=[],d,e,f=2;',
+                output: 'var a, b, c = [],\n    d, e, f = 2;'
+            }, {
+                unchanged: 'function() {\n    var a, b, c, d, e = [],\n        f;\n}'
+            },
 
-            { input: 'do/regexp/;\nwhile(1);', output: 'do /regexp/;\nwhile (1);' },
-            { input: 'var a = a,\na;\nb = {\nb\n}', output: 'var a = a,\n    a;\nb = {\n    b\n}' },
+            {
+                input: 'do/regexp/;\nwhile(1);',
+                output: 'do /regexp/;\nwhile (1);'
+            }, {
+                input: 'var a = a,\na;\nb = {\nb\n}',
+                output: 'var a = a,\n    a;\nb = {\n    b\n}'
+            },
 
-            { unchanged: 'var a = a,\n    /* c */\n    b;' },
-            { unchanged: 'var a = a,\n    // c\n    b;' },
+            {
+                unchanged: 'var a = a,\n    /* c */\n    b;'
+            }, {
+                unchanged: 'var a = a,\n    // c\n    b;'
+            },
 
             {
                 comment: 'weird element referencing',
@@ -2425,41 +2989,75 @@ exports.test_data = {
             },
 
 
-            { unchanged: 'if (a) a()\nelse b()\nnewline()' },
-            { unchanged: 'if (a) a()\nnewline()' },
-            { input: 'a=typeof(x)', output: 'a = typeof(x)' },
+            {
+                unchanged: 'if (a) a()\nelse b()\nnewline()'
+            }, {
+                unchanged: 'if (a) a()\nnewline()'
+            }, {
+                input: 'a=typeof(x)',
+                output: 'a = typeof(x)'
+            },
 
-            { unchanged: 'var a = function() {\n        return null;\n    },\n    b = false;' },
+            {
+                unchanged: 'var a = function() {\n        return null;\n    },\n    b = false;'
+            },
 
-            { unchanged: 'var a = function() {\n    func1()\n}' },
-            { unchanged: 'var a = function() {\n    func1()\n}\nvar b = function() {\n    func2()\n}' },
+            {
+                unchanged: 'var a = function() {\n    func1()\n}'
+            }, {
+                unchanged: 'var a = function() {\n    func1()\n}\nvar b = function() {\n    func2()\n}'
+            },
 
             {
                 comment: 'code with and without semicolons',
                 input_: 'var whatever = require("whatever");\nfunction() {\n    a = 6;\n}',
                 output: 'var whatever = require("whatever");\n\nfunction() {\n    a = 6;\n}'
-            },
-            {
+            }, {
                 input: 'var whatever = require("whatever")\nfunction() {\n    a = 6\n}',
                 output: 'var whatever = require("whatever")\n\nfunction() {\n    a = 6\n}'
             },
 
-            { input: '{"x":[{"a":1,"b":3},\n7,8,8,8,8,{"b":99},{"a":11}]}', output: '{\n    "x": [{\n            "a": 1,\n            "b": 3\n        },\n        7, 8, 8, 8, 8, {\n            "b": 99\n        }, {\n            "a": 11\n        }\n    ]\n}' },
-            { input: '{"x":[{"a":1,"b":3},7,8,8,8,8,{"b":99},{"a":11}]}', output: '{\n    "x": [{\n        "a": 1,\n        "b": 3\n    }, 7, 8, 8, 8, 8, {\n        "b": 99\n    }, {\n        "a": 11\n    }]\n}' },
+            {
+                input: '{"x":[{"a":1,"b":3},\n7,8,8,8,8,{"b":99},{"a":11}]}',
+                output: '{\n    "x": [{\n            "a": 1,\n            "b": 3\n        },\n        7, 8, 8, 8, 8, {\n            "b": 99\n        }, {\n            "a": 11\n        }\n    ]\n}'
+            }, {
+                input: '{"x":[{"a":1,"b":3},7,8,8,8,8,{"b":99},{"a":11}]}',
+                output: '{\n    "x": [{\n        "a": 1,\n        "b": 3\n    }, 7, 8, 8, 8, 8, {\n        "b": 99\n    }, {\n        "a": 11\n    }]\n}'
+            },
 
-            { input: '{"1":{"1a":"1b"},"2"}', output: '{\n    "1": {\n        "1a": "1b"\n    },\n    "2"\n}' },
-            { input: '{a:{a:b},c}', output: '{\n    a: {\n        a: b\n    },\n    c\n}' },
+            {
+                input: '{"1":{"1a":"1b"},"2"}',
+                output: '{\n    "1": {\n        "1a": "1b"\n    },\n    "2"\n}'
+            }, {
+                input: '{a:{a:b},c}',
+                output: '{\n    a: {\n        a: b\n    },\n    c\n}'
+            },
 
-            { input: '{[y[a]];keep_indent;}', output: '{\n    [y[a]];\n    keep_indent;\n}' },
+            {
+                input: '{[y[a]];keep_indent;}',
+                output: '{\n    [y[a]];\n    keep_indent;\n}'
+            },
 
-            { input: 'if (x) {y} else { if (x) {y}}', output: 'if (x) {\n    y\n} else {\n    if (x) {\n        y\n    }\n}' },
+            {
+                input: 'if (x) {y} else { if (x) {y}}',
+                output: 'if (x) {\n    y\n} else {\n    if (x) {\n        y\n    }\n}'
+            },
 
-            { unchanged: 'if (foo) one()\ntwo()\nthree()' },
-            { unchanged: 'if (1 + foo() && bar(baz()) / 2) one()\ntwo()\nthree()' },
-            { unchanged: 'if (1 + foo() && bar(baz()) / 2) one();\ntwo();\nthree();' },
+            {
+                unchanged: 'if (foo) one()\ntwo()\nthree()'
+            }, {
+                unchanged: 'if (1 + foo() && bar(baz()) / 2) one()\ntwo()\nthree()'
+            }, {
+                unchanged: 'if (1 + foo() && bar(baz()) / 2) one();\ntwo();\nthree();'
+            },
 
-            { input: 'var a=1,b={bang:2},c=3;', output: 'var a = 1,\n    b = {\n        bang: 2\n    },\n    c = 3;' },
-            { input: 'var a={bing:1},b=2,c=3;', output: 'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;' },
+            {
+                input: 'var a=1,b={bang:2},c=3;',
+                output: 'var a = 1,\n    b = {\n        bang: 2\n    },\n    c = 3;'
+            }, {
+                input: 'var a={bing:1},b=2,c=3;',
+                output: 'var a = {\n        bing: 1\n    },\n    b = 2,\n    c = 3;'
+            },
 
         ],
     }],

--- a/test/generate-tests.js
+++ b/test/generate-tests.js
@@ -6,10 +6,12 @@ var path = require('path');
 
 function generate_tests() {
     // javascript
-    generate_test_files('javascript', 'bt', 'js/test/generated/beautify-javascript-tests.js', 'python/jsbeautifier/tests/generated/tests.py');
+    generate_test_files('javascript', 'bt', 'js/test/generated/beautify-javascript-tests.js',
+        'python/jsbeautifier/tests/generated/tests.py');
 
     // css
-    generate_test_files('css', 't', 'js/test/generated/beautify-css-tests.js', 'python/cssbeautifier/tests/generated/tests.py');
+    generate_test_files('css', 't', 'js/test/generated/beautify-css-tests.js',
+        'python/cssbeautifier/tests/generated/tests.py');
 
     // html
     // no python html beautifier, so no tests
@@ -22,29 +24,44 @@ function generate_test_files(data_folder, test_method, node_output, python_outpu
 
     input_path = path.resolve(__dirname, 'data', data_folder);
     data_file_path = path.resolve(input_path, 'tests.js');
-    test_data = require(data_file_path).test_data;
+    test_data = require(data_file_path)
+        .test_data;
 
     template_file_path = path.resolve(input_path, 'node.mustache');
-    template = fs.readFileSync(template_file_path, { encoding: 'utf-8' });
+    template = fs.readFileSync(template_file_path, {
+        encoding: 'utf-8'
+    });
     set_formatters(test_data, test_method, '// ');
     set_generated_header(test_data, data_file_path, template_file_path);
     fs.writeFileSync(path.resolve(__dirname, '..', node_output),
-        mustache.render(template, test_data), { encoding: 'utf-8' });
+        mustache.render(template, test_data), {
+            encoding: 'utf-8'
+        });
 
     if (python_output) {
         template_file_path = path.resolve(input_path, 'python.mustache');
-        template = fs.readFileSync(template_file_path, { encoding: 'utf-8' });
+        template = fs.readFileSync(template_file_path, {
+            encoding: 'utf-8'
+        });
         set_formatters(test_data, test_method, '# ');
         set_generated_header(test_data, data_file_path, template_file_path);
         fs.writeFileSync(path.resolve(__dirname, '..', python_output),
-            mustache.render(template, test_data), { encoding: 'utf-8' });
+            mustache.render(template, test_data), {
+                encoding: 'utf-8'
+            });
     }
 }
 
 function set_generated_header(data, data_file_path, template_file_path) {
-    var relative_script_path = path.relative(process.cwd(), __filename).split(path.sep).join('/');
-    var relative_data_file_path = path.relative(process.cwd(), data_file_path).split(path.sep).join('/');
-    var relative_template_file_path = path.relative(process.cwd(), template_file_path).split(path.sep).join('/');
+    var relative_script_path = path.relative(process.cwd(), __filename)
+        .split(path.sep)
+        .join('/');
+    var relative_data_file_path = path.relative(process.cwd(), data_file_path)
+        .split(path.sep)
+        .join('/');
+    var relative_template_file_path = path.relative(process.cwd(), template_file_path)
+        .split(path.sep)
+        .join('/');
 
     data.header_text =
         '    AUTO-GENERATED. DO NOT MODIFY.\n' +
@@ -60,9 +77,11 @@ function isStringOrArray(val) {
 
 function getTestString(val) {
     if (typeof val === 'string') {
-        return "'" + val.replace(/\n/g, '\\n').replace(/\t/g, '\\t') + "'";
+        return "'" + val.replace(/\n/g, '\\n')
+            .replace(/\t/g, '\\t') + "'";
     } else if (val instanceof Array) {
-        return "'" + val.join("\\n' +\n            '").replace(/\t/g, '\\t') + "'";
+        return "'" + val.join("\\n' +\n            '")
+            .replace(/\t/g, '\\t') + "'";
     } else {
         return null;
     }


### PR DESCRIPTION
I had a request for the VS Code beautify extension to support spaces around selector separators (`>+~`) in CSS (HookyQR/VSCodeBeautify#9). Although the reference was incorrect, this PR will enable css-beautify to support the requested option.

