### PR TITLE
Add initial indent level

### DIFF
--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -890,7 +890,7 @@
                         return;
                     }
                     if (text || text !== '') {
-                        if (this.output.length && this.output[this.output.length - 1] === '\n') {
+                        if (!this.output.length || this.output[this.output.length - 1] === '\n') {
                             this.print_indentation(this.output);
                             text = ltrim(text);
                         }

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -43,6 +43,7 @@
     indent_inner_html (default false)  — indent <head> and <body> sections,
     indent_size (default 4)          — indentation size,
     indent_char (default space)      — character to indent with,
+    indent_level (default 0)         — the initial indent level,
     wrap_line_length (default 250)            -  maximum amount of characters per line (0 = disable)
     brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none"
             put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.
@@ -116,6 +117,7 @@
             indent_head_inner_html,
             indent_size,
             indent_character,
+            indent_level,
             wrap_line_length,
             brace_style,
             unformatted,
@@ -149,6 +151,7 @@
         indent_head_inner_html = (options.indent_head_inner_html === undefined) ? true : options.indent_head_inner_html;
         indent_size = (options.indent_size === undefined) ? 4 : parseInt(options.indent_size, 10);
         indent_character = (options.indent_char === undefined) ? ' ' : options.indent_char;
+        indent_level = (options.indent_level === undefined) ? 0 : parseInt(options.indent_level, 10);
         brace_style = (options.brace_style === undefined) ? 'collapse' : options.brace_style;
         wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
         unformatted = options.unformatted || [
@@ -853,7 +856,7 @@
                 this.indent_string = '';
                 this.indent_size = indent_size;
                 this.brace_style = brace_style;
-                this.indent_level = 0;
+                this.indent_level = indent_level;
                 this.wrap_line_length = wrap_line_length;
                 this.line_char_count = 0; //count to see if wrap_line_length was exceeded
 

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -2776,6 +2776,22 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
+        // Indent with initial level
+        reset_options();
+        opts.indent_level = 1;
+        test_fragment(
+            '<div>\n' +
+            '<div>\n' +
+            '</div>\n' +
+            '</div>',
+            //  -- output --
+            '    <div>\n' +
+            '        <div>\n' +
+            '        </div>\n' +
+            '    </div>');
+
+
+        //============================================================
         // Indent body inner html by default
         reset_options();
         test_fragment(

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -926,6 +926,23 @@ exports.test_data = {
                 '</div>'
         }]
     }, {
+        name: "Indent with initial level",
+        description: "",
+        options: [
+            { name: 'indent_level', value: "1" }
+        ],
+        tests: [{
+            fragment: true,
+            input_: '<div>\n' +
+                '<div>\n' +
+                '</div>\n' +
+                '</div>',
+            output: '    <div>\n' +
+                '        <div>\n' +
+                '        </div>\n' +
+                '    </div>'
+        }]
+    }, {
         name: "Indent body inner html by default",
         description: "",
         tests: [{


### PR DESCRIPTION
Allows specifying the initial indentation level to be used. Typically when formatting a full document that is 0, but when formatting a snippet of HTML that should be inserted in an existing document or formatting a range of a document ('format selection') it is useful to be able to get an initial indent greater than 0.