### PR TITLE
css-beautify: python cssbeautifier cli

### DIFF
--- a/python/css-beautify
+++ b/python/css-beautify
@@ -1,0 +1,8 @@
+#! /usr/bin/env python
+#
+# Stub script to run cssbeautifier
+#
+import sys
+from cssbeautifier import main
+sys.exit(main())
+

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -25,9 +25,13 @@
 
 from __future__ import print_function
 import sys
+import os
+import io
 import re
 import copy
+import getopt
 from jsbeautifier.__version__ import __version__
+from jsbeautifier import isFileDifferent, mkdir_p
 from cssbeautifier.css.options import BeautifierOptions
 from cssbeautifier.css.beautifier import Beautifier
 
@@ -43,9 +47,18 @@ def beautify(string, opts=default_options()):
 
 def beautify_file(file_name, opts=default_options()):
     if file_name == '-':  # stdin
-        stream = sys.stdin
+        try:
+            if sys.stdin.isatty():
+                raise Exception()
+
+            stream = sys.stdin
+        except Exception as ex:
+            print("Must pipe input or define input file.\n", file=sys.stderr)
+            usage(sys.stderr)
+            raise Exception()
     else:
         stream = open(file_name)
+
     content = ''.join(stream.readlines())
     b = Beautifier(content, opts)
     return b.beautify()
@@ -57,8 +70,134 @@ def usage(stream=sys.stdout):
 
 CSS beautifier (http://jsbeautifier.org/)
 
+Usage: cssbeautifier.py [options] <infile>
+
+    <infile> can be "-", which means stdin.
+
+Input options:
+
+ -i,  --stdin                      Read input from stdin
+
+Output options:
+
+ -s,  --indent-size=NUMBER         Indentation size. (default 4).
+ -c,  --indent-char=CHAR           Character to indent with. (default space).
+ -e,  --eol=STRING                 Character(s) to use as line terminators.
+                                   (default first newline in file, otherwise "\\n")
+ -t,  --indent-with-tabs           Indent with tabs, overrides -s and -c
+      --preserve-newlines          Preserve existing line breaks.
+      --disable-selector-separator-newline
+                                   Do not print each selector on a separate line.
+ -n,  --end-with-newline           End output with newline
+      --disable-newline-between-rules
+                                   Do not print empty line between rules.
+      --space-around-combinator    Print spaces around combinator.
+ -r,  --replace                    Write output in-place, replacing input
+ -o,  --outfile=FILE               Specify a file to output to (default stdout)
+
+Rarely needed options:
+
+ -h,  --help, --usage              Prints this help statement.
+ -v,  --version                    Show the version
+
 """, file=stream)
     if stream == sys.stderr:
         return 1
     else:
         return 0
+
+def main():
+
+    argv = sys.argv[1:]
+
+    try:
+        opts, args = getopt.getopt(argv, "hvio:rs:c:e:tn",
+            ['help', 'usage', 'version', 'stdin', 'outfile=', 'replace',
+            'indent-size=', 'indent-char=', 'eol=', 'indent-with-tabs',
+            'preserve-newlines', 'disable-selector-separator-newline',
+            'end-with-newline', 'disable-newline-between-rules',
+            'space-around-combinator'])
+    except getopt.GetoptError as ex:
+        print(ex, file=sys.stderr)
+        return usage(sys.stderr)
+
+    css_options = default_options()
+
+    file = None
+    outfile = 'stdout'
+    replace = False
+    if len(args) == 1:
+        file = args[0]
+
+    for opt, arg in opts:
+        if opt in ('--stdin', '-i'):
+            file = '-'
+        elif opt in ('--outfile', '-o'):
+            outfile = arg
+        elif opt in ('--replace', '-r'):
+            replace = True
+        elif opt in ('--version', '-v'):
+            return print(__version__)
+        elif opt in ('--help', '--usage', '-h'):
+            return usage()
+
+        elif opt in ('--indent-size', '-s'):
+            css_options.indent_size = int(arg)
+        elif opt in ('--indent-char', '-c'):
+            css_options.indent_char = arg
+        elif opt in ('--eol', '-e'):
+            css_options.eol = arg
+        elif opt in ('--indent-with-tabs', '-t'):
+            css_options.indent_with_tabs = True
+        elif opt in ('--preserve-newlines'):
+            css_options.preserve_newlines = True
+        elif opt in ('--disable-selector-separator-newline'):
+            css_options.selector_separator_newline = False
+        elif opt in ('--end-with-newline', '-n'):
+            css_options.end_with_newline = True
+        elif opt in ('--disable-newline-between-rules'):
+            css_options.newline_between_rules = False
+        elif opt in ('--space-around-combinator'):
+            css_options.space_around_combinator = True
+
+
+    if not file:
+        file = '-'
+
+    try:
+        if outfile == 'stdout' and replace and not file == '-':
+            outfile = file
+
+        pretty = beautify_file(file, css_options)
+
+        if outfile == 'stdout':
+            # python automatically converts newlines in text to "\r\n" when on windows
+            # switch to binary to prevent this
+            if sys.platform == "win32":
+                import msvcrt
+                msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
+            sys.stdout.write(pretty)
+        else:
+            if isFileDifferent(outfile, pretty):
+                mkdir_p(os.path.dirname(outfile))
+
+                # python automatically converts newlines in text to "\r\n" when on windows
+                # set newline to empty to prevent this
+                with io.open(outfile, 'wt', newline='') as f:
+                    print('writing ' + outfile, file=sys.stderr)
+                    try:
+                        f.write(pretty)
+                    except TypeError:
+                        # This is not pretty, but given how we did the version import
+                        # it is the only way to do this without having setup.py fail on a missing six dependency.
+                        six = __import__("six")
+                        f.write(six.u(pretty))
+
+
+    except Exception as ex:
+        print(ex, file=sys.stderr)
+        return 1
+
+    # Success
+    return 0


### PR DESCRIPTION
This adds a command line tool for the python cssbeautifier.  It is based
on and re-uses as much code as possible from the js-beautify tool.

Long command line options make it possible to control all currently
implemented options in the CSS Beautifier.  Short command line options
are only supported for options that are identical to those of the
js-beautify tool.

Note that there is an inconsistency between the two tools caused by the
different default for the preserve_newlines option - True for
jsbeautifier and False for cssbeautifier, hence different command line
options --disable-preserve-newlines vs. --preserve-newlines.