### PR TITLE
Space around selector separator

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -39,13 +39,14 @@
         css_beautify(source_text, options);
 
     The options are (default in brackets):
-        indent_size (4)                   — indentation size,
-        indent_char (space)               — character to indent with,
-        selector_separator_newline (true) - separate selectors with newline or
-                                            not (e.g. "a,\nbr" or "a, br")
-        end_with_newline (false)          - end with a newline
-        newline_between_rules (true)      - add a new line after every css rule
-
+        indent_size (4)                         — indentation size,
+        indent_char (space)                     — character to indent with,
+        selector_separator_newline (true)       - separate selectors with newline or
+                                                  not (e.g. "a,\nbr" or "a, br")
+        end_with_newline (false)                - end with a newline
+        newline_between_rules (true)            - add a new line after every css rule
+        space_around_selector_separator (false) - ensure space around selector separators:
+                                                  '>', '+', '~' (e.g. "a>b" -> "a > b")
     e.g
 
     css_beautify(css_source_text, {
@@ -53,7 +54,8 @@
       'indent_char': '\t',
       'selector_separator': ' ',
       'end_with_newline': false,
-      'newline_between_rules': true
+      'newline_between_rules': true,
+      'space_around_selector_separator': true
     });
 */
 
@@ -72,6 +74,7 @@
         var selectorSeparatorNewline = (options.selector_separator_newline === undefined) ? true : options.selector_separator_newline;
         var end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
         var newline_between_rules = (options.newline_between_rules === undefined) ? true : options.newline_between_rules;
+        var spaceAroundSelectorSeparator = (options.space_around_selector_separator === undefined) ? false : options.space_around_selector_separator;
         var eol = options.eol ? options.eol : '\n';
 
         // compatibility
@@ -421,6 +424,15 @@
                     print.newLine();
                 } else {
                     print.singleSpace();
+                }
+            } else if (ch === '>' || ch === '+' || ch === '~') {
+                //handl selector separator spacing
+                if (spaceAroundSelectorSeparator && !insidePropertyValue && parenLevel < 1) {
+                    print.singleSpace();
+                    output.push(ch);
+                    print.singleSpace();
+                } else {
+                    output.push(ch);
                 }
             } else if (ch === ']') {
                 output.push(ch);

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -70,6 +70,7 @@ var fs = require('fs'),
         // CSS-only
         "selector_separator_newline": Boolean,
         "newline_between_rules": Boolean,
+        "space_around_selector_separator": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
         "unformatted": [String, Array],

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -28,6 +28,7 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
     default_opts.selector_separator_newline = true;
     default_opts.end_with_newline = false;
     default_opts.newline_between_rules = false;
+    default_opts.space_around_selector_separator = false;
 
     function reset_options()
     {
@@ -115,6 +116,23 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         //============================================================
         // 
         t('#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity = 90);\n}', '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}');
+
+
+        reset_options();
+        //============================================================
+        // Space Around Selector Separator - (space = " ")
+        opts.space_around_selector_separator = true;
+        t('a>b{}', 'a > b {}');
+        t('a~b{}', 'a ~ b {}');
+        t('a+b{}', 'a + b {}');
+        t('a+b>c{}', 'a + b > c {}');
+
+        // Space Around Selector Separator - (space = "")
+        opts.space_around_selector_separator = false;
+        t('a>b{}', 'a>b {}');
+        t('a~b{}', 'a~b {}');
+        t('a+b{}', 'a+b {}');
+        t('a+b>c{}', 'a+b>c {}');
 
 
         reset_options();

--- a/js/test/node-beautify-tests.js
+++ b/js/test/node-beautify-tests.js
@@ -39,7 +39,7 @@ if (require.main === module) {
     process.exit(
         test_legacy_names() +
         node_beautifier_tests('js-beautifier', run_javascript_tests).get_exitcode() +
-        node_beautifier_tests('cs-beautifier', run_css_tests).get_exitcode() +
+        node_beautifier_tests('css-beautifier', run_css_tests).get_exitcode() +
         node_beautifier_tests('html-beautifier', run_html_tests).get_exitcode()
     );
 }

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -37,6 +37,7 @@ class BeautifierOptions:
         self.selector_separator_newline = True
         self.end_with_newline = False
         self.newline_between_rules = True
+        self.space_around_selector_separator = False
         self.eol = '\n'
 
 
@@ -48,8 +49,10 @@ indent_with_tabs = [%s]
 separate_selectors_newline = [%s]
 end_with_newline = [%s]
 newline_between_rules = [%s]
+space_around_selector_separator = [%s]
 """ % (self.indent_size, self.indent_char, self.indent_with_tabs,
-       self.selector_separator_newline, self.end_with_newline, self.newline_between_rules)
+       self.selector_separator_newline, self.end_with_newline, self.newline_between_rules, 
+       self.space_around_selector_separator)
 
 
 def default_options():
@@ -445,6 +448,13 @@ class Beautifier:
                     printer.newLine()
                 else:
                     printer.singleSpace()
+            elif self.ch == '>' or self.ch == '+' or self.ch == '~':
+                if not insidePropertyValue and self.opts.space_around_selector_separator and parenLevel < 1:
+                    printer.singleSpace()
+                    printer.push(self.ch)
+                    printer.singleSpace()
+                else:
+                    printer.push(self.ch)
             elif self.ch == ']':
                 printer.push(self.ch)
             elif self.ch == '[':

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -33,6 +33,7 @@ class CSSBeautifierTest(unittest.TestCase):
         default_options.selector_separator_newline = true
         default_options.end_with_newline = false
         default_options.newline_between_rules = false
+        default_options.space_around_selector_separator = false
 
         cls.default_options = default_options
 
@@ -78,6 +79,23 @@ class CSSBeautifierTest(unittest.TestCase):
         #============================================================
         # 
         t('#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity = 90);\n}', '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}')
+
+
+        self.reset_options();
+        #============================================================
+        # Space Around Selector Separator - (space = " ")
+        self.options.space_around_selector_separator = true
+        t('a>b{}', 'a > b {}')
+        t('a~b{}', 'a ~ b {}')
+        t('a+b{}', 'a + b {}')
+        t('a+b>c{}', 'a + b > c {}')
+
+        # Space Around Selector Separator - (space = "")
+        self.options.space_around_selector_separator = false
+        t('a>b{}', 'a>b {}')
+        t('a~b{}', 'a~b {}')
+        t('a+b{}', 'a+b {}')
+        t('a+b>c{}', 'a+b>c {}')
 
 
         self.reset_options();

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -5,6 +5,7 @@ exports.test_data = {
         { name: "selector_separator_newline", value: "true" },
         { name: "end_with_newline", value: "false" },
         { name: "newline_between_rules", value: "false" },
+        { name: "space_around_selector_separator", value: "false" }
     ],
     groups: [{
         name: "End With Newline",
@@ -43,6 +44,22 @@ exports.test_data = {
             input: '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity = 90);\n}',
             output: '#cboxOverlay {\n\tbackground: url(images/overlay.png) repeat 0 0;\n\topacity: 0.9;\n\tfilter: alpha(opacity=90);\n}'
         }, ],
+    }, {
+        name: "Space Around Selector Separator",
+        description: "",
+        matrix: [{
+            options: [{ name: "space_around_selector_separator", value: "true" }],
+            space: ' '
+        }, {
+            options: [{ name: "space_around_selector_separator", value: "false" }],
+            space: ''
+        }],
+        tests: [
+            { input: 'a>b{}', output: 'a{{space}}>{{space}}b {}' },
+            { input: 'a~b{}', output: 'a{{space}}~{{space}}b {}' },
+            { input: 'a+b{}', output: 'a{{space}}+{{space}}b {}' },
+            { input: 'a+b>c{}', output: 'a{{space}}+{{space}}b{{space}}>{{space}}c {}' }
+        ]
     }, {
         name: 'Selector Separator',
         description: '',


### PR DESCRIPTION
I had a request for the VS Code beautify extension to support spaces around selector separators (>+~) in CSS (HookyQR/VSCodeBeautify#9). Although the reference was incorrect, this PR will enable css-beautify to support the requested option.

Scratched the previous branch and made the changes again.