### PR TITLE
Whitespace between async and arrow function

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -878,8 +878,8 @@ function Beautifier(js_source_text, options) {
             }
         }
 
-        // Should be a space between await and an IIFE
-        if (current_token.text === '(' && last_type === 'TK_RESERVED' && flags.last_word === 'await') {
+        // Should be a space between await and an IIFE, or async and an arrow function
+        if (current_token.text === '(' && last_type === 'TK_RESERVED' && in_array(flags.last_word, ['await', 'async'])) {
             output.space_before_token = true;
         }
 

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -646,8 +646,8 @@ function Beautifier(js_source_text, options) {
             }
         }
 
-        // Should be a space between await and an IIFE
-        if (current_token.text === '(' && last_type === 'TK_RESERVED' && flags.last_word === 'await') {
+        // Should be a space between await and an IIFE, or async and an arrow function
+        if (current_token.text === '(' && last_type === 'TK_RESERVED' && in_array(flags.last_word, ['await', 'async'])) {
             output.space_before_token = true;
         }
 

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -1725,6 +1725,12 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         
         // ensure that this doesn't break anyone with the async library
         bt('async.map(function(t) {})');
+        
+        // async on arrow function. should have a space after async
+        bt(
+            'async() => {}',
+            //  -- output --
+            'async () => {}');
 
 
         //============================================================

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -1731,6 +1731,38 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             'async() => {}',
             //  -- output --
             'async () => {}');
+        
+        // async on arrow function. should have a space after async
+        bt(
+            'async() => {\n' +
+            '    return 5;\n' +
+            '}',
+            //  -- output --
+            'async () => {\n' +
+            '    return 5;\n' +
+            '}');
+        
+        // async on arrow function returning expression. should have a space after async
+        bt(
+            'async() => 5;',
+            //  -- output --
+            'async () => 5;');
+        
+        // async on arrow function returning object literal. should have a space after async
+        bt(
+            'async(x) => ({\n' +
+            '    foo: "5"\n' +
+            '})',
+            //  -- output --
+            'async (x) => ({\n' +
+            '    foo: "5"\n' +
+            '})');
+        bt(
+            'async (x) => {\n' +
+            '    return x * 2;\n' +
+            '}');
+        bt('async () => 5;');
+        bt('async x => x * 2;');
 
 
         //============================================================

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -480,7 +480,7 @@ class Beautifier:
             # TODO: option space_before_conditional
             self.output.space_before_token = True
 
-        elif current_token.text == '(' and self.last_type == 'TK_RESERVED' and self.flags.last_word == 'await':
+        elif current_token.text == '(' and self.last_type == 'TK_RESERVED' and self.flags.last_word in ['await', 'async']:
             self.output.space_before_token = True
 
 

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -1559,6 +1559,38 @@ class TestJSBeautifier(unittest.TestCase):
             'async() => {}',
             #  -- output --
             'async () => {}')
+        
+        # async on arrow function. should have a space after async
+        bt(
+            'async() => {\n' +
+            '    return 5;\n' +
+            '}',
+            #  -- output --
+            'async () => {\n' +
+            '    return 5;\n' +
+            '}')
+        
+        # async on arrow function returning expression. should have a space after async
+        bt(
+            'async() => 5;',
+            #  -- output --
+            'async () => 5;')
+        
+        # async on arrow function returning object literal. should have a space after async
+        bt(
+            'async(x) => ({\n' +
+            '    foo: "5"\n' +
+            '})',
+            #  -- output --
+            'async (x) => ({\n' +
+            '    foo: "5"\n' +
+            '})')
+        bt(
+            'async (x) => {\n' +
+            '    return x * 2;\n' +
+            '}')
+        bt('async () => 5;')
+        bt('async x => x * 2;')
 
 
         #============================================================

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -1553,6 +1553,12 @@ class TestJSBeautifier(unittest.TestCase):
         
         # ensure that this doesn't break anyone with the async library
         bt('async.map(function(t) {})')
+        
+        # async on arrow function. should have a space after async
+        bt(
+            'async() => {}',
+            #  -- output --
+            'async () => {}')
 
 
         #============================================================

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -793,6 +793,11 @@ exports.test_data = {
             {
                 comment: "ensure that this doesn't break anyone with the async library",
                 unchanged: "async.map(function(t) {})"
+            },
+            {
+                comment: "async on arrow function. should have a space after async",
+                input_: "async() => {}",
+                output: "async () => {}"
             }
         ]
     }, {

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -798,6 +798,30 @@ exports.test_data = {
                 comment: "async on arrow function. should have a space after async",
                 input_: "async() => {}",
                 output: "async () => {}"
+            },
+            {
+                comment: "async on arrow function. should have a space after async",
+                input_: "async() => {\n    return 5;\n}",
+                output: "async () => {\n    return 5;\n}"
+            },
+            {
+                comment: "async on arrow function returning expression. should have a space after async",
+                input_: "async() => 5;",
+                output: "async () => 5;"
+            },
+            {
+                comment: "async on arrow function returning object literal. should have a space after async",
+                input_: "async(x) => ({\n    foo: \"5\"\n})",
+                output: "async (x) => ({\n    foo: \"5\"\n})"
+            },
+            {
+                unchanged: "async (x) => {\n    return x * 2;\n}"
+            },
+            {
+                unchanged: "async () => 5;"
+            },
+            {
+                unchanged: "async x => x * 2;"
             }
         ]
     }, {


### PR DESCRIPTION
Adds whitespace between `async` and an arrow function:

*Input*
`async() => {}`

*Output*
`async () => {}`

Addresses #896 and #1187 and is a continuation of #977