### PR TITLE
Add 'aligned' option that align attributes after specific line length…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as well as deobfuscate scripts processed by
 # Contributors Needed
 I'm putting this front and center above because existing owners have very limited time to work on this project currently.
 This is a popular project and widely used but it desperately needs contributors who have time to commit to fixing both
-customer facing bugs and underlying problems with the internal design and implementation.  
+customer facing bugs and underlying problems with the internal design and implementation.
 
 If you are interested, please take a look at the [CONTRIBUTING.md](https://github.com/beautify-web/js-beautify/blob/master/CONTRIBUTING.md) then fix an issue marked with the ["Good first issue"](https://github.com/beautify-web/js-beautify/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label and submit a PR. Repeat as often as possible.  Thanks!
 
@@ -94,7 +94,7 @@ You can also use `js-beautify` as a `node` library (install locally, the `npm` d
 $ npm install js-beautify
 ```
 
-Import and call the appropriate beautifier method for javascript (js), css, or html.  All three method signatures are `beautify(code, options)`. `code` is the string of code to be beautified. options is an object with the settings you would like used to beautify the code.  
+Import and call the appropriate beautifier method for javascript (js), css, or html.  All three method signatures are `beautify(code, options)`. `code` is the string of code to be beautified. options is an object with the settings you would like used to beautify the code.
 
 The configuration option names are the same as the CLI names but with underscores instead of dashes.  For example, `--indent-size 2 --space-in-empty-paren` would be `{ indent_size: 2, space_in_empty_paren: true }`.
 
@@ -210,7 +210,7 @@ Configuration sources provided earlier in this stack will override later ones.
 
 The settings are a shallow tree whose values are inherited for all languages, but
 can be overridden.  This works for settings passed directly to the API in either implementation.
-In the Javascript implementation, settings loaded from a config file, such as .jsbeautifyrc, can also use inheritance/overriding.  
+In the Javascript implementation, settings loaded from a config file, such as .jsbeautifyrc, can also use inheritance/overriding.
 
 Below is an example configuration tree showing all the supported locations
 for language override nodes.  We'll use `indent_size` to discuss how this configuration would behave, but any number of settings can be inherited or overridden:
@@ -239,7 +239,7 @@ for language override nodes.  We'll use `indent_size` to discuss how this config
 Using the above example would have the following result:
 
 * HTML files
-  * Inherit `indent_size` of 4 spaces from the top-level setting.  
+  * Inherit `indent_size` of 4 spaces from the top-level setting.
   * The files would also end with a newline.
   * JavaScript and CSS inside HTML
     * Inherit the HTML `end_with_newline` setting.
@@ -289,8 +289,8 @@ HTML Beautifier Options:
   -b, --brace-style                  [collapse-preserve-inline|collapse|expand|end-expand|none] ["collapse"]
   -S, --indent-scripts               [keep|separate|normal] ["normal"]
   -w, --wrap-line-length             Maximum characters per line (0 disables) [250]
-  -A, --wrap-attributes              Wrap attributes to new lines [auto|force|force-aligned|force-expand-multiline] ["auto"]
-  -i, --wrap-attributes-indent-size  Indent wrapped attributes to after N characters [indent-size] (ignored if wrap-attributes is "force-aligned")
+  -A, --wrap-attributes              Wrap attributes to new lines [auto|force|force-aligned|force-expand-multiline|aligned-multiple] ["auto"]
+  -i, --wrap-attributes-indent-size  Indent wrapped attributes to after N characters [indent-size] (ignored if wrap-attributes is "aligned")
   -d, --inline                       List of tags to be considered inline tags
   -U, --unformatted                  List of tags (defaults to inline) that should not be reformatted
   -T, --content_unformatted          List of tags (defaults to pre) whose content should not be reformatted

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -277,7 +277,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         is_wrap_attributes_force,
         is_wrap_attributes_force_expand_multiline,
         is_wrap_attributes_force_aligned,
-        is_wrap_attributes_aligned,
+        is_wrap_attributes_aligned_multiple,
         end_with_newline,
         extra_liners,
         eol;
@@ -324,7 +324,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     is_wrap_attributes_force = wrap_attributes.substr(0, 'force'.length) === 'force';
     is_wrap_attributes_force_expand_multiline = (wrap_attributes === 'force-expand-multiline');
     is_wrap_attributes_force_aligned = (wrap_attributes === 'force-aligned');
-    is_wrap_attributes_aligned = (wrap_attributes === 'aligned');
+    is_wrap_attributes_aligned_multiple = (wrap_attributes === 'aligned-multiple');
     end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
     extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
         options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
@@ -663,7 +663,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
                         //indent attributes an auto, forced, aligned or forced-align line-wrap
                         var alignment_size = wrap_attributes_indent_size;
-                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned) {
+                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned_multiple) {
                             alignment_size = content.indexOf(' ') + 1;
                         }
 

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -277,6 +277,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         is_wrap_attributes_force,
         is_wrap_attributes_force_expand_multiline,
         is_wrap_attributes_force_aligned,
+        is_wrap_attributes_aligned,
         end_with_newline,
         extra_liners,
         eol;
@@ -323,6 +324,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     is_wrap_attributes_force = wrap_attributes.substr(0, 'force'.length) === 'force';
     is_wrap_attributes_force_expand_multiline = (wrap_attributes === 'force-expand-multiline');
     is_wrap_attributes_force_aligned = (wrap_attributes === 'force-aligned');
+    is_wrap_attributes_aligned = (wrap_attributes === 'aligned');
     end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
     extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
         options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
@@ -659,9 +661,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     if (indentAttrs) {
                         has_wrapped_attrs = true;
 
-                        //indent attributes an auto, forced, or forced-align line-wrap
+                        //indent attributes an auto, forced, aligned or forced-align line-wrap
                         var alignment_size = wrap_attributes_indent_size;
-                        if (is_wrap_attributes_force_aligned) {
+                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned) {
                             alignment_size = content.indexOf(' ') + 1;
                         }
 

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -69,6 +69,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         is_wrap_attributes_force,
         is_wrap_attributes_force_expand_multiline,
         is_wrap_attributes_force_aligned,
+        is_wrap_attributes_aligned,
         end_with_newline,
         extra_liners,
         eol;
@@ -115,6 +116,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     is_wrap_attributes_force = wrap_attributes.substr(0, 'force'.length) === 'force';
     is_wrap_attributes_force_expand_multiline = (wrap_attributes === 'force-expand-multiline');
     is_wrap_attributes_force_aligned = (wrap_attributes === 'force-aligned');
+    is_wrap_attributes_aligned = (wrap_attributes === 'aligned');
     end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
     extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
         options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
@@ -451,9 +453,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     if (indentAttrs) {
                         has_wrapped_attrs = true;
 
-                        //indent attributes an auto, forced, or forced-align line-wrap
+                        //indent attributes an auto, forced, aligned or forced-align line-wrap
                         var alignment_size = wrap_attributes_indent_size;
-                        if (is_wrap_attributes_force_aligned) {
+                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned) {
                             alignment_size = content.indexOf(' ') + 1;
                         }
 

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -69,7 +69,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         is_wrap_attributes_force,
         is_wrap_attributes_force_expand_multiline,
         is_wrap_attributes_force_aligned,
-        is_wrap_attributes_aligned,
+        is_wrap_attributes_aligned_multiple,
         end_with_newline,
         extra_liners,
         eol;
@@ -116,7 +116,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     is_wrap_attributes_force = wrap_attributes.substr(0, 'force'.length) === 'force';
     is_wrap_attributes_force_expand_multiline = (wrap_attributes === 'force-expand-multiline');
     is_wrap_attributes_force_aligned = (wrap_attributes === 'force-aligned');
-    is_wrap_attributes_aligned = (wrap_attributes === 'aligned');
+    is_wrap_attributes_aligned_multiple = (wrap_attributes === 'aligned-multiple');
     end_with_newline = (options.end_with_newline === undefined) ? false : options.end_with_newline;
     extra_liners = (typeof options.extra_liners === 'object') && options.extra_liners ?
         options.extra_liners.concat() : (typeof options.extra_liners === 'string') ?
@@ -455,7 +455,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
                         //indent attributes an auto, forced, aligned or forced-align line-wrap
                         var alignment_size = wrap_attributes_indent_size;
-                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned) {
+                        if (is_wrap_attributes_force_aligned || is_wrap_attributes_aligned_multiple) {
                             alignment_size = content.indexOf(' ') + 1;
                         }
 

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -667,6 +667,45 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '      rel="stylesheet"\n' +
             '      type="text/css">');
 
+        // Attribute Wrap - (indent_attr = " ", indent_attr_first = " ", indent_end = "", indent_attr_aligned = " ", indent_end_selfclosing = " ", indent_over80 = "\n     ")
+        reset_options();
+        opts.wrap_attributes = 'aligned';
+        opts.wrap_line_length = 80;
+        test_fragment('<div  >This is some text</div>', '<div>This is some text</div>');
+        test_fragment('<div attr="123"  >This is some text</div>', '<div attr="123">This is some text</div>');
+        test_fragment('<div attr0 attr1="123" data-attr2="hello    t here">This is some text</div>');
+        test_fragment(
+            '<div lookatthissuperduperlongattributenamewhoahcrazy0="true" attr0 attr1="123" data-attr2="hello    t here" heymanimreallylongtoowhocomesupwiththesenames="false">This is some text</div>',
+            //  -- output --
+            '<div lookatthissuperduperlongattributenamewhoahcrazy0="true" attr0 attr1="123" data-attr2="hello    t here"\n' +
+            '     heymanimreallylongtoowhocomesupwiththesenames="false">This is some text</div>');
+        test_fragment('<img attr0 attr1="123" data-attr2="hello    t here"/>', '<img attr0 attr1="123" data-attr2="hello    t here" />');
+        test_fragment(
+            '<?xml version="1.0" encoding="UTF-8" ?><root attr1="foo" attr2="bar"/>',
+            //  -- output --
+            '<?xml version="1.0" encoding="UTF-8" ?>\n' +
+            '<root attr1="foo" attr2="bar" />');
+        test_fragment(
+            '<link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin" rel="stylesheet" type="text/css">',
+            //  -- output --
+            '<link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin"\n' +
+            '      rel="stylesheet" type="text/css">');
+
+        // Attribute Wrap - (indent_attr = " ", indent_attr_first = " ", indent_end = "", indent_end_selfclosing = " ", indent_over80 = " ")
+        reset_options();
+        opts.wrap_attributes = 'aligned';
+        test_fragment('<div  >This is some text</div>', '<div>This is some text</div>');
+        test_fragment('<div attr="123"  >This is some text</div>', '<div attr="123">This is some text</div>');
+        test_fragment('<div attr0 attr1="123" data-attr2="hello    t here">This is some text</div>');
+        test_fragment('<div lookatthissuperduperlongattributenamewhoahcrazy0="true" attr0 attr1="123" data-attr2="hello    t here" heymanimreallylongtoowhocomesupwiththesenames="false">This is some text</div>');
+        test_fragment('<img attr0 attr1="123" data-attr2="hello    t here"/>', '<img attr0 attr1="123" data-attr2="hello    t here" />');
+        test_fragment(
+            '<?xml version="1.0" encoding="UTF-8" ?><root attr1="foo" attr2="bar"/>',
+            //  -- output --
+            '<?xml version="1.0" encoding="UTF-8" ?>\n' +
+            '<root attr1="foo" attr2="bar" />');
+        test_fragment('<link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin" rel="stylesheet" type="text/css">');
+
         // Attribute Wrap - (indent_attr = "\n     ", indent_attr_faligned = " ", indent_attr_first = " ", indent_end = "", indent_end_selfclosing = " ", indent_over80 = "\n     ")
         reset_options();
         opts.wrap_attributes = 'force-aligned';

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -669,7 +669,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
         // Attribute Wrap - (indent_attr = " ", indent_attr_first = " ", indent_end = "", indent_attr_aligned = " ", indent_end_selfclosing = " ", indent_over80 = "\n     ")
         reset_options();
-        opts.wrap_attributes = 'aligned';
+        opts.wrap_attributes = 'aligned-multiple';
         opts.wrap_line_length = 80;
         test_fragment('<div  >This is some text</div>', '<div>This is some text</div>');
         test_fragment('<div attr="123"  >This is some text</div>', '<div attr="123">This is some text</div>');
@@ -693,7 +693,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
         // Attribute Wrap - (indent_attr = " ", indent_attr_first = " ", indent_end = "", indent_end_selfclosing = " ", indent_over80 = " ")
         reset_options();
-        opts.wrap_attributes = 'aligned';
+        opts.wrap_attributes = 'aligned-multiple';
         test_fragment('<div  >This is some text</div>', '<div>This is some text</div>');
         test_fragment('<div attr="123"  >This is some text</div>', '<div attr="123">This is some text</div>');
         test_fragment('<div attr0 attr1="123" data-attr2="hello    t here">This is some text</div>');

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -406,6 +406,26 @@ exports.test_data = {
             indent_over80: '\n     '
         }, {
             options: [
+                { name: "wrap_attributes", value: "'aligned'" },
+                { name: "wrap_line_length", value: "80" }
+            ],
+            indent_attr: ' ',
+            indent_attr_first: ' ',
+            indent_end: '',
+            indent_attr_aligned: ' ',
+            indent_end_selfclosing: ' ',
+            indent_over80: '\n     '
+        }, {
+            options: [
+                { name: "wrap_attributes", value: "'aligned'" },
+            ],
+            indent_attr: ' ',
+            indent_attr_first: ' ',
+            indent_end: '',
+            indent_end_selfclosing: ' ',
+            indent_over80: ' '
+        }, {
+            options: [
                 { name: "wrap_attributes", value: "'force-aligned'" },
                 { name: "wrap_attributes_indent_size", value: "8" }
             ],
@@ -474,7 +494,7 @@ exports.test_data = {
         }, {
             fragment: true,
             input: '<link href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin" rel="stylesheet" type="text/css">',
-            output: '<link{{indent_attr_first}}href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin"{{indent_over80}}{{indent_attr_faligned}}rel="stylesheet"{{indent_attr}}{{indent_attr_faligned}}type="text/css"{{indent_end}}>'
+            output: '<link{{indent_attr_first}}href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&amp;subset=latin"{{indent_over80}}{{indent_attr_faligned}}{{indent_attr_aligned}}rel="stylesheet"{{indent_attr}}{{indent_attr_faligned}}type="text/css"{{indent_end}}>'
         }]
     }, {
         name: "Handlebars Indenting Off",

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -406,7 +406,7 @@ exports.test_data = {
             indent_over80: '\n     '
         }, {
             options: [
-                { name: "wrap_attributes", value: "'aligned'" },
+                { name: "wrap_attributes", value: "'aligned-multiple'" },
                 { name: "wrap_line_length", value: "80" }
             ],
             indent_attr: ' ',
@@ -417,7 +417,7 @@ exports.test_data = {
             indent_over80: '\n     '
         }, {
             options: [
-                { name: "wrap_attributes", value: "'aligned'" },
+                { name: "wrap_attributes", value: "'aligned-multiple'" },
             ],
             indent_attr: ' ',
             indent_attr_first: ' ',


### PR DESCRIPTION
This PR is about requested soft-alignment feature of attributes alignment after and only after specific line length threshold is reached. 

related to https://github.com/beautify-web/js-beautify/issues/1262

Basically, this PR adds a new option that doesn't match 'is_wrap_attributes_force' condition (that forces line break after each attribute) but indents the attributes same way as  'is_wrap_attributes_force_aligned' if 'wrapped' is set to true by wrap_line_length. 

//At least, I suppose it does :)

As I said previously, I am not exactly an open source expert, so comments, guidance, and advice appreciated. 
(Hope that I understood how the test matrices work correctly too)

