### PR TITLE
Add space between async keyword and arrow functions

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -476,7 +476,7 @@ if (!Object.values) {
                 return out;
             }
 
-            var newline_restricted_tokens = ['break', 'contiue', 'return', 'throw'];
+            var newline_restricted_tokens = ['break', 'continue', 'return', 'throw'];
 
             function allow_wrap_or_preserved_newline(force_linewrap) {
                 force_linewrap = (force_linewrap === undefined) ? false : force_linewrap;

--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -755,6 +755,11 @@ if (!Object.values) {
                     output.space_before_token = true;
                 }
 
+                // Should be a space between async and arrow function
+                if (current_token.text === '(' && last_type === 'TK_RESERVED' && flags.last_word === 'async') {
+                    output.space_before_token = true;
+                }
+
                 // Support of this kind of newline preservation.
                 // a = (b &&
                 //     (c || d));

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -493,7 +493,7 @@ class Beautifier:
         return mode in [MODE.Expression, MODE.ForInitializer, MODE.Conditional]
 
 
-    _newline_restricted_tokens = ['break','contiue','return', 'throw']
+    _newline_restricted_tokens = ['break','continue','return', 'throw']
     def allow_wrap_or_preserved_newline(self, current_token, force_linewrap = False):
         # never wrap the first token of a line.
         if self.output.just_added_newline():

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -699,6 +699,9 @@ class Beautifier:
         elif current_token.text == '(' and self.last_type == 'TK_RESERVED' and self.flags.last_word == 'await':
             self.output.space_before_token = True
 
+        elif current_token.text == '(' and self.last_type == 'TK_RESERVED' and self.flags.last_word == 'async':
+            self.output.space_before_token = True
+
 
         # Support of this kind of newline preservation:
         # a = (b &&


### PR DESCRIPTION
Fixes #896 