### PR TITLE
Made brace_style option more inclusive

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -425,15 +425,22 @@ function Beautifier(js_source_text, options) {
         options.brace_style = "collapse,preserve-inline";
     } else if (options.braces_on_own_line !== undefined) { //graceful handling of deprecated option
         options.brace_style = options.braces_on_own_line ? "expand" : "collapse";
-    } else if (!options.brace_style) //Nothing exists to set it
-    {
+    } else if (!options.brace_style) { //Nothing exists to set it
         options.brace_style = "collapse";
     }
 
-
+    //preserve-inline in delimited string will trigger brace_preserve_inline, everything
+    //else is considered a brace_style and the last one only will have an effect
     var brace_style_split = options.brace_style.split(/[^a-zA-Z0-9_\-]+/);
-    opt.brace_style = brace_style_split[0];
-    opt.brace_preserve_inline = brace_style_split[1] ? brace_style_split[1] : false;
+    opt.brace_preserve_inline = false; //Defaults in case one or other was not specified in meta-option
+    opt.brace_style = "collapse";
+    for (var bs = 0; bs < brace_style_split.length; bs++) {
+        if (brace_style_split[bs] === "preserve-inline") {
+            opt.brace_preserve_inline = true;
+        } else {
+            opt.brace_style = brace_style_split[bs];
+        }
+    }
 
     opt.indent_size = options.indent_size ? parseInt(options.indent_size, 10) : 4;
     opt.indent_char = options.indent_char ? options.indent_char : ' ';

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -47,14 +47,14 @@ nopt.typeDefs.brace_style = {
         data[key] = val;
         // TODO: expand-strict is obsolete, now identical to expand.  Remove in future version
         // TODO: collapse-preserve-inline is obselete, now identical to collapse,preserve-inline = true. Remove in future version
-        var validVals = ["collapse", "collapse-preserve-inline", "expand", "end-expand", "expand-strict", "none"];
-        var valSplit = val.split(/[^a-zA-Z0-9_\-]+/);
-        for (var i = 0; i < validVals.length; i++) {
-            if (validVals[i] === val || validVals[i] === valSplit[0] && valSplit[1] === "preserve-inline") {
-                return true;
+        var validVals = ["collapse", "collapse-preserve-inline", "expand", "end-expand", "expand-strict", "none", "preserve-inline"];
+        var valSplit = val.split(/[^a-zA-Z0-9_\-]+/); //Split will always return at least one parameter
+        for (var i = 0; i < valSplit.length; i++) {
+            if (validVals.indexOf(valSplit[i]) === -1) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 };
 var path = require('path'),

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -41,6 +41,9 @@ var fs = require('fs'),
     beautify = require('../index'),
     mkdirp = require('mkdirp'),
     nopt = require('nopt');
+nopt.invalidHandler = function(key, val, types) {
+    throw new Error(key + " was invalid with value \"" + val + "\"");
+}
 nopt.typeDefs.brace_style = {
     type: "brace_style",
     validate: function(data, key, val) {

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -193,15 +193,22 @@ function Beautifier(js_source_text, options) {
         options.brace_style = "collapse,preserve-inline";
     } else if (options.braces_on_own_line !== undefined) { //graceful handling of deprecated option
         options.brace_style = options.braces_on_own_line ? "expand" : "collapse";
-    } else if (!options.brace_style) //Nothing exists to set it
-    {
+    } else if (!options.brace_style) { //Nothing exists to set it
         options.brace_style = "collapse";
     }
 
-
+    //preserve-inline in delimited string will trigger brace_preserve_inline, everything
+    //else is considered a brace_style and the last one only will have an effect
     var brace_style_split = options.brace_style.split(/[^a-zA-Z0-9_\-]+/);
-    opt.brace_style = brace_style_split[0];
-    opt.brace_preserve_inline = brace_style_split[1] ? brace_style_split[1] : false;
+    opt.brace_preserve_inline = false; //Defaults in case one or other was not specified in meta-option
+    opt.brace_style = "collapse";
+    for (var bs = 0; bs < brace_style_split.length; bs++) {
+        if (brace_style_split[bs] === "preserve-inline") {
+            opt.brace_preserve_inline = true;
+        } else {
+            opt.brace_style = brace_style_split[bs];
+        }
+    }
 
     opt.indent_size = options.indent_size ? parseInt(options.indent_size, 10) : 4;
     opt.indent_char = options.indent_char ? options.indent_char : ' ';

--- a/js/test/shell-smoke-test.sh
+++ b/js/test/shell-smoke-test.sh
@@ -343,15 +343,15 @@ test_cli_js_beautify()
   #meta-parameter brace_style
   $CLI_SCRIPT -b 'invalid' $TEST_TEMP/example1-default.js > /dev/null && {
     echo "[$CLI_SCRIPT_NAME -b 'invalid' $TEST_TEMP/example1-default.js] Return code for invalid brace_style meta-parameter should be error."
-    exit 1
+    cleanup 1
   }
   $CLI_SCRIPT -b 'expand,preserve-inline,invalid' $TEST_TEMP/example1-default.js > /dev/null && {
     echo "[$CLI_SCRIPT_NAME -b 'expand,preserve-inline,invalid' $TEST_TEMP/example1-default.js] Return code for invalid brace_style meta-parameter should be error."
-    exit 1
+    cleanup 1
   }
   $CLI_SCRIPT -b 'preserve-inline' $TEST_TEMP/example1-default.js > /dev/null || {
     echo "[$CLI_SCRIPT_NAME -b 'preserve-inline' $TEST_TEMP/example1-default.js] Return code for only one part of valid brace_style meta-parameter should be success (uses default where it can)."
-    exit 1
+    cleanup 1
   }
 
   cleanup

--- a/js/test/shell-smoke-test.sh
+++ b/js/test/shell-smoke-test.sh
@@ -55,7 +55,6 @@ test_cli_common()
       echo "[$CLI_SCRIPT_NAME $MISSING_FILE] Stdout should have no text."
       exit 1
   fi
-
 }
 
 setup_temp()
@@ -339,6 +338,20 @@ test_cli_js_beautify()
   $CLI_SCRIPT $TEST_TEMP/example1-default.js | diff -q $TEST_TEMP/example1-default.js - && {
       echo "js-beautify output for $TEST_TEMP/example1-default.js was expected to be different based on USERPROFILE settings."
       cleanup 1
+  }
+
+  #meta-parameter brace_style
+  $CLI_SCRIPT -b 'invalid' $TEST_TEMP/example1-default.js > /dev/null && {
+    echo "[$CLI_SCRIPT_NAME -b 'invalid' $TEST_TEMP/example1-default.js] Return code for invalid brace_style meta-parameter should be error."
+    exit 1
+  }
+  $CLI_SCRIPT -b 'expand,preserve-inline,invalid' $TEST_TEMP/example1-default.js > /dev/null && {
+    echo "[$CLI_SCRIPT_NAME -b 'expand,preserve-inline,invalid' $TEST_TEMP/example1-default.js] Return code for invalid brace_style meta-parameter should be error."
+    exit 1
+  }
+  $CLI_SCRIPT -b 'preserve-inline' $TEST_TEMP/example1-default.js > /dev/null || {
+    echo "[$CLI_SCRIPT_NAME -b 'preserve-inline' $TEST_TEMP/example1-default.js] Return code for only one part of valid brace_style meta-parameter should be success (uses default where it can)."
+    exit 1
   }
 
   cleanup

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -173,15 +173,23 @@ class Beautifier:
         if self.opts.brace_style == 'collapse-preserve-inline':
             self.opts.brace_style = 'collapse,preserve-inline'
 
+        #split always returns at least one value
         split = re.compile("[^a-zA-Z0-9_\-]+").split(self.opts.brace_style)
-        self.opts.brace_style = split[0]
-        self.opts.brace_preserve_inline = (True if bool(split[1] == 'preserve-inline') else None) if len(split) > 1 else False
-
-        if self.opts.brace_style not in ['expand', 'collapse', 'end-expand', 'none']:
-            raise(Exception('opts.brace_style must be "expand", "collapse", "end-expand", or "none".'))
-
-        if self.opts.brace_preserve_inline == None:
-            raise(Exception('opts.brace_style second item must be "preserve-inline"'))
+        #preserve-inline in delimited string will trigger brace_preserve_inline
+        #Everything else is considered a brace_style and the last one only will
+        #have an effect
+        #specify defaults in case one half of meta-option is missing
+        self.opts.brace_style = "collapse"
+        self.opts.brace_preserve_inline = False
+        for bs in split:
+            if bs == "preserve-inline":
+                self.opts.brace_preserve_inline = True
+            else:
+                #validate each brace_style that's not a preserve-inline
+                #(results in very similar validation as js version)
+                if bs not in ['expand', 'collapse', 'end-expand', 'none']:
+                    raise(Exception('opts.brace_style must be "expand", "collapse", "end-expand", or "none".'))
+                self.opts.brace_style = bs
 
         s = self.blank_state(s)
 

--- a/python/jsbeautifier/tests/shell-smoke-test.sh
+++ b/python/jsbeautifier/tests/shell-smoke-test.sh
@@ -54,7 +54,6 @@ test_cli_common()
         echo "[$CLI_SCRIPT_NAME $MISSING_FILE] Stdout should have no text."
         exit 1
     fi
-
 }
 
 setup_temp()
@@ -289,6 +288,20 @@ test_cli_js_beautify()
     $CLI_SCRIPT $SCRIPT_DIR/../../../js/bin/css-beautify.js | diff -q $SCRIPT_DIR/../../../js/bin/css-beautify.js - && {
         echo "js-beautify output for $SCRIPT_DIR/../../../js/bin/css-beautify.js was expected to be different."
         cleanup 1
+    }
+
+    #meta-parameter brace_style
+    $CLI_SCRIPT -b 'invalid' $TEST_TEMP/js-beautify.js > /dev/null && {
+        echo "[$CLI_SCRIPT_NAME -b 'invalid' $TEST_TEMP/js-beautify.js] Return code for invalid brace_style meta-parameter should be error."
+        exit 1
+    }
+    $CLI_SCRIPT -b 'expand,preserve-inline,invalid' $TEST_TEMP/js-beautify.js > /dev/null && {
+        echo "[$CLI_SCRIPT_NAME -b 'expand,preserve-inline,invalid' $TEST_TEMP/js-beautify.js] Return code for invalid brace_style meta-parameter should be error."
+        exit 1
+    }
+    $CLI_SCRIPT -b 'preserve-inline' $TEST_TEMP/js-beautify.js > /dev/null || {
+        echo "[$CLI_SCRIPT_NAME -b 'preserve-inline' $TEST_TEMP/js-beautify.js] Return code for only one part of valid brace_style meta-parameter should be success (uses default where it can)."
+        exit 1
     }
 
     cleanup

--- a/python/jsbeautifier/tests/shell-smoke-test.sh
+++ b/python/jsbeautifier/tests/shell-smoke-test.sh
@@ -291,17 +291,18 @@ test_cli_js_beautify()
     }
 
     #meta-parameter brace_style
-    $CLI_SCRIPT -b 'invalid' $TEST_TEMP/js-beautify.js > /dev/null && {
-        echo "[$CLI_SCRIPT_NAME -b 'invalid' $TEST_TEMP/js-beautify.js] Return code for invalid brace_style meta-parameter should be error."
-        exit 1
+    cp ../js/test/resources/example1.js $TEST_TEMP/example.js
+    $CLI_SCRIPT --brace-style=invalid $TEST_TEMP/example.js > /dev/null && {
+        echo "[$CLI_SCRIPT_NAME --brace-style=invalid $TEST_TEMP/example.js] Return code for invalid brace_style meta-parameter should be error."
+        cleanup 1
     }
-    $CLI_SCRIPT -b 'expand,preserve-inline,invalid' $TEST_TEMP/js-beautify.js > /dev/null && {
-        echo "[$CLI_SCRIPT_NAME -b 'expand,preserve-inline,invalid' $TEST_TEMP/js-beautify.js] Return code for invalid brace_style meta-parameter should be error."
-        exit 1
+    $CLI_SCRIPT --brace-style=expand,preserve-inline,invalid 'expand,preserve-inline,invalid' $TEST_TEMP/example.js > /dev/null && {
+        echo "[$CLI_SCRIPT_NAME --brace-style=expand,preserve-inline,invalid $TEST_TEMP/example.js] Return code for invalid brace_style meta-parameter should be error."
+        cleanup 1
     }
-    $CLI_SCRIPT -b 'preserve-inline' $TEST_TEMP/js-beautify.js > /dev/null || {
-        echo "[$CLI_SCRIPT_NAME -b 'preserve-inline' $TEST_TEMP/js-beautify.js] Return code for only one part of valid brace_style meta-parameter should be success (uses default where it can)."
-        exit 1
+    $CLI_SCRIPT --brace-style=preserve-inline $TEST_TEMP/example.js > /dev/null || {
+        echo "[$CLI_SCRIPT_NAME --brace-style=preserve-inline $TEST_TEMP/example.js] Return code for only one part of valid brace_style meta-parameter should be success (uses default where it can)."
+        cleanup 1
     }
 
     cleanup


### PR DESCRIPTION
Per the discussion of https://github.com/beautify-web/js-beautify/pull/1058, the `brace_style` option has been made more inclusive. Also 3 shell tests have been added.

* Accepts `expand,collapse,preserve-inline` as `collapse,preserve-inline`
* Accepts `preserve-inline` as `collapse,preserve-inline` (uses the default `brace_style` `collapse`+ user specified `preserve-inline`)
* Accepts `preserve-inline,collapse` as `preserve-inline`
* Rejects `invalid,preserve-line,collapse` as invalid

Whereas in the previous version these would all reject as invalid.