### PR TITLE
cli.js: Make directory of outfile only if outfile is truthy

### DIFF
--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -315,8 +315,9 @@ function processInputSync(filepath) {
             makePretty(data, config, outfile, writePretty);
         });
     } else {
-        var dir = path.dirname(outfile);
-        mkdirp.sync(dir);
+        if (outfile) {
+            mkdirp.sync(path.dirname(outfile));
+        }
         data = fs.readFileSync(filepath, 'utf8');
         makePretty(data, config, outfile, writePretty);
     }


### PR DESCRIPTION
Starting from node 6.0.0, the argument to `path.dirname` must be a string. Previously, `path.dirname(undefined)` returns `'.'`, but now it throws an error. For details, compare
https://nodejs.org/docs/latest-v5.x/api/path.html#path_path_dirname_p and https://nodejs.org/docs/latest-v6.x/api/path.html#path_path_dirname_path.

Also added missing newline at the end of file.

Fixes #933.