### PR TITLE
Don't publish unnessessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
 **/*
 !js/
-!README.md
-!LICENSE
-!CHANGELOG.md
 !CONTRIBUTING.MD
+# README, LICENSE, CHANGELOG and package.json are always added

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
-Makefile
-index.html
-php/
-python/
-web/
+**/*
+!js/
+!README.md
+!LICENSE
+!CHANGELOG.md
+!CONTRIBUTING.MD


### PR DESCRIPTION
By ignoring everything at the start of the npmignore and then excluding the files you actually need, you can reduce your node_modules foodprint.

The difference:

| What | Current size | New size | Difference |
|-----:|:--------:|:-----:|:----:|
|node_modules| 2.18 MB | 1.57 MB | 38.85% |
| js-beautify folder | 1.27 MB | 674 KB | 46.93% |
| zipped | 656 KB | 416 KB | 36.58% |

If js-beautify would be downloaded 1.3 milion times in the month after this is released, it would save about 312 GB of traffic due to the smaller zip size.
