### PR TITLE
Remove headings from inline element list

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -131,7 +131,6 @@
             // prexisting - not sure of full effect of removing, leaving in
             'acronym', 'address', 'big', 'dt', 'ins', 'small', 'strike', 'tt',
             'pre',
-            'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
         ];
         preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
         max_preserve_newlines = preserve_newlines ?

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -96,6 +96,17 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
         reset_options();
         //============================================================
+        // Handle inline and block elements differently - ()
+        test_fragment(
+            '<body><h1>Block</h1></body>',
+            '<body>\n' +
+            '    <h1>Block</h1>\n' +
+            '</body>');
+        test_fragment('<body><i>Inline</i></body>');
+
+
+        reset_options();
+        //============================================================
         // End With Newline - (eof = "\n")
         opts.end_with_newline = true;
         test_fragment('', '\n');
@@ -562,7 +573,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         reset_options();
         //============================================================
         // Php formatting
-        test_fragment('<h1 class="content-page-header"><?=$view["name"]; ?></h1>');
+        test_fragment('<h1 class="content-page-header"><?=$view["name"]; ?></h1>', '<h1 class="content-page-header">\n    <?=$view["name"]; ?>\n</h1>');
         test_fragment(
             '<?php\n' +
             'for($i = 1; $i <= 100; $i++;) {\n' +

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -10,6 +10,22 @@ exports.test_data = {
         { name: "extra_liners", value: "['html', 'head', '/html']" }
     ],
     groups: [{
+        name: "Handle inline and block elements differently",
+        description: "",
+        matrix: [{}],
+        tests: [{
+            fragment: true,
+            input: '<body><h1>Block</h1></body>',
+            output: [
+                '<body>',
+                '    <h1>Block</h1>',
+                '</body>'
+            ]
+        }, {
+            fragment: true,
+            unchanged: '<body><i>Inline</i></body>'
+        }]
+    }, {
         name: "End With Newline",
         description: "",
         matrix: [{
@@ -555,33 +571,35 @@ exports.test_data = {
         name: "Php formatting",
         description: "Php (<?php ... ?>) treated as comments.",
         options: [],
-        tests: [
-            { fragment: true, unchanged: '<h1 class="content-page-header"><?=$view["name"]; ?></h1>' }, {
-                fragment: true,
-                unchanged: [
-                    '<?php',
-                    'for($i = 1; $i <= 100; $i++;) {',
-                    '    #count to 100!',
-                    '    echo($i . "</br>");',
-                    '}',
-                    '?>'
-                ]
-            }, {
-                fragment: true,
-                unchanged: [
-                    '<?php ?>',
-                    '<!DOCTYPE html>',
-                    '',
-                    '<html>',
-                    '',
-                    '<head></head>',
-                    '',
-                    '<body></body>',
-                    '',
-                    '</html>'
-                ]
-            }
-        ]
+        tests: [{
+            fragment: true,
+            input: '<h1 class="content-page-header"><?=$view["name"]; ?></h1>',
+            output: '<h1 class="content-page-header">\n    <?=$view["name"]; ?>\n</h1>',
+        }, {
+            fragment: true,
+            unchanged: [
+                '<?php',
+                'for($i = 1; $i <= 100; $i++;) {',
+                '    #count to 100!',
+                '    echo($i . "</br>");',
+                '}',
+                '?>'
+            ]
+        }, {
+            fragment: true,
+            unchanged: [
+                '<?php ?>',
+                '<!DOCTYPE html>',
+                '',
+                '<html>',
+                '',
+                '<head></head>',
+                '',
+                '<body></body>',
+                '',
+                '</html>'
+            ]
+        }]
     }, {
         name: "underscore.js  formatting",
         description: "underscore.js templates (<% ... %>) treated as comments.",


### PR DESCRIPTION
Right now

```html
<!DOCTYPE html><html><head><title>Article Title</title></head><body><h1>My</h1></body></html>
```

is beautified as

```html
<!DOCTYPE html>
<html>

<head>
    <title>Article Title</title>
</head>

<body>
    <h1>My</h1></body>

</html>
```

`h1` (and all other heading elements) are block-level elements.

For further information, `git blame` shows that the elements were added in 34f59337ffdfaadcddcd9422afc135c526d67620 which intended to add the inline elements only.