### PR TITLE
1283 - Javascript ++ Operator Gets Wrong Indentation

### DIFF
--- a/js/lib/beautify.js
+++ b/js/lib/beautify.js
@@ -642,7 +642,7 @@ function Beautifier(js_source_text, options) {
 
     function print_newline(force_newline, preserve_statement_flags) {
         if (!preserve_statement_flags) {
-            if (flags.last_text !== ';' && flags.last_text !== ',' && flags.last_text !== '=' && last_type !== 'TK_OPERATOR') {
+            if (flags.last_text !== ';' && flags.last_text !== ',' && flags.last_text !== '=' && (last_type !== 'TK_OPERATOR' || flags.last_text === '--' || flags.last_text === '++')) {
                 var next_token = get_token(1);
                 while (flags.mode === MODE.Statement &&
                     !(flags.if_block && next_token && next_token.type === 'TK_RESERVED' && next_token.text === 'else') &&

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -410,7 +410,7 @@ function Beautifier(js_source_text, options) {
 
     function print_newline(force_newline, preserve_statement_flags) {
         if (!preserve_statement_flags) {
-            if (flags.last_text !== ';' && flags.last_text !== ',' && flags.last_text !== '=' && last_type !== 'TK_OPERATOR') {
+            if (flags.last_text !== ';' && flags.last_text !== ',' && flags.last_text !== '=' && (last_type !== 'TK_OPERATOR' || flags.last_text === '--' || flags.last_text === '++')) {
                 var next_token = get_token(1);
                 while (flags.mode === MODE.Statement &&
                     !(flags.if_block && next_token && next_token.type === 'TK_RESERVED' && next_token.text === 'else') &&

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -3744,6 +3744,26 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             'if (someCondition) {\n' +
             '    return something;\n' +
             '}');
+        
+        // Issue #1283 - Javascript ++ Operator get wrong indent 
+        bt(
+            '{this.foo++\n' +
+            'bar}',
+            //  -- output --
+            '{\n' +
+            '    this.foo++\n' +
+            '    bar\n' +
+            '}');
+        
+        // Issue #1283 - Javascript ++ Operator get wrong indent (2)
+        bt(
+            'axios.interceptors.request.use(\n' +
+            '    config => {\n' +
+            '        // loading\n' +
+            '        window.store.loading++\n' +
+            '        let extraParams = {}\n' +
+            '    }\n' +
+            ')');
 
 
         //============================================================

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -307,7 +307,7 @@ class Beautifier:
 
     def print_newline(self, force_newline = False, preserve_statement_flags = False):
         if not preserve_statement_flags:
-            if self.flags.last_text != ';' and self.flags.last_text != ',' and self.flags.last_text != '=' and self.last_type != 'TK_OPERATOR':
+            if self.flags.last_text != ';' and self.flags.last_text != ',' and self.flags.last_text != '=' and (self.last_type != 'TK_OPERATOR' or self.flags.last_text == '--' or self.flags.last_text == '++'):
                 next_token = self.get_token(1)
                 while (self.flags.mode == MODE.Statement and
                         not (self.flags.if_block and next_token and next_token.type == 'TK_RESERVED' and next_token.text == 'else') and

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -3572,6 +3572,26 @@ class TestJSBeautifier(unittest.TestCase):
             'if (someCondition) {\n' +
             '    return something;\n' +
             '}')
+        
+        # Issue #1283 - Javascript ++ Operator get wrong indent 
+        bt(
+            '{this.foo++\n' +
+            'bar}',
+            #  -- output --
+            '{\n' +
+            '    this.foo++\n' +
+            '    bar\n' +
+            '}')
+        
+        # Issue #1283 - Javascript ++ Operator get wrong indent (2)
+        bt(
+            'axios.interceptors.request.use(\n' +
+            '    config => {\n' +
+            '        // loading\n' +
+            '        window.store.loading++\n' +
+            '        let extraParams = {}\n' +
+            '    }\n' +
+            ')')
 
 
         #============================================================

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -2627,6 +2627,31 @@ exports.test_data = {
                     '    return something;',
                     '}'
                 ]
+            },
+            {
+                comment: "Issue #1283 - Javascript ++ Operator get wrong indent ",
+                input: [
+                    '{this.foo++',
+                    'bar}'
+                ],
+                output: [
+                    '{',
+                    '    this.foo++',
+                    '    bar',
+                    '}'
+                ]
+            },
+            {
+                comment: "Issue #1283 - Javascript ++ Operator get wrong indent (2)",
+                unchanged: [
+                    'axios.interceptors.request.use(',
+                    '    config => {',
+                    '        // loading',
+                    '        window.store.loading++',
+                    '        let extraParams = {}',
+                    '    }',
+                    ')'
+                ]
             }
         ]
     }, {


### PR DESCRIPTION
Resolves #1283

**What was done:**
 - Adapted function print_newline to restore mode if last_test was operator ++ or --
 - Added corresponding test.

**Example of behavior:**

```js
// == Input ==
{this.foo++
bar}

// == Expected Output ==
{
    this.foo++
    bar
}
```