### PR TITLE
Format yield* the same as function*

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -748,6 +748,9 @@ if (!Object.values) {
                 if (opt.space_after_anon_function) {
                     output.space_before_token = true;
                 }
+            } else if (flags.last_text === '*' && last_last_text === 'yield') {
+                // yield* () vs yield * ()
+                output.space_before_token = true;
             } else if (last_type === 'TK_RESERVED' && (in_array(flags.last_text, Tokenizer.line_starters) || flags.last_text === 'catch')) {
                 if (opt.space_before_conditional) {
                     output.space_before_token = true;
@@ -1077,6 +1080,9 @@ if (!Object.values) {
             } else if (last_type === 'TK_RESERVED' || last_type === 'TK_WORD' ||
                 (flags.last_text === '*' && last_last_text === 'function')) {
                 prefix = 'SPACE';
+            } else if (last_type === 'TK_RESERVED' || last_type === 'TK_WORD' ||
+                (flags.last_text === '*' && last_last_text === 'yield')) {
+                prefix = 'SPACE';
             } else if (last_type === 'TK_START_BLOCK') {
                 if (flags.inline_frame) {
                     prefix = 'SPACE';
@@ -1276,6 +1282,7 @@ if (!Object.values) {
             var space_after = true;
             var in_ternary = false;
             var isGeneratorAsterisk = current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text === 'function';
+            var isYieldAsterisk = current_token.text === '*' && last_type === 'TK_RESERVED' && flags.last_text === 'yield';
             var isUnary = in_array(current_token.text, ['-', '+']) && (
                 in_array(last_type, ['TK_START_BLOCK', 'TK_START_EXPR', 'TK_EQUALS', 'TK_OPERATOR']) ||
                 in_array(flags.last_text, Tokenizer.line_starters) ||
@@ -1295,7 +1302,7 @@ if (!Object.values) {
             }
 
             // let's handle the operator_position option prior to any conflicting logic
-            if (!isUnary && !isGeneratorAsterisk && opt.preserve_newlines && in_array(current_token.text, Tokenizer.positionable_operators)) {
+            if (!isUnary && !isGeneratorAsterisk && !isYieldAsterisk && opt.preserve_newlines && in_array(current_token.text, Tokenizer.positionable_operators)) {
                 var isColon = current_token.text === ':';
                 var isTernaryColon = (isColon && in_ternary);
                 var isOtherColon = (isColon && !in_ternary);
@@ -1393,7 +1400,7 @@ if (!Object.values) {
                     // foo(); --bar;
                     print_newline();
                 }
-            } else if (isGeneratorAsterisk) {
+            } else if (isGeneratorAsterisk || isYieldAsterisk) {
                 space_before = false;
                 space_after = false;
             }

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -990,6 +990,21 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
         reset_options();
         //============================================================
+        // Yield tests
+        bt('yield /foo\\//;');
+        bt('result = yield pgClient.query_(queryString);');
+        bt('yield [1, 2]');
+        bt('yield* bar();');
+        
+        // yield should have no space between yield and star
+        bt('yield * bar();', 'yield* bar();');
+        
+        // yield should have space between star and generator
+        bt('yield *bar();', 'yield* bar();');
+
+
+        reset_options();
+        //============================================================
         // Async / await tests
         bt('async function foo() {}');
         bt('let w = async function foo() {}');
@@ -2514,7 +2529,6 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         // allow unescaped / in char classes
         bt('a(/[a/b]/);b()', 'a(/[a/b]/);\nb()');
         bt('typeof /foo\\//;');
-        bt('yield /foo\\//;');
         bt('throw /foo\\//;');
         bt('do /foo\\//;');
         bt('return /foo\\//;');
@@ -2522,7 +2536,6 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('if (a) /foo\\//\nelse /foo\\//;');
         bt('if (foo) /regex/.test();');
         bt('for (index in [1, 2, 3]) /^test$/i.test(s)');
-        bt('result = yield pgClient.query_(queryString);');
         bt('function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}');
         bt('a=[[1,2],[4,5],[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]');
         bt('a=[[1,2],[4,5],function(){},[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    function() {},\n    [7, 8]\n]');
@@ -2543,7 +2556,6 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         bt('return;');
         bt('return\nfunc');
         bt('catch(e)', 'catch (e)');
-        bt('yield [1, 2]');
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;', 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    }, c = 4;');
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},\nc=4;', 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;');
         

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -815,6 +815,21 @@ class TestJSBeautifier(unittest.TestCase):
 
         self.reset_options();
         #============================================================
+        # Yield tests
+        bt('yield /foo\\//;')
+        bt('result = yield pgClient.query_(queryString);')
+        bt('yield [1, 2]')
+        bt('yield* bar();')
+        
+        # yield should have no space between yield and star
+        bt('yield * bar();', 'yield* bar();')
+        
+        # yield should have space between star and generator
+        bt('yield *bar();', 'yield* bar();')
+
+
+        self.reset_options();
+        #============================================================
         # Async / await tests
         bt('async function foo() {}')
         bt('let w = async function foo() {}')
@@ -2339,7 +2354,6 @@ class TestJSBeautifier(unittest.TestCase):
         # allow unescaped / in char classes
         bt('a(/[a/b]/);b()', 'a(/[a/b]/);\nb()')
         bt('typeof /foo\\//;')
-        bt('yield /foo\\//;')
         bt('throw /foo\\//;')
         bt('do /foo\\//;')
         bt('return /foo\\//;')
@@ -2347,7 +2361,6 @@ class TestJSBeautifier(unittest.TestCase):
         bt('if (a) /foo\\//\nelse /foo\\//;')
         bt('if (foo) /regex/.test();')
         bt('for (index in [1, 2, 3]) /^test$/i.test(s)')
-        bt('result = yield pgClient.query_(queryString);')
         bt('function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}')
         bt('a=[[1,2],[4,5],[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]')
         bt('a=[[1,2],[4,5],function(){},[7,8]]', 'a = [\n    [1, 2],\n    [4, 5],\n    function() {},\n    [7, 8]\n]')
@@ -2368,7 +2381,6 @@ class TestJSBeautifier(unittest.TestCase):
         bt('return;')
         bt('return\nfunc')
         bt('catch(e)', 'catch (e)')
-        bt('yield [1, 2]')
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;', 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    }, c = 4;')
         bt('var a=1,b={foo:2,bar:3},{baz:4,wham:5},\nc=4;', 'var a = 1,\n    b = {\n        foo: 2,\n        bar: 3\n    },\n    {\n        baz: 4,\n        wham: 5\n    },\n    c = 4;')
         

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -542,6 +542,25 @@ exports.test_data = {
             unchanged: inputlib.operator_position.catch_all
         }]
     }, {
+        name: "Yield tests",
+        description: "ES6 yield tests",
+        tests: [
+            { unchanged: 'yield /foo\\\\//;' },
+            { unchanged: 'result = yield pgClient.query_(queryString);' },
+            { unchanged: 'yield [1, 2]' },
+            { input: "yield* bar();" },
+            {
+                comment: "yield should have no space between yield and star",
+                input: "yield * bar();",
+                output: "yield* bar();"
+            },
+            {
+                comment: "yield should have space between star and generator",
+                input: "yield *bar();",
+                output: "yield* bar();"
+            }
+        ]
+    }, {
         name: "Async / await tests",
         description: "ES7 async / await tests",
         tests: [
@@ -2318,7 +2337,6 @@ exports.test_data = {
                 output: "a(/[a/b]/);\nb()"
             },
             { unchanged: 'typeof /foo\\\\//;' },
-            { unchanged: 'yield /foo\\\\//;' },
             { unchanged: 'throw /foo\\\\//;' },
             { unchanged: 'do /foo\\\\//;' },
             { unchanged: 'return /foo\\\\//;' },
@@ -2327,7 +2345,6 @@ exports.test_data = {
 
             { unchanged: 'if (foo) /regex/.test();' },
             { unchanged: "for (index in [1, 2, 3]) /^test$/i.test(s)" },
-            { unchanged: 'result = yield pgClient.query_(queryString);' },
 
             { unchanged: 'function foo() {\n    return [\n        "one",\n        "two"\n    ];\n}' },
             { input: 'a=[[1,2],[4,5],[7,8]]', output: "a = [\n    [1, 2],\n    [4, 5],\n    [7, 8]\n]" },
@@ -2370,7 +2387,6 @@ exports.test_data = {
             { unchanged: 'return;' },
             { unchanged: 'return\nfunc' },
             { input: 'catch(e)', output: 'catch (e)' },
-            { unchanged: 'yield [1, 2]' },
 
             {
                 input: 'var a=1,b={foo:2,bar:3},{baz:4,wham:5},c=4;',


### PR DESCRIPTION
Fixes #920 to have `yield*` formatting follow `function*` formatting