### PR TITLE
Add support for GNU Sort being named `sort`

### DIFF
--- a/tools/generate-changelog.sh
+++ b/tools/generate-changelog.sh
@@ -15,20 +15,22 @@ main()
       exit 1
     fi
 
-    jq --version || {
+    local JQ
+    JQ=$(command -v jq) || {
       echo "Required tool 'jq' missing.  Failed."
       exit 1
     }
 
-    gsort --version || {
-      echo "Required tool 'gsort' missing.  Failed."
+    local GSORT
+    GSORT=$(command -v gsort || command -v sort) || {
+      echo "Required tool 'GNU sort' missing.  Failed."
       exit 1
     }
 
     IFS=$'\n'
     echo "# Changelog" > CHANGELOG.md
 
-    for m in $(curl -s "https://api.github.com/repos/$1/milestones?state=closed" | jq -c '.[] | [.title, .number, .description]' | gsort -r -V); do
+    for m in $(curl -s "https://api.github.com/repos/$1/milestones?state=closed" | "$JQ" -c '.[] | [.title, .number, .description]' | "$GSORT" -r -V); do
         mid=$(echo $m | sed 's/\[".*",\(.*\),".*"\]/\1/')
         title=$(echo $m | sed 's/\["\(.*\)",.*,".*"\]/\1/')
 
@@ -39,7 +41,7 @@ main()
         echo $m | sed 's/\[".*",.*,"\(.*\)"\]/\1/' | sed -e 's/\\"/"/g' | sed -e 's/\\r\\n/\\n/g' | sed -e 's/\\n/\'$'\n/g' >> CHANGELOG.md
         echo "" >> CHANGELOG.md
         echo '### Closed Issues' >> CHANGELOG.md
-        for i in $(curl -s "https://api.github.com/repos/$1/issues?milestone=$mid&state=closed" | jq -c '.[] | [.html_url, .number, .title]'); do
+        for i in $(curl -s "https://api.github.com/repos/$1/issues?milestone=$mid&state=closed" | "$JQ" -c '.[] | [.html_url, .number, .title]'); do
             echo $i | sed 's/\["\(.*\)",\(.*\),\"\(.*\)\"\]/* \3 ([#\2](\1))/' | sed 's/\\"/"/g' >> CHANGELOG.md
         done
         echo "" >> CHANGELOG.md


### PR DESCRIPTION
Closes issue [1314](https://github.com/beautify-web/js-beautify/issues/1314).
Successfully tested locally (README was identical before and after running).