### PR TITLE
fix: strict violation (ReferenceError)

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -130,7 +130,8 @@
             is_wrap_attributes_force_aligned,
             end_with_newline,
             extra_liners,
-            eol;
+            eol,
+            source_text;
 
         options = options || {};
 


### PR DESCRIPTION
causing the following error in strict mode:
```
ReferenceError: source_text is not defined
```