### PR TITLE
No extra newline following header comment in CSS

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -104,6 +104,7 @@
         var space_around_combinator = (options.space_around_combinator === undefined) ? false : options.space_around_combinator;
         space_around_combinator = space_around_combinator || ((options.space_around_selector_separator === undefined) ? false : options.space_around_selector_separator);
         var eol = options.eol ? options.eol : 'auto';
+        var newline_following_header = (options.newline_following_header == undefined) ? true : options.newline_following_header;
 
         if (options.indent_with_tabs) {
             indentCharacter = '\t';
@@ -325,7 +326,7 @@
 
                 output.push(eatComment());
                 print.newLine();
-                if (header) {
+                if (header && newline_following_header) {
                     print.newLine(true);
                 }
             } else if (ch === '/' && peek() === '/') { // single line comment

--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -104,7 +104,7 @@
         var space_around_combinator = (options.space_around_combinator === undefined) ? false : options.space_around_combinator;
         space_around_combinator = space_around_combinator || ((options.space_around_selector_separator === undefined) ? false : options.space_around_selector_separator);
         var eol = options.eol ? options.eol : 'auto';
-        var newline_following_header = (options.newline_following_header == undefined) ? true : options.newline_following_header;
+        var newline_following_header = (options.newline_following_header === undefined) ? true : options.newline_following_header;
 
         if (options.indent_with_tabs) {
             indentCharacter = '\t';

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -87,6 +87,7 @@ var path = require('path'),
         "selector_separator_newline": Boolean,
         "newline_between_rules": Boolean,
         "space_around_combinator": Boolean,
+        "newline_following_header": Boolean,
         //deprecated - replaced with space_around_combinator, remove in future version
         "space_around_selector_separator": Boolean,
         // HTML-only
@@ -149,7 +150,8 @@ var path = require('path'),
         "good-stuff": [
             "--keep_array_indentation",
             "--keep_function_indentation",
-            "--jslint_happy"
+            "--jslint_happy",
+            "--newline_following_header"
         ],
         "js": ["--type", "js"],
         "css": ["--type", "css"],
@@ -362,6 +364,7 @@ function usage(err) {
         case "css":
             msg.push('  -L, --selector-separator-newline        Add a newline between multiple selectors.');
             msg.push('  -N, --newline-between-rules             Add a newline between CSS rules.');
+            msg.push('  --newline-following-header              Add a newline following a header comment');
     }
 
     if (err) {

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -848,8 +848,9 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
 
 
         //============================================================
-        // Comments
+        // Comments - (separator = "\n")
         reset_options();
+        opts.newline_following_header = true;
         t('/* test */');
         t(
             '.tabs{/* test */}',
@@ -952,6 +953,27 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
             '\twidth: 10px; //end of line comment\n' +
             '\theight: 10px; //another\n' +
             '}');
+
+        // Comments - (separator = "")
+        reset_options();
+        opts.newline_following_header = false;
+        t('/* test */');
+        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}');
+        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}');
+        t('/* header */.tabs {}', '/* header */\n.tabs {}');
+        t('.tabs {\n/* non-header */\nwidth:10px;}', '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}');
+        t('/* header');
+        t('// comment');
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}');
+        
+        // single line comment support (less/sass)
+        t('.tabs{\n// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}');
+        t('.tabs{// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}');
+        t('//comment\n.tabs{width:10px;}', '//comment\n.tabs {\n\twidth: 10px;\n}');
+        t('.tabs{//comment\n//2nd single line comment\nwidth:10px;}', '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}');
+        t('.tabs{width:10px;//end of line comment\n}', '.tabs {\n\twidth: 10px; //end of line comment\n}');
+        t('.tabs{width:10px;//end of line comment\nheight:10px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}');
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}');
 
 
         //============================================================

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -868,8 +868,7 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
             '/* header */.tabs {}',
             //  -- output --
             '/* header */\n' +
-            '\n' +
-            '.tabs {}');
+            '\n.tabs {}');
         t(
             '.tabs {\n' +
             '/* non-header */\n' +
@@ -958,22 +957,106 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         reset_options();
         opts.newline_following_header = false;
         t('/* test */');
-        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}');
-        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}');
-        t('/* header */.tabs {}', '/* header */\n.tabs {}');
-        t('.tabs {\n/* non-header */\nwidth:10px;}', '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}');
+        t(
+            '.tabs{/* test */}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t/* test */\n' +
+            '}');
+        t(
+            '.tabs{/* test */}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t/* test */\n' +
+            '}');
+        t(
+            '/* header */.tabs {}',
+            //  -- output --
+            '/* header */\n' +
+            '.tabs {}');
+        t(
+            '.tabs {\n' +
+            '/* non-header */\n' +
+            'width:10px;}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t/* non-header */\n' +
+            '\twidth: 10px;\n' +
+            '}');
         t('/* header');
         t('// comment');
-        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}');
+        t(
+            '.selector1 {\n' +
+            '\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n' +
+            '}',
+            //  -- output --
+            '.selector1 {\n' +
+            '\tmargin: 0;\n' +
+            '\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n' +
+            '}');
         
         // single line comment support (less/sass)
-        t('.tabs{\n// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}');
-        t('.tabs{// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}');
-        t('//comment\n.tabs{width:10px;}', '//comment\n.tabs {\n\twidth: 10px;\n}');
-        t('.tabs{//comment\n//2nd single line comment\nwidth:10px;}', '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}');
-        t('.tabs{width:10px;//end of line comment\n}', '.tabs {\n\twidth: 10px; //end of line comment\n}');
-        t('.tabs{width:10px;//end of line comment\nheight:10px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}');
-        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}');
+        t(
+            '.tabs{\n' +
+            '// comment\n' +
+            'width:10px;\n' +
+            '}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t// comment\n' +
+            '\twidth: 10px;\n' +
+            '}');
+        t(
+            '.tabs{// comment\n' +
+            'width:10px;\n' +
+            '}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t// comment\n' +
+            '\twidth: 10px;\n' +
+            '}');
+        t(
+            '//comment\n' +
+            '.tabs{width:10px;}',
+            //  -- output --
+            '//comment\n' +
+            '.tabs {\n' +
+            '\twidth: 10px;\n' +
+            '}');
+        t(
+            '.tabs{//comment\n' +
+            '//2nd single line comment\n' +
+            'width:10px;}',
+            //  -- output --
+            '.tabs {\n' +
+            '\t//comment\n' +
+            '\t//2nd single line comment\n' +
+            '\twidth: 10px;\n' +
+            '}');
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            '}',
+            //  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '}');
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            'height:10px;}',
+            //  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '\theight: 10px;\n' +
+            '}');
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            'height:10px;//another\n' +
+            '}',
+            //  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '\theight: 10px; //another\n' +
+            '}');
 
 
         //============================================================

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -40,6 +40,7 @@ class BeautifierOptions:
         self.newline_between_rules = True
         self.space_around_combinator = False
         self.eol = 'auto'
+        self.newline_following_header = True
 
         self.css = None
         self.js = None
@@ -69,9 +70,10 @@ separate_selectors_newline = [%s]
 end_with_newline = [%s]
 newline_between_rules = [%s]
 space_around_combinator = [%s]
+newline_following_header = [%s]
 """ % (self.indent_size, self.indent_char, self.indent_with_tabs,
        self.selector_separator_newline, self.end_with_newline, self.newline_between_rules,
-       self.space_around_combinator)
+       self.space_around_combinator, self.newline_following_header)
 
 
 def default_options():
@@ -218,6 +220,8 @@ class Beautifier:
 
         self.opts.eol = self.opts.eol.replace('\\r', '\r').replace('\\n', '\n')
 
+        self.newlineFollowingHeader = self.opts.newline_following_header
+
         # HACK: newline parsing inconsistent. This brute force normalizes the input newlines.
         self.source_text = re.sub(self.allLineBreaks, '\n', source_text)
 
@@ -361,8 +365,8 @@ class Beautifier:
                 comment = self.eatComment()
                 printer.comment(comment)
                 printer.newLine()
-                if header:
-                    printer.newLine(True)
+                if header and self.newlineFollowingHeader:
+                   printer.newLine(True)
             elif self.ch == '/' and self.peek() == '/':
                 if not isAfterNewline and last_top_ch != '{':
                     printer.trim()

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -826,8 +826,7 @@ class CSSBeautifierTest(unittest.TestCase):
             '/* header */.tabs {}',
             #  -- output --
             '/* header */\n' +
-            '\n' +
-            '.tabs {}')
+            '\n.tabs {}')
         t(
             '.tabs {\n' +
             '/* non-header */\n' +
@@ -916,22 +915,106 @@ class CSSBeautifierTest(unittest.TestCase):
         self.reset_options();
         self.options.newline_following_header = false
         t('/* test */')
-        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}')
-        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}')
-        t('/* header */.tabs {}', '/* header */\n.tabs {}')
-        t('.tabs {\n/* non-header */\nwidth:10px;}', '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}')
+        t(
+            '.tabs{/* test */}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t/* test */\n' +
+            '}')
+        t(
+            '.tabs{/* test */}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t/* test */\n' +
+            '}')
+        t(
+            '/* header */.tabs {}',
+            #  -- output --
+            '/* header */\n' +
+            '.tabs {}')
+        t(
+            '.tabs {\n' +
+            '/* non-header */\n' +
+            'width:10px;}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t/* non-header */\n' +
+            '\twidth: 10px;\n' +
+            '}')
         t('/* header')
         t('// comment')
-        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}')
+        t(
+            '.selector1 {\n' +
+            '\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n' +
+            '}',
+            #  -- output --
+            '.selector1 {\n' +
+            '\tmargin: 0;\n' +
+            '\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n' +
+            '}')
         
         # single line comment support (less/sass)
-        t('.tabs{\n// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}')
-        t('.tabs{// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}')
-        t('//comment\n.tabs{width:10px;}', '//comment\n.tabs {\n\twidth: 10px;\n}')
-        t('.tabs{//comment\n//2nd single line comment\nwidth:10px;}', '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}')
-        t('.tabs{width:10px;//end of line comment\n}', '.tabs {\n\twidth: 10px; //end of line comment\n}')
-        t('.tabs{width:10px;//end of line comment\nheight:10px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}')
-        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}')
+        t(
+            '.tabs{\n' +
+            '// comment\n' +
+            'width:10px;\n' +
+            '}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t// comment\n' +
+            '\twidth: 10px;\n' +
+            '}')
+        t(
+            '.tabs{// comment\n' +
+            'width:10px;\n' +
+            '}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t// comment\n' +
+            '\twidth: 10px;\n' +
+            '}')
+        t(
+            '//comment\n' +
+            '.tabs{width:10px;}',
+            #  -- output --
+            '//comment\n' +
+            '.tabs {\n' +
+            '\twidth: 10px;\n' +
+            '}')
+        t(
+            '.tabs{//comment\n' +
+            '//2nd single line comment\n' +
+            'width:10px;}',
+            #  -- output --
+            '.tabs {\n' +
+            '\t//comment\n' +
+            '\t//2nd single line comment\n' +
+            '\twidth: 10px;\n' +
+            '}')
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            '}',
+            #  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '}')
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            'height:10px;}',
+            #  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '\theight: 10px;\n' +
+            '}')
+        t(
+            '.tabs{width:10px;//end of line comment\n' +
+            'height:10px;//another\n' +
+            '}',
+            #  -- output --
+            '.tabs {\n' +
+            '\twidth: 10px; //end of line comment\n' +
+            '\theight: 10px; //another\n' +
+            '}')
 
 
         #============================================================

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -806,8 +806,9 @@ class CSSBeautifierTest(unittest.TestCase):
 
 
         #============================================================
-        # Comments
+        # Comments - (separator = "\n")
         self.reset_options();
+        self.options.newline_following_header = true
         t('/* test */')
         t(
             '.tabs{/* test */}',
@@ -910,6 +911,27 @@ class CSSBeautifierTest(unittest.TestCase):
             '\twidth: 10px; //end of line comment\n' +
             '\theight: 10px; //another\n' +
             '}')
+
+        # Comments - (separator = "")
+        self.reset_options();
+        self.options.newline_following_header = false
+        t('/* test */')
+        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}')
+        t('.tabs{/* test */}', '.tabs {\n\t/* test */\n}')
+        t('/* header */.tabs {}', '/* header */\n.tabs {}')
+        t('.tabs {\n/* non-header */\nwidth:10px;}', '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}')
+        t('/* header')
+        t('// comment')
+        t('.selector1 {\n\tmargin: 0; /* This is a comment including an url http://domain.com/path/to/file.ext */\n}', '.selector1 {\n\tmargin: 0;\n\t/* This is a comment including an url http://domain.com/path/to/file.ext */\n}')
+        
+        # single line comment support (less/sass)
+        t('.tabs{\n// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}')
+        t('.tabs{// comment\nwidth:10px;\n}', '.tabs {\n\t// comment\n\twidth: 10px;\n}')
+        t('//comment\n.tabs{width:10px;}', '//comment\n.tabs {\n\twidth: 10px;\n}')
+        t('.tabs{//comment\n//2nd single line comment\nwidth:10px;}', '.tabs {\n\t//comment\n\t//2nd single line comment\n\twidth: 10px;\n}')
+        t('.tabs{width:10px;//end of line comment\n}', '.tabs {\n\twidth: 10px; //end of line comment\n}')
+        t('.tabs{width:10px;//end of line comment\nheight:10px;}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px;\n}')
+        t('.tabs{width:10px;//end of line comment\nheight:10px;//another\n}', '.tabs {\n\twidth: 10px; //end of line comment\n\theight: 10px; //another\n}')
 
 
         #============================================================

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -251,11 +251,22 @@ exports.test_data = {
     }, {
         name: "Comments",
         description: "",
+        matrix: [{
+            options: [
+                { name: "newline_following_header", value: "true" }
+            ],
+            separator: '\\n'
+        }, {
+            options: [
+                { name: "newline_following_header", value: "false" }
+            ],
+            separator: ''
+        }],
         tests: [
             { unchanged: '/* test */' },
             { input: '.tabs{/* test */}', output: '.tabs {\n\t/* test */\n}' },
             { input: '.tabs{/* test */}', output: '.tabs {\n\t/* test */\n}' },
-            { input: '/* header */.tabs {}', output: '/* header */\n\n.tabs {}' },
+            { input: '/* header */.tabs {}', output: '/* header */\n{{separator}}.tabs {}' },
             { input: '.tabs {\n/* non-header */\nwidth:10px;}', output: '.tabs {\n\t/* non-header */\n\twidth: 10px;\n}' },
             { unchanged: '/* header' },
             { unchanged: '// comment' }, {


### PR DESCRIPTION
Add a cli flag to control whether CSS  block comments in the header
are followed by a blank line.

This is intended to fix #531 . I would be happier not having it controlled by a switch or defaulting to no newline, but am open to advice