### PR TITLE
Whitespace before '!important'

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -584,7 +584,9 @@ function Beautifier(source_text, options) {
                 if (whiteRe.test(ch)) {
                     ch = '';
                 }
-
+            } else if (ch === '!') { // !important
+                print_string(' ');
+                print_string(ch);
             } else {
                 preserveSingleSpace(isAfterSpace);
                 print_string(ch);

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -445,7 +445,9 @@ function Beautifier(source_text, options) {
                 if (whiteRe.test(ch)) {
                     ch = '';
                 }
-
+            } else if (ch === '!') { // !important
+                print_string(' ');
+                print_string(ch);
             } else {
                 preserveSingleSpace(isAfterSpace);
                 print_string(ch);

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -1252,6 +1252,31 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
 
 
         //============================================================
+        // Important 
+        reset_options();
+        t(
+            'a {\n' +
+            '\tcolor: blue  !important;\n' +
+            '}',
+            //  -- output --
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}');
+        t(
+            'a {\n' +
+            '\tcolor: blue!important;\n' +
+            '}',
+            //  -- output --
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}');
+        t(
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}');
+
+
+        //============================================================
         // 
         reset_options();
 

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -443,7 +443,7 @@ class Beautifier:
                 printer.print_string('=')
                 if WHITE_RE.search(self.ch):
                     self.ch = ''
-            elif self.ch == '!': # !important
+            elif self.ch == '!':  # !important
                 printer.print_string(' ')
                 printer.print_string(self.ch)
             else:

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -443,6 +443,9 @@ class Beautifier:
                 printer.print_string('=')
                 if WHITE_RE.search(self.ch):
                     self.ch = ''
+            elif self.ch == '!': # !important
+                printer.print_string(' ')
+                printer.print_string(self.ch)
             else:
                 printer.preserveSingleSpace(isAfterSpace)
                 printer.print_string(self.ch)

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -1210,6 +1210,31 @@ class CSSBeautifierTest(unittest.TestCase):
 
 
         #============================================================
+        # Important 
+        self.reset_options();
+        t(
+            'a {\n' +
+            '\tcolor: blue  !important;\n' +
+            '}',
+            #  -- output --
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}')
+        t(
+            'a {\n' +
+            '\tcolor: blue!important;\n' +
+            '}',
+            #  -- output --
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}')
+        t(
+            'a {\n' +
+            '\tcolor: blue !important;\n' +
+            '}')
+
+
+        #============================================================
         # 
         self.reset_options();
 

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -439,6 +439,19 @@ exports.test_data = {
                 ]
             }]
         }, {
+            name: "Important ",
+            description: "Spacing of !important",
+            options: [],
+            tests: [{
+                input: 'a {\n\tcolor: blue  !important;\n}',
+                output: 'a {\n\tcolor: blue !important;\n}'
+            }, {
+                input: 'a {\n\tcolor: blue!important;\n}',
+                output: 'a {\n\tcolor: blue !important;\n}'
+            }, {
+                unchanged: 'a {\n\tcolor: blue !important;\n}'
+            }]
+        }, {
 
         }
     ]


### PR DESCRIPTION
fixes #1273

Before:
```css
a {
    color: blue!important;
}

a {
    color: blue !important;
}

a {
    color: blue          !important;
}
```

After:
```css
a {
    color: blue !important;
}
```