### PR TITLE
fix #906. New unformatted_tag_content option.

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -308,7 +308,7 @@
                 this.pos -= end_tag.length;
 
                 return res;
-            }
+            };
 
             this.get_content = function() { //function to capture regular content between tags
                 var input_char = '',
@@ -825,8 +825,7 @@
                 }
 
                 if (this.last_token === 'TK_TAG_UNFORMATTED') {
-                    // get_contents_to ?
-                    var token = this.get_unformatted_content();
+                    token = this.get_unformatted_content();
 
                     if (typeof token !== 'string') {
                         return token;

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -289,12 +289,12 @@
                 }
             };
 
-            this.get_unformatted_content = function () {
+            this.get_unformatted_content = function() {
                 var target = this.last_text.match(/<([^>\s]+)/)[1],
                     end_tag = '</' + target + '>',
 
                     m_start = new RegExp('<\s*' + target + '[^>]*>', "gi"),
-                    m_end   = new RegExp('</\s*' + target + '[^>]*>', "gi");
+                    m_end = new RegExp('</\s*' + target + '[^>]*>', "gi");
 
                 var res = '';
 
@@ -1028,9 +1028,9 @@
                             tag_extracted_from_last_output = multi_parser.output[multi_parser.output.length - 1].match(/(?:<|{{#)\s*(\w+)/);
                         }
                         if (tag_extracted_from_last_output === null ||
-                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted)
-                                && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted_tag_content))
-                            ) {
+                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted) &&
+                                !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted_tag_content))
+                        ) {
                             multi_parser.print_newline(false, multi_parser.output);
                         }
                     }

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -161,8 +161,8 @@ var path = require('path'),
         "o": ["--outfile"],
         "r": ["--replace"],
         "q": ["--quiet"],
-            // no shorthand for "config"
-            // no shorthand for "editorconfig"
+        // no shorthand for "config"
+        // no shorthand for "editorconfig"
     });
 
 function verifyExists(fullPath) {

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -91,6 +91,7 @@ var path = require('path'),
         "space_around_selector_separator": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
+        "unformatted_tag_content": [String, Array],
         "unformatted": [String, Array],
         "indent_inner_html": [Boolean],
         "indent_handlebars": [Boolean],
@@ -143,6 +144,7 @@ var path = require('path'),
         "H": ["--indent_handlebars"],
         "S": ["--indent_scripts"],
         "E": ["--extra_liners"],
+        "utc": ["--unformatted_tag_content"],
         // non-dasherized hybrid shortcuts
         "good-stuff": [
             "--keep_array_indentation",
@@ -158,7 +160,7 @@ var path = require('path'),
         "f": ["--files"],
         "o": ["--outfile"],
         "r": ["--replace"],
-        "q": ["--quiet"]
+        "q": ["--quiet"],
             // no shorthand for "config"
             // no shorthand for "editorconfig"
     });
@@ -414,6 +416,7 @@ function processInputSync(filepath) {
 }
 
 function makePretty(code, config, outfile, callback) {
+
     try {
         var fileType = getOutputType(outfile, config.type);
         var pretty = beautify[fileType](code, config);

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -1028,6 +1028,17 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
+        // Unformatted script/style with extra script, style and body liners
+        reset_options();
+        opts.unformatted_tag_content = [ 'script', 'style', 'p', 'span', 'br' ];
+        test_fragment('<body><h1>Heading</h1><script>var formatMe = function() { return false; };</script><style>.format-disabled { display: none; } </style></body>', '<body>\n    <h1>Heading</h1>\n    <script>var formatMe = function() { return false; };</script>\n    <style>.format-disabled { display: none; } </style>\n</body>');
+        test_fragment('<div><p>Beautify me</p></div><p><p>But not me</p></p>', '<div>\n    <p>Beautify me</p>\n</div>\n<p><p>But not me</p></p>');
+        test_fragment('<div><p\n  class="beauty-me"\n>Beautify me</p></div><p><p\n  class="iamalreadybeauty"\n>But not me</p></p>', '<div>\n    <p class="beauty-me">Beautify me</p>\n</div>\n<p><p\n  class="iamalreadybeauty"\n>But not me</p></p>');
+        test_fragment('<div><span>blabla<div>something here</div></span></div>');
+        test_fragment('<div><br /></div>');
+
+
+        //============================================================
         // New Test Suite
         reset_options();
 

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -900,6 +900,42 @@ exports.test_data = {
             unchanged: '<html>\n\n<head>\n<meta>\n</head>\n\n</html>'
         }]
     }, {
+        name: "Unformatted script/style with extra script, style and body liners",
+        options: [
+            { name: 'unformatted_tag_content', value: "[ 'script', 'style', 'p', 'span', 'br' ]" }
+        ],
+        tests: [{
+            fragment: true,
+            input: "<body><h1>Heading</h1><script>var formatMe = function() { return false; };</script><style>.format-disabled { display: none; } </style></body>",
+            output: "<body>\n" +
+                "    <h1>Heading</h1>\n" +
+                "    <script>var formatMe = function() { return false; };</script>\n" +
+                "    <style>.format-disabled { display: none; } </style>\n" +
+                "</body>"
+        }, {
+            fragment: true,
+            input: "<div><p>Beautify me</p></div><p><p>But not me</p></p>",
+            output: "<div>\n" +
+                "    <p>Beautify me</p>\n" +
+                "</div>\n" +
+                "<p><p>But not me</p></p>"
+        }, {
+            fragment: true,
+            input: "<div><p\n  class=\"beauty-me\"\n>Beautify me</p></div><p><p\n  class=\"iamalreadybeauty\"\n>But not me</p></p>",
+            output: "<div>\n" +
+                "    <p class=\"beauty-me\">Beautify me</p>\n" +
+                "</div>\n" +
+                "<p><p\n" +
+                "  class=\"iamalreadybeauty\"\n" +
+                ">But not me</p></p>"
+        }, {
+            fragment: true,
+            unchanged: "<div><span>blabla<div>something here</div></span></div>",
+        }, {
+            fragment: true,
+            unchanged: "<div><br /></div>"
+        }]
+    }, {
         name: "New Test Suite"
     }],
 };


### PR DESCRIPTION
Fix for [#906](https://github.com/beautify-web/js-beautify/issues/906)

New option for unformatted content:  `unformatted_tag_content`. Usage same as for `unformatted`, console short version: `-utc`.

Parser now has new tag_type: `UNFORMATTED`. It parses content inside tag but process tag itself as separate `tag_type` instead of getting them as raw text.