### PR TITLE
issue-1156:fixed line break in mixins after background url

### DIFF
--- a/js/lib/beautify-css.js
+++ b/js/lib/beautify-css.js
@@ -540,6 +540,7 @@ function Beautifier(source_text, options) {
                             print_string(eatString(')'));
                         } else {
                             pos--;
+                            parenLevel++;
                         }
                     }
                 } else {

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -401,6 +401,7 @@ function Beautifier(source_text, options) {
                             print_string(eatString(')'));
                         } else {
                             pos--;
+                            parenLevel++;
                         }
                     }
                 } else {

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -1391,6 +1391,11 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         t("@myvar:10px;.tabs{width:10px;}", "@myvar: 10px;\n.tabs {\n\twidth: 10px;\n}");
         t("@myvar:10px; .tabs{width:10px;}", "@myvar: 10px;\n.tabs {\n\twidth: 10px;\n}");
 
+        //mixins
+        t("div{.px2rem(width,12);}", "div {\n\t.px2rem(width, 12);\n}");
+        // mixin next to 'background: url("...")' should not add a line break after the comma
+        t("div {\n\tbackground: url(\"//test.com/dummy.png\");\n\t.px2rem(width, 12);\n}");
+
         // test options
         opts.indent_size = 2;
         opts.indent_char = ' ';

--- a/test/data/css/node.mustache
+++ b/test/data/css/node.mustache
@@ -238,6 +238,11 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
         t("@myvar:10px;.tabs{width:10px;}", "@myvar: 10px;\n.tabs {\n\twidth: 10px;\n}");
         t("@myvar:10px; .tabs{width:10px;}", "@myvar: 10px;\n.tabs {\n\twidth: 10px;\n}");
 
+        //mixins
+        t("div{.px2rem(width,12);}", "div {\n\t.px2rem(width, 12);\n}");
+        // mixin next to 'background: url("...")' should not add a line break after the comma
+        t("div {\n\tbackground: url(\"//test.com/dummy.png\");\n\t.px2rem(width, 12);\n}");
+
         // test options
         opts.indent_size = 2;
         opts.indent_char = ' ';


### PR DESCRIPTION
Change-Id: I91fa77493eafb9de820eba802529dcf84ddd0170

See issue in:  https://github.com/beautify-web/js-beautify/issues/1156.

If "(" is detected, and it does not run in the eatString(')') block, parenLevel should always add 1.