### PR TITLE
Unindent-chained-methods option. resolves #482

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Beautifier Options:
   -j, --jslint-happy                Enable jslint-stricter mode
   -a, --space-after-anon-function   Add a space before an anonymous function's parens, ie. function ()
   -b, --brace-style                 [collapse-preserve-inline|collapse|expand|end-expand|none] ["collapse"]
+  -u, --unindent-chained-methods    Don't indent chained method calls
   -B, --break-chained-methods       Break chained method calls across subsequent lines
   -k, --keep-array-indentation      Preserve array indentation
   -x, --unescape-strings            Decode printable characters encoded in xNN notation
@@ -126,6 +127,7 @@ These largely correspond to the underscored option keys for both library interfa
     "keep_array_indentation": false,
     "keep_function_indentation": false,
     "space_before_conditional": true,
+    "unindent_chained_methods": false,
     "break_chained_methods": false,
     "eval_code": false,
     "unescape_strings": false,

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -318,6 +318,7 @@ if (!Object.values) {
         opt.indent_char = options.indent_char ? options.indent_char : ' ';
         opt.eol = options.eol ? options.eol : 'auto';
         opt.preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
+        opt.unindent_chained_methods = (options.unindent_chained_methods === undefined) ? false : options.unindent_chained_methods;
         opt.break_chained_methods = (options.break_chained_methods === undefined) ? false : options.break_chained_methods;
         opt.max_preserve_newlines = (options.max_preserve_newlines === undefined) ? 0 : parseInt(options.max_preserve_newlines, 10);
         opt.space_in_paren = (options.space_in_paren === undefined) ? false : options.space_in_paren;
@@ -1479,6 +1480,8 @@ if (!Object.values) {
         function handle_dot() {
             if (start_of_statement()) {
                 // The conditional starts the statement if appropriate.
+            } else if (opt.unindent_chained_methods) {
+                deindent();
             }
 
             if (last_type === 'TK_RESERVED' && is_special_word(flags.last_text)) {

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -57,6 +57,7 @@ var fs = require('fs'),
         "space_after_anon_function": Boolean,
         // TODO: expand-strict is obsolete, now identical to expand.  Remove in future version
         "brace_style": ["collapse", "expand", "end-expand", "collapse-preserve-inline", "expand-strict", "none"],
+        "unindent_chained_methods": Boolean,
         "break_chained_methods": Boolean,
         "keep_array_indentation": Boolean,
         "unescape_strings": Boolean,
@@ -102,6 +103,7 @@ var fs = require('fs'),
         "j": ["--jslint_happy"],
         "a": ["--space_after_anon_function"],
         "b": ["--brace_style"],
+        "u": ["--unindent_chained_methods"],
         "B": ["--break_chained_methods"],
         "k": ["--keep_array_indentation"],
         "x": ["--unescape_strings"],
@@ -253,6 +255,7 @@ function usage(err) {
             msg.push('  -j, --jslint-happy                Enable jslint-stricter mode');
             msg.push('  -a, --space-after-anon-function   Add a space before an anonymous function\'s parens, ie. function ()');
             msg.push('  -b, --brace-style                 [collapse|expand|collapse-preserve-inline|end-expand|none] ["collapse"]');
+            msg.push('  -u, --unindent-chained-methods    Don\'t indent chained method calls');
             msg.push('  -B, --break-chained-methods       Break chained method calls across subsequent lines');
             msg.push('  -k, --keep-array-indentation      Preserve array indentation');
             msg.push('  -x, --unescape-strings            Decode printable characters encoded in xNN notation');

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -403,6 +403,35 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
         reset_options();
         //============================================================
+        // Unindent chained functions - ()
+        opts.unindent_chained_methods = true;
+        bt(
+            'f().f().f()\n' +
+            '    .f().f();',
+            'f().f().f()\n' +
+            '.f().f();');
+        bt(
+            'f()\n' +
+            '    .f()\n' +
+            '    .f();',
+            'f()\n' +
+            '.f()\n' +
+            '.f();');
+        bt(
+            'f(function() {\n' +
+            '    f()\n' +
+            '        .f()\n' +
+            '        .f();\n' +
+            '});',
+            'f(function() {\n' +
+            '    f()\n' +
+            '    .f()\n' +
+            '    .f();\n' +
+            '});');
+
+
+        reset_options();
+        //============================================================
         // Space in parens tests - (s = "", e = "")
         opts.space_in_paren = false;
         opts.space_in_empty_paren = false;

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -79,6 +79,7 @@ class BeautifierOptions:
         self.eval_code = False
         self.unescape_strings = False
         self.wrap_line_length = 0
+        self.unindent_chained_methods = False
         self.break_chained_methods = False
         self.end_with_newline = False
         self.comma_first = False
@@ -1335,6 +1336,9 @@ class Beautifier:
         if self.start_of_statement(current_token):
             # The conditional starts the statement if appropriate.
             pass
+        elif self.opts.unindent_chained_methods:
+            self.deindent()
+            
 
         if self.last_type == 'TK_RESERVED' and self.is_special_word(self.flags.last_text):
             self.output.space_before_token = True

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -228,6 +228,35 @@ class TestJSBeautifier(unittest.TestCase):
 
         self.reset_options();
         #============================================================
+        # Unindent chained functions - ()
+        self.options.unindent_chained_methods = true
+        bt(
+            'f().f().f()\n' +
+            '    .f().f();',
+            'f().f().f()\n' +
+            '.f().f();')
+        bt(
+            'f()\n' +
+            '    .f()\n' +
+            '    .f();',
+            'f()\n' +
+            '.f()\n' +
+            '.f();')
+        bt(
+            'f(function() {\n' +
+            '    f()\n' +
+            '        .f()\n' +
+            '        .f();\n' +
+            '});',
+            'f(function() {\n' +
+            '    f()\n' +
+            '    .f()\n' +
+            '    .f();\n' +
+            '});')
+
+
+        self.reset_options();
+        #============================================================
         # Space in parens tests - (s = "", e = "")
         self.options.space_in_paren = false
         self.options.space_in_empty_paren = false

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -240,6 +240,53 @@ exports.test_data = {
             }
         ],
     }, {
+        name: "Unindent chained functions",
+        description: "Don't indent chained functions if unindent_chained_functions is true",
+        matrix: [{
+            options: [
+                { name: "unindent_chained_methods", value: "true" }
+            ]
+        }],
+        tests: [{
+                input: [
+                    'f().f().f()',
+                    '    .f().f();',
+                ],
+                output: [
+                    'f().f().f()',
+                    '.f().f();'
+                ]
+            },
+            {
+                input: [
+                    'f()',
+                    '    .f()',
+                    '    .f();'
+                ],
+                output: [
+                    'f()',
+                    '.f()',
+                    '.f();'
+                ]
+            },
+            {
+                input: [
+                    'f(function() {',
+                    '    f()',
+                    '        .f()',
+                    '        .f();',
+                    '});'
+                ],
+                output: [
+                    'f(function() {',
+                    '    f()',
+                    '    .f()',
+                    '    .f();',
+                    '});'
+                ]
+            }
+        ],
+    }, {
         name: "Space in parens tests",
         description: "put space inside parens",
         matrix: [{


### PR DESCRIPTION
`unindent_chained_method =  true` will produce this:

    fun1()
    .fun2();

instead of

    fun1()
        .fun2();