### PR TITLE
Format inline HTML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ HTML Beautifier Options:
   -w, --wrap-line-length             Maximum characters per line (0 disables) [250]
   -A, --wrap-attributes              Wrap attributes to new lines [auto|force|force-aligned|force-expand-multiline] ["auto"]
   -i, --wrap-attributes-indent-size  Indent wrapped attributes to after N characters [indent-size] (ignored if wrap-attributes is "force-aligned")
+  -d, --inline                       List of tags to be considered inline tags
   -U, --unformatted                  List of tags (defaults to inline) that should not be reformatted
   -T, --content_unformatted          List of tags (defaults to pre) whose content should not be reformatted
   -E, --extra_liners                 List of tags (defaults to [head,body,/html] that should have an extra newline before them.

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -47,8 +47,9 @@
     wrap_line_length (default 250)            -  maximum amount of characters per line (0 = disable)
     brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none"
             put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.
+    inline (defaults to inline tags) - list of tags to be considered inline tags
     unformatted (defaults to inline tags) - list of tags, that shouldn't be reformatted
-    content_unformatted (defaults to pre tag) - list of tags, whose content shouldn't be reformatted
+    content_unformatted (defaults to ["pre", "textarea"] tags) - list of tags, whose content shouldn't be reformatted
     indent_scripts (default normal)  - "keep"|"separate"|"normal"
     preserve_newlines (default true) - whether existing line breaks before elements should be preserved
                                         Only works before elements, not inside tags or for text.
@@ -206,6 +207,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         indent_character,
         wrap_line_length,
         brace_style,
+        inline_tags,
         unformatted,
         content_unformatted,
         preserve_newlines,
@@ -237,7 +239,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     indent_character = (options.indent_char === undefined) ? ' ' : options.indent_char;
     brace_style = (options.brace_style === undefined) ? 'collapse' : options.brace_style;
     wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
-    unformatted = options.unformatted || [
+    inline_tags = options.inline || [
         // https://www.w3.org/TR/html5/dom.html#phrasing-content
         'a', 'abbr', 'area', 'audio', 'b', 'bdi', 'bdo', 'br', 'button', 'canvas', 'cite',
         'code', 'data', 'datalist', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
@@ -248,8 +250,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         // prexisting - not sure of full effect of removing, leaving in
         'acronym', 'address', 'big', 'dt', 'ins', 'strike', 'tt',
     ];
+    unformatted = options.unformatted || [];
     content_unformatted = options.content_unformatted || [
-        'pre',
+        'pre', 'textarea'
     ];
     preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
     max_preserve_newlines = preserve_newlines ?
@@ -330,6 +333,14 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                 }
                 return false;
+            },
+            get_tag_name: function(full_tag) {
+                var tag_match = (full_tag || "").match(/^\s*(<\/?|\{\{[#\/])([^\s>\}]+)/);
+                var is_closing_tag = !!((full_tag || "").match(/^\s*(<\/|\{\{\/)/));
+                return {
+                    tag_name: tag_match && tag_match[2],
+                    is_closing_tag: is_closing_tag
+                };
             }
         };
 
@@ -375,6 +386,17 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 content.push(' ');
                 return false;
             }
+        };
+
+        this.get_last_tag = function() {
+            var last_tag;
+            for (var i = this.output.length - 1; i >= 0; i --) {
+                last_tag = this.Utils.get_tag_name(multi_parser.output[i]);
+                if (last_tag.tag_name) {
+                    break;
+                }
+            }
+            return last_tag;
         };
 
         this.get_content = function() { //function to capture regular content between tags
@@ -659,6 +681,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 tag_offset = tag_complete.charAt(2) === '#' ? 3 : 2;
             }
             var tag_check = tag_complete.substring(tag_offset, tag_index).toLowerCase();
+            this.is_inline_tag = this.Utils.in_array(tag_check, inline_tags);
             if (tag_complete.charAt(tag_complete.length - 2) === '/' ||
                 this.Utils.in_array(tag_check, this.Utils.single_token)) { //if this tag name is a single tag type (either in the list or has a closing /)
                 if (!peek) {
@@ -674,6 +697,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             } else if (this.is_unformatted(tag_check, unformatted) ||
                 this.is_unformatted(tag_check, content_unformatted)) {
                 // do not reformat the "unformatted" or "content_unformatted" tags
+                if (this.is_unformatted(tag_check, unformatted)) {
+                    content = [this.input.slice(tag_start, this.pos)];
+                }
                 comment = this.get_unformatted('</' + tag_check + '>', tag_complete); //...delegate to get_unformatted function
                 content.push(comment);
                 tag_end = this.pos - 1;
@@ -710,6 +736,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                     this.tag_type = 'START';
                 }
+                this.is_inline_tag = this.Utils.in_array(tag_check.charAt(0) === '/' ? tag_check.substr(1) : tag_check, inline_tags);
 
                 // Allow preserving of newlines after a start or end tag
                 if (this.traverse_whitespace()) {
@@ -860,6 +887,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
         this.get_token = function() { //initial handler for token-retrieval
             var token;
+            this.is_inline_tag = true;
 
             if (this.last_token === 'TK_TAG_SCRIPT' || this.last_token === 'TK_TAG_STYLE') { //check if we need to format javascript
                 var type = this.last_token.substr(7);
@@ -1036,7 +1064,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
             switch (multi_parser.token_type) {
                 case 'TK_TAG_START':
-                    multi_parser.print_newline(false, multi_parser.output);
+                    if (!multi_parser.is_last_tag_inline && !multi_parser.is_inline_tag) {
+                        multi_parser.print_newline(false, multi_parser.output);
+                    }
                     multi_parser.print_token(multi_parser.token_text);
                     if (multi_parser.indent_content) {
                         if ((multi_parser.indent_body_inner_html || !multi_parser.token_text.match(/<body(?:.*)>/)) &&
@@ -1056,15 +1086,18 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_END':
-                    //Print new line only if the tag has no content and has child
-                    if (multi_parser.last_token === 'TK_CONTENT' && multi_parser.last_text === '') {
-                        var tag_name = (multi_parser.token_text.match(/\w+/) || [])[0];
-                        var tag_extracted_from_last_output = null;
-                        if (multi_parser.output.length) {
-                            tag_extracted_from_last_output = multi_parser.output[multi_parser.output.length - 1].match(/(?:<|{{#)\s*(\w+)/);
-                        }
-                        if (tag_extracted_from_last_output === null ||
-                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted))) {
+                    if (!multi_parser.is_inline_tag) {
+                        //Print new line only if the tag has no content and has child
+                        var tag_name = multi_parser.Utils.get_tag_name(multi_parser.token_text).tag_name;
+                        var last_tag = multi_parser.get_last_tag();
+                        if (
+                            !(
+                                !last_tag.is_closing_tag &&
+                                tag_name === last_tag.tag_name &&
+                                !multi_parser.Utils.in_array(tag_name, content_unformatted)
+                            ) &&
+                            !multi_parser.is_last_tag_inline
+                        ) {
                             multi_parser.print_newline(false, multi_parser.output);
                         }
                     }
@@ -1074,7 +1107,11 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 case 'TK_TAG_SINGLE':
                     // Don't add a newline before elements that should remain unformatted.
                     var tag_check = multi_parser.token_text.match(/^\s*<([a-z-]+)/i);
-                    if (!tag_check || !multi_parser.Utils.in_array(tag_check[1], unformatted)) {
+                    if (
+                        !tag_check ||
+                        !multi_parser.Utils.in_array(tag_check[1], inline_tags) &&
+                        !multi_parser.Utils.in_array(tag_check[1], unformatted)
+                    ) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }
                     multi_parser.print_token(multi_parser.token_text);
@@ -1110,6 +1147,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 case 'TK_CONTENT':
                     multi_parser.print_token(multi_parser.token_text);
                     multi_parser.current_mode = 'TAG';
+                    if (!multi_parser.token_text) {
+                        continue;
+                    }
                     break;
                 case 'TK_STYLE':
                 case 'TK_SCRIPT':
@@ -1166,6 +1206,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             }
             multi_parser.last_token = multi_parser.token_type;
             multi_parser.last_text = multi_parser.token_text;
+            multi_parser.is_last_tag_inline = multi_parser.is_inline_tag;
         }
         var sweet_code = multi_parser.output.join('').replace(/[\r\n\t ]+$/, '');
 

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -795,7 +795,8 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 }
 
                 // only need to search for custom delimiter for the first few characters
-                if (!matched && comment.length < 10) {
+                if (!matched) {
+                    matched = comment.length > 10;
                     if (comment.indexOf('<![if') === 0) { //peek for <![if conditional comment
                         delimiter = '<![endif]>';
                         matched = true;
@@ -1041,8 +1042,8 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                     multi_parser.print_token(token.text);
                     if (multi_parser.indent_content) {
-                        if ((multi_parser.indent_body_inner_html || !token.text.match(/<body(?:.*)>/)) &&
-                            (multi_parser.indent_head_inner_html || !token.text.match(/<head(?:.*)>/))) {
+                        if ((multi_parser.indent_body_inner_html || token.tag_name !== 'body') &&
+                            (multi_parser.indent_head_inner_html || token.tag_name !== 'head')) {
 
                             multi_parser.indent();
                         }

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -706,10 +706,10 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     this.indent_content = true;
                     this.traverse_whitespace();
                 }
-            } else if (this.is_unformatted(tag_check, unformatted) ||
-                this.is_unformatted(tag_check, content_unformatted)) {
+            } else if (this.Utils.in_array(tag_check, unformatted) ||
+                this.Utils.in_array(tag_check, content_unformatted)) {
                 // do not reformat the "unformatted" or "content_unformatted" tags
-                if (this.is_unformatted(tag_check, unformatted)) {
+                if (this.Utils.in_array(tag_check, unformatted)) {
                     content = [this.input.slice(tag_start, this.pos)];
                 }
                 comment = this.get_unformatted('</' + tag_check + '>', tag_complete); //...delegate to get_unformatted function
@@ -921,33 +921,6 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             }
 
             return Array(level + 1).join(this.indent_string);
-        };
-
-        this.is_unformatted = function(tag_check, unformatted) {
-            //is this an HTML5 block-level link?
-            if (!this.Utils.in_array(tag_check, unformatted)) {
-                return false;
-            }
-
-            if (tag_check.toLowerCase() !== 'a' || !this.Utils.in_array('a', unformatted)) {
-                return true;
-            }
-
-            //at this point we have a tag; is its first child something we want to remain
-            //unformatted?
-            var next_tag = this.get_tag(true /* peek. */ );
-
-            // test next_tag to see if it is just html tag (no external content)
-            var tag = (next_tag.text).match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
-
-            // if next_tag comes back but is not an isolated tag, then
-            // let's treat the 'a' tag as having content
-            // and respect the unformatted option
-            if (!tag || this.Utils.in_array(tag[1], unformatted)) {
-                return true;
-            } else {
-                return false;
-            }
         };
 
         this.printer = function(js_source, indent_character, indent_size, wrap_line_length, brace_style) { //handles input/output and some other printing functions

--- a/js/lib/beautify-html.js
+++ b/js/lib/beautify-html.js
@@ -297,8 +297,11 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             parentcount: 1,
             parent1: ''
         };
-        this.tag_type = '';
-        this.token_text = this.last_token = this.last_text = this.token_type = '';
+        this.last_token = {
+            text: '',
+            type: ''
+        };
+        this.token_text = '';
         this.newlines = 0;
         this.indent_content = indent_inner_html;
         this.indent_body_inner_html = indent_body_inner_html;
@@ -334,14 +337,6 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 }
                 return false;
             },
-            get_tag_name: function(full_tag) {
-                var tag_match = (full_tag || "").match(/^\s*(<\/?|\{\{[#\/])([^\s>\}]+)/);
-                var is_closing_tag = !!((full_tag || "").match(/^\s*(<\/|\{\{\/)/));
-                return {
-                    tag_name: tag_match && tag_match[2],
-                    is_closing_tag: is_closing_tag
-                };
-            }
         };
 
         // Return true if the given text is composed entirely of whitespace.
@@ -388,25 +383,21 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             }
         };
 
-        this.get_last_tag = function() {
-            var last_tag;
-            for (var i = this.output.length - 1; i >= 0; i --) {
-                last_tag = this.Utils.get_tag_name(multi_parser.output[i]);
-                if (last_tag.tag_name) {
-                    break;
-                }
-            }
-            return last_tag;
-        };
-
         this.get_content = function() { //function to capture regular content between tags
             var input_char = '',
+                token = {
+                    text: '',
+                    type: 'TK_CONTENT'
+                },
                 content = [],
                 handlebarsStarted = 0;
 
             while (this.input.charAt(this.pos) !== '<' || handlebarsStarted === 2) {
                 if (this.pos >= this.input.length) {
-                    return content.length ? content.join('') : ['', 'TK_EOF'];
+                    if (!content.length) {
+                        token.type = 'TK_EOF';
+                    }
+                    break;
                 }
 
                 if (handlebarsStarted < 2 && this.traverse_whitespace()) {
@@ -437,9 +428,11 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                         // These are tags and not content.
                         break;
                     } else if (peek3 === '{{!') {
-                        return [this.get_tag(), 'TK_TAG_HANDLEBARS_COMMENT'];
+                        token = this.get_tag();
+                        token.type = 'TK_TAG_HANDLEBARS_COMMENT';
+                        return token;
                     } else if (this.input.substr(this.pos, 2) === '{{') {
-                        if (this.get_tag(true) === '{{else}}') {
+                        if (this.get_tag(true).text === '{{else}}') {
                             break;
                         }
                     }
@@ -449,12 +442,13 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 this.line_char_count++;
                 content.push(input_char); //letter at-a-time (or string) inserted to an array
             }
-            return content.length ? content.join('') : '';
+            token.text = content.join('');
+            return token;
         };
 
         this.get_contents_to = function(name) { //get the full content of a script or style to pass to js_beautify
             if (this.pos === this.input.length) {
-                return ['', 'TK_EOF'];
+                return {text: '', type: 'TK_EOF'};
             }
             var content = '';
             var reg_match = new RegExp('</' + name + '\\s*>', 'igm');
@@ -465,7 +459,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 content = this.input.substring(this.pos, end_script);
                 this.pos = end_script;
             }
-            return content;
+            return {text: content, type: 'TK_' + name};
         };
 
         this.record_tag = function(tag) { //function to record a tag and its parent in this.tags Object
@@ -522,6 +516,15 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
         this.get_tag = function(peek) { //function to get a full tag and parse its type
             var input_char = '',
+                token = {
+                    text: '',
+                    type: '',
+                    tag_type: '',
+                    tag_name: '',
+                    is_inline_tag: false,
+                    is_opening_tag: false,
+                    is_closing_tag: false
+                },
                 content = [],
                 comment = '',
                 space = false,
@@ -542,7 +545,13 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                         this.pos = orig_pos;
                         this.line_char_count = orig_line_char_count;
                     }
-                    return content.length ? content.join('') : ['', 'TK_EOF'];
+                    if (content.length) {
+                        token.text = content.join('');
+                    } else {
+                        token.type = 'TK_EOF';
+                    }
+
+                    return token;
                 }
 
                 input_char = this.input.charAt(this.pos);
@@ -681,16 +690,19 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 tag_offset = tag_complete.charAt(2) === '#' ? 3 : 2;
             }
             var tag_check = tag_complete.substring(tag_offset, tag_index).toLowerCase();
-            this.is_inline_tag = this.Utils.in_array(tag_check, inline_tags);
+            token.is_closing_tag = tag_check.charAt(0) === '/';
+            token.tag_name = token.is_closing_tag ? tag_check.substr(1) : tag_check;
+            token.is_inline_tag = this.Utils.in_array(token.tag_name, inline_tags);
+
+
             if (tag_complete.charAt(tag_complete.length - 2) === '/' ||
                 this.Utils.in_array(tag_check, this.Utils.single_token)) { //if this tag name is a single tag type (either in the list or has a closing /)
-                if (!peek) {
-                    this.tag_type = 'SINGLE';
-                }
+                token.tag_type = 'SINGLE';
+                token.is_closing_tag = true;
             } else if (indent_handlebars && tag_complete.charAt(0) === '{' && tag_check === 'else') {
                 if (!peek) {
                     this.indent_to_tag('if');
-                    this.tag_type = 'HANDLEBARS_ELSE';
+                    token.tag_type = 'HANDLEBARS_ELSE';
                     this.indent_content = true;
                     this.traverse_whitespace();
                 }
@@ -703,40 +715,41 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 comment = this.get_unformatted('</' + tag_check + '>', tag_complete); //...delegate to get_unformatted function
                 content.push(comment);
                 tag_end = this.pos - 1;
-                this.tag_type = 'SINGLE';
+                token.tag_type = 'SINGLE';
+                token.is_closing_tag = true;
             } else if (tag_check === 'script' &&
                 (tag_complete.search('type') === -1 ||
                     (tag_complete.search('type') > -1 &&
                         tag_complete.search(/\b(text|application|dojo)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json|method|aspect)/) > -1))) {
                 if (!peek) {
                     this.record_tag(tag_check);
-                    this.tag_type = 'SCRIPT';
+                    token.tag_type = 'SCRIPT';
                 }
             } else if (tag_check === 'style' &&
                 (tag_complete.search('type') === -1 ||
                     (tag_complete.search('type') > -1 && tag_complete.search('text/css') > -1))) {
                 if (!peek) {
                     this.record_tag(tag_check);
-                    this.tag_type = 'STYLE';
+                    token.tag_type = 'STYLE';
                 }
             } else if (tag_check.charAt(0) === '!') { //peek for <! comment
                 // for comments content is already correct.
                 if (!peek) {
-                    this.tag_type = 'SINGLE';
+                    token.tag_type = 'SINGLE';
                     this.traverse_whitespace();
                 }
             } else if (!peek) {
-                if (tag_check.charAt(0) === '/') { //this tag is a double tag so check for tag-ending
+                if (token.is_closing_tag) { //this tag is a double tag so check for tag-ending
                     this.retrieve_tag(tag_check.substring(1)); //remove it and all ancestors
-                    this.tag_type = 'END';
+                    token.tag_type = 'END';
                 } else { //otherwise it's a start-tag
                     this.record_tag(tag_check); //push it on the tag stack
                     if (tag_check.toLowerCase() !== 'html') {
                         this.indent_content = true;
                     }
-                    this.tag_type = 'START';
+                    token.tag_type = 'START';
+                    token.is_opening_tag = true;
                 }
-                this.is_inline_tag = this.Utils.in_array(tag_check.charAt(0) === '/' ? tag_check.substr(1) : tag_check, inline_tags);
 
                 // Allow preserving of newlines after a start or end tag
                 if (this.traverse_whitespace()) {
@@ -756,7 +769,10 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 this.line_char_count = orig_line_char_count;
             }
 
-            return content.join(''); //returns fully formatted tag
+            token.text = content.join('');
+            token.type = 'TK_TAG_' + token.tag_type;
+
+            return token; //returns fully formatted tag
         };
 
         this.get_comment = function(start_pos) { //function to return comment content in its entirety
@@ -886,35 +902,16 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         };
 
         this.get_token = function() { //initial handler for token-retrieval
-            var token;
-            this.is_inline_tag = true;
-
-            if (this.last_token === 'TK_TAG_SCRIPT' || this.last_token === 'TK_TAG_STYLE') { //check if we need to format javascript
-                var type = this.last_token.substr(7);
+            var token ;
+            if (this.last_token.type === 'TK_TAG_SCRIPT' || this.last_token.type === 'TK_TAG_STYLE') { //check if we need to format javascript
+                var type = this.last_token.type.substr(7);
                 token = this.get_contents_to(type);
-                if (typeof token !== 'string') {
-                    return token;
-                }
-                return [token, 'TK_' + type];
-            }
-            if (this.current_mode === 'CONTENT') {
+            } else if (this.current_mode === 'CONTENT') {
                 token = this.get_content();
-                if (typeof token !== 'string') {
-                    return token;
-                } else {
-                    return [token, 'TK_CONTENT'];
-                }
-            }
-
-            if (this.current_mode === 'TAG') {
+            } else if (this.current_mode === 'TAG') {
                 token = this.get_tag();
-                if (typeof token !== 'string') {
-                    return token;
-                } else {
-                    var tag_name_type = 'TK_TAG_' + this.tag_type;
-                    return [token, tag_name_type];
-                }
             }
+            return token;
         };
 
         this.get_full_indent = function(level) {
@@ -936,17 +933,12 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 return true;
             }
 
-            //at this point we have an  tag; is its first child something we want to remain
+            //at this point we have a tag; is its first child something we want to remain
             //unformatted?
             var next_tag = this.get_tag(true /* peek. */ );
 
-            next_tag = next_tag || '';
-            if (typeof next_tag !== 'string') {
-                next_tag = next_tag[0];
-            }
-
             // test next_tag to see if it is just html tag (no external content)
-            var tag = (next_tag || "").match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
+            var tag = (next_tag.text).match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
 
             // if next_tag comes back but is not an isolated tag, then
             // let's treat the 'a' tag as having content
@@ -1053,60 +1045,68 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     this.beautify = function() {
         multi_parser = new Parser(); //wrapping functions Parser
         multi_parser.printer(html_source, indent_character, indent_size, wrap_line_length, brace_style); //initialize starting values
+        var token = null;
+        var last_tag_token = {
+            text: '',
+            type: '',
+            tag_name: '',
+            is_opening_tag: false,
+            is_closing_tag: false,
+            is_inline_tag: false
+        };
         while (true) {
-            var t = multi_parser.get_token();
-            multi_parser.token_text = t[0];
-            multi_parser.token_type = t[1];
+            token = multi_parser.get_token();
 
-            if (multi_parser.token_type === 'TK_EOF') {
+            if (token.type === 'TK_EOF') {
                 break;
             }
 
-            switch (multi_parser.token_type) {
+            switch (token.type) {
                 case 'TK_TAG_START':
-                    if (!multi_parser.is_last_tag_inline && !multi_parser.is_inline_tag) {
+                    if (!last_tag_token.is_inline_tag && !token.is_inline_tag) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
                     if (multi_parser.indent_content) {
-                        if ((multi_parser.indent_body_inner_html || !multi_parser.token_text.match(/<body(?:.*)>/)) &&
-                            (multi_parser.indent_head_inner_html || !multi_parser.token_text.match(/<head(?:.*)>/))) {
+                        if ((multi_parser.indent_body_inner_html || !token.text.match(/<body(?:.*)>/)) &&
+                            (multi_parser.indent_head_inner_html || !token.text.match(/<head(?:.*)>/))) {
 
                             multi_parser.indent();
                         }
 
                         multi_parser.indent_content = false;
                     }
+                    last_tag_token = token;
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_STYLE':
                 case 'TK_TAG_SCRIPT':
                     multi_parser.print_newline(false, multi_parser.output);
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
+                    last_tag_token = token;
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_END':
-                    if (!multi_parser.is_inline_tag) {
+                    if (!token.is_inline_tag) {
                         //Print new line only if the tag has no content and has child
-                        var tag_name = multi_parser.Utils.get_tag_name(multi_parser.token_text).tag_name;
-                        var last_tag = multi_parser.get_last_tag();
                         if (
                             !(
-                                !last_tag.is_closing_tag &&
-                                tag_name === last_tag.tag_name &&
-                                !multi_parser.Utils.in_array(tag_name, content_unformatted)
+                                !last_tag_token.is_closing_tag &&
+                                token.tag_name === last_tag_token.tag_name &&
+                                !multi_parser.Utils.in_array(token.tag_name, content_unformatted)
                             ) &&
-                            !multi_parser.is_last_tag_inline
+                            !last_tag_token.is_inline_tag
                         ) {
                             multi_parser.print_newline(false, multi_parser.output);
                         }
                     }
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
+                    last_tag_token = token;
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_SINGLE':
                     // Don't add a newline before elements that should remain unformatted.
-                    var tag_check = multi_parser.token_text.match(/^\s*<([a-z-]+)/i);
+                    var tag_check = token.text.match(/^\s*<([a-z-]+)/i);
                     if (
                         !tag_check ||
                         !multi_parser.Utils.in_array(tag_check[1], inline_tags) &&
@@ -1114,7 +1114,8 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     ) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
+                    last_tag_token = token;
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_HANDLEBARS_ELSE':
@@ -1133,7 +1134,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     if (!foundIfOnCurrentLine) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
                     if (multi_parser.indent_content) {
                         multi_parser.indent();
                         multi_parser.indent_content = false;
@@ -1141,26 +1142,26 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_HANDLEBARS_COMMENT':
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
                     multi_parser.current_mode = 'TAG';
                     break;
                 case 'TK_CONTENT':
-                    multi_parser.print_token(multi_parser.token_text);
+                    multi_parser.print_token(token.text);
                     multi_parser.current_mode = 'TAG';
-                    if (!multi_parser.token_text) {
+                    if (!token.text) {
                         continue;
                     }
                     break;
                 case 'TK_STYLE':
                 case 'TK_SCRIPT':
-                    if (multi_parser.token_text !== '') {
+                    if (token.text !== '') {
                         multi_parser.print_newline(false, multi_parser.output);
-                        var text = multi_parser.token_text,
+                        var text = token.text,
                             _beautifier,
                             script_indent_level = 1;
-                        if (multi_parser.token_type === 'TK_SCRIPT') {
+                        if (token.type === 'TK_SCRIPT') {
                             _beautifier = typeof js_beautify === 'function' && js_beautify;
-                        } else if (multi_parser.token_type === 'TK_STYLE') {
+                        } else if (token.type === 'TK_STYLE') {
                             _beautifier = typeof css_beautify === 'function' && css_beautify;
                         }
 
@@ -1199,14 +1200,13 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 default:
                     // We should not be getting here but we don't want to drop input on the floor
                     // Just output the text and move on
-                    if (multi_parser.token_text !== '') {
-                        multi_parser.print_token(multi_parser.token_text);
+                    if (token.text !== '') {
+                        multi_parser.print_token(token.text);
                     }
                     break;
             }
-            multi_parser.last_token = multi_parser.token_type;
-            multi_parser.last_text = multi_parser.token_text;
-            multi_parser.is_last_tag_inline = multi_parser.is_inline_tag;
+            multi_parser.last_token = token;
+
         }
         var sweet_code = multi_parser.output.join('').replace(/[\r\n\t ]+$/, '');
 

--- a/js/lib/cli.js
+++ b/js/lib/cli.js
@@ -95,6 +95,7 @@ var path = require('path'),
         "space_around_selector_separator": Boolean,
         // HTML-only
         "max_char": Number, // obsolete since 1.3.5
+        "inline": [String, Array],
         "unformatted": [String, Array],
         "content_unformatted": [String, Array],
         "indent_inner_html": [Boolean],
@@ -144,6 +145,7 @@ var path = require('path'),
         "A": ["--wrap_attributes"],
         "i": ["--wrap_attributes_indent_size"],
         "W": ["--max_char"], // obsolete since 1.3.5
+        "d": ["--inline"],
         "U": ["--unformatted"],
         "T": ["--content_unformatted"],
         "I": ["--indent_inner_html"],

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -58,6 +58,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         indent_character,
         wrap_line_length,
         brace_style,
+        inline_tags,
         unformatted,
         content_unformatted,
         preserve_newlines,
@@ -89,7 +90,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
     indent_character = (options.indent_char === undefined) ? ' ' : options.indent_char;
     brace_style = (options.brace_style === undefined) ? 'collapse' : options.brace_style;
     wrap_line_length = parseInt(options.wrap_line_length, 10) === 0 ? 32786 : parseInt(options.wrap_line_length || 250, 10);
-    unformatted = options.unformatted || [
+    inline_tags = options.inline || [
         // https://www.w3.org/TR/html5/dom.html#phrasing-content
         'a', 'abbr', 'area', 'audio', 'b', 'bdi', 'bdo', 'br', 'button', 'canvas', 'cite',
         'code', 'data', 'datalist', 'del', 'dfn', 'em', 'embed', 'i', 'iframe', 'img',
@@ -100,8 +101,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
         // prexisting - not sure of full effect of removing, leaving in
         'acronym', 'address', 'big', 'dt', 'ins', 'strike', 'tt',
     ];
+    unformatted = options.unformatted || [];
     content_unformatted = options.content_unformatted || [
-        'pre',
+        'pre', 'textarea'
     ];
     preserve_newlines = (options.preserve_newlines === undefined) ? true : options.preserve_newlines;
     max_preserve_newlines = preserve_newlines ?
@@ -182,6 +184,14 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                 }
                 return false;
+            },
+            get_tag_name: function(full_tag) {
+                var tag_match = (full_tag || "").match(/^\s*(<\/?|\{\{[#\/])([^\s>\}]+)/);
+                var is_closing_tag = !!((full_tag || "").match(/^\s*(<\/|\{\{\/)/));
+                return {
+                    tag_name: tag_match && tag_match[2],
+                    is_closing_tag: is_closing_tag
+                };
             }
         };
 
@@ -227,6 +237,17 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 content.push(' ');
                 return false;
             }
+        };
+
+        this.get_last_tag = function() {
+            var last_tag;
+            for (var i = this.output.length - 1; i >= 0; i --) {
+                last_tag = this.Utils.get_tag_name(multi_parser.output[i]);
+                if (last_tag.tag_name) {
+                    break;
+                }
+            }
+            return last_tag;
         };
 
         this.get_content = function() { //function to capture regular content between tags
@@ -511,6 +532,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 tag_offset = tag_complete.charAt(2) === '#' ? 3 : 2;
             }
             var tag_check = tag_complete.substring(tag_offset, tag_index).toLowerCase();
+            this.is_inline_tag = this.Utils.in_array(tag_check, inline_tags);
             if (tag_complete.charAt(tag_complete.length - 2) === '/' ||
                 this.Utils.in_array(tag_check, this.Utils.single_token)) { //if this tag name is a single tag type (either in the list or has a closing /)
                 if (!peek) {
@@ -526,6 +548,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             } else if (this.is_unformatted(tag_check, unformatted) ||
                 this.is_unformatted(tag_check, content_unformatted)) {
                 // do not reformat the "unformatted" or "content_unformatted" tags
+                if (this.is_unformatted(tag_check, unformatted)) {
+                    content = [this.input.slice(tag_start, this.pos)];
+                }
                 comment = this.get_unformatted('</' + tag_check + '>', tag_complete); //...delegate to get_unformatted function
                 content.push(comment);
                 tag_end = this.pos - 1;
@@ -562,6 +587,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                     this.tag_type = 'START';
                 }
+                this.is_inline_tag = this.Utils.in_array(tag_check.charAt(0) === '/' ? tag_check.substr(1) : tag_check, inline_tags);
 
                 // Allow preserving of newlines after a start or end tag
                 if (this.traverse_whitespace()) {
@@ -712,6 +738,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
         this.get_token = function() { //initial handler for token-retrieval
             var token;
+            this.is_inline_tag = true;
 
             if (this.last_token === 'TK_TAG_SCRIPT' || this.last_token === 'TK_TAG_STYLE') { //check if we need to format javascript
                 var type = this.last_token.substr(7);
@@ -888,7 +915,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
 
             switch (multi_parser.token_type) {
                 case 'TK_TAG_START':
-                    multi_parser.print_newline(false, multi_parser.output);
+                    if (!multi_parser.is_last_tag_inline && !multi_parser.is_inline_tag) {
+                        multi_parser.print_newline(false, multi_parser.output);
+                    }
                     multi_parser.print_token(multi_parser.token_text);
                     if (multi_parser.indent_content) {
                         if ((multi_parser.indent_body_inner_html || !multi_parser.token_text.match(/<body(?:.*)>/)) &&
@@ -908,15 +937,18 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     multi_parser.current_mode = 'CONTENT';
                     break;
                 case 'TK_TAG_END':
-                    //Print new line only if the tag has no content and has child
-                    if (multi_parser.last_token === 'TK_CONTENT' && multi_parser.last_text === '') {
-                        var tag_name = (multi_parser.token_text.match(/\w+/) || [])[0];
-                        var tag_extracted_from_last_output = null;
-                        if (multi_parser.output.length) {
-                            tag_extracted_from_last_output = multi_parser.output[multi_parser.output.length - 1].match(/(?:<|{{#)\s*(\w+)/);
-                        }
-                        if (tag_extracted_from_last_output === null ||
-                            (tag_extracted_from_last_output[1] !== tag_name && !multi_parser.Utils.in_array(tag_extracted_from_last_output[1], unformatted))) {
+                    if (!multi_parser.is_inline_tag) {
+                        //Print new line only if the tag has no content and has child
+                        var tag_name = multi_parser.Utils.get_tag_name(multi_parser.token_text).tag_name;
+                        var last_tag = multi_parser.get_last_tag();
+                        if (
+                            !(
+                                !last_tag.is_closing_tag &&
+                                tag_name === last_tag.tag_name &&
+                                !multi_parser.Utils.in_array(tag_name, content_unformatted)
+                            ) &&
+                            !multi_parser.is_last_tag_inline
+                        ) {
                             multi_parser.print_newline(false, multi_parser.output);
                         }
                     }
@@ -926,7 +958,11 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 case 'TK_TAG_SINGLE':
                     // Don't add a newline before elements that should remain unformatted.
                     var tag_check = multi_parser.token_text.match(/^\s*<([a-z-]+)/i);
-                    if (!tag_check || !multi_parser.Utils.in_array(tag_check[1], unformatted)) {
+                    if (
+                        !tag_check ||
+                        !multi_parser.Utils.in_array(tag_check[1], inline_tags) &&
+                        !multi_parser.Utils.in_array(tag_check[1], unformatted)
+                    ) {
                         multi_parser.print_newline(false, multi_parser.output);
                     }
                     multi_parser.print_token(multi_parser.token_text);
@@ -962,6 +998,9 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 case 'TK_CONTENT':
                     multi_parser.print_token(multi_parser.token_text);
                     multi_parser.current_mode = 'TAG';
+                    if (!multi_parser.token_text) {
+                        continue;
+                    }
                     break;
                 case 'TK_STYLE':
                 case 'TK_SCRIPT':
@@ -1018,6 +1057,7 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             }
             multi_parser.last_token = multi_parser.token_type;
             multi_parser.last_text = multi_parser.token_text;
+            multi_parser.is_last_tag_inline = multi_parser.is_inline_tag;
         }
         var sweet_code = multi_parser.output.join('').replace(/[\r\n\t ]+$/, '');
 

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -646,7 +646,8 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                 }
 
                 // only need to search for custom delimiter for the first few characters
-                if (!matched && comment.length < 10) {
+                if (!matched) {
+                    matched = comment.length > 10;
                     if (comment.indexOf('<![if') === 0) { //peek for <![if conditional comment
                         delimiter = '<![endif]>';
                         matched = true;
@@ -892,8 +893,8 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     }
                     multi_parser.print_token(token.text);
                     if (multi_parser.indent_content) {
-                        if ((multi_parser.indent_body_inner_html || !token.text.match(/<body(?:.*)>/)) &&
-                            (multi_parser.indent_head_inner_html || !token.text.match(/<head(?:.*)>/))) {
+                        if ((multi_parser.indent_body_inner_html || token.tag_name !== 'body') &&
+                            (multi_parser.indent_head_inner_html || token.tag_name !== 'head')) {
 
                             multi_parser.indent();
                         }

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -557,10 +557,10 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
                     this.indent_content = true;
                     this.traverse_whitespace();
                 }
-            } else if (this.is_unformatted(tag_check, unformatted) ||
-                this.is_unformatted(tag_check, content_unformatted)) {
+            } else if (this.Utils.in_array(tag_check, unformatted) ||
+                this.Utils.in_array(tag_check, content_unformatted)) {
                 // do not reformat the "unformatted" or "content_unformatted" tags
-                if (this.is_unformatted(tag_check, unformatted)) {
+                if (this.Utils.in_array(tag_check, unformatted)) {
                     content = [this.input.slice(tag_start, this.pos)];
                 }
                 comment = this.get_unformatted('</' + tag_check + '>', tag_complete); //...delegate to get_unformatted function
@@ -772,33 +772,6 @@ function Beautifier(html_source, options, js_beautify, css_beautify) {
             }
 
             return Array(level + 1).join(this.indent_string);
-        };
-
-        this.is_unformatted = function(tag_check, unformatted) {
-            //is this an HTML5 block-level link?
-            if (!this.Utils.in_array(tag_check, unformatted)) {
-                return false;
-            }
-
-            if (tag_check.toLowerCase() !== 'a' || !this.Utils.in_array('a', unformatted)) {
-                return true;
-            }
-
-            //at this point we have a tag; is its first child something we want to remain
-            //unformatted?
-            var next_tag = this.get_tag(true /* peek. */ );
-
-            // test next_tag to see if it is just html tag (no external content)
-            var tag = (next_tag.text).match(/^\s*<\s*\/?([a-z]*)\s*[^>]*>\s*$/);
-
-            // if next_tag comes back but is not an isolated tag, then
-            // let's treat the 'a' tag as having content
-            // and respect the unformatted option
-            if (!tag || this.Utils.in_array(tag[1], unformatted)) {
-                return true;
-            } else {
-                return false;
-            }
         };
 
         this.printer = function(js_source, indent_character, indent_size, wrap_line_length, brace_style) { //handles input/output and some other printing functions

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -2878,25 +2878,25 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '\n' +
             '</html>');
         test_fragment(
-            '<div><p>Beautify me</p></div><p><p>But not me</p></p>',
+            '<div><p>Beautify me</p></div><p><div>But not me</div></p>',
             //  -- output --
             '<div>\n' +
             '    <p>Beautify me</p>\n' +
             '</div>\n' +
-            '<p><p>But not me</p></p>');
+            '<p><div>But not me</div></p>');
         test_fragment(
             '<div><p\n' +
             '  class="beauty-me"\n' +
-            '>Beautify me</p></div><p><p\n' +
+            '>Beautify me</p></div><p><div\n' +
             '  class="iamalreadybeauty"\n' +
-            '>But not me</p></p>',
+            '>But not me</div></p>',
             //  -- output --
             '<div>\n' +
             '    <p class="beauty-me">Beautify me</p>\n' +
             '</div>\n' +
-            '<p><p\n' +
+            '<p><div\n' +
             '  class="iamalreadybeauty"\n' +
-            '>But not me</p></p>');
+            '>But not me</div></p>');
         test_fragment('<div><span>blabla<div>something here</div></span></div>');
         test_fragment('<div><br /></div>');
         test_fragment(

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -2863,6 +2863,27 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
+        // Inline tags formatting
+        reset_options();
+        test_fragment('<div><span></span></div><span><div></div></span>');
+        test_fragment(
+            '<div><div><span><span>Nested spans</span></span></div></div>',
+            //  -- output --
+            '<div>\n' +
+            '    <div><span><span>Nested spans</span></span></div>\n' +
+            '</div>');
+        test_fragment(
+            '<p>Should remove <span><span \n' +
+            '\n' +
+            'class="some-class">attribute</span></span> newlines</p>',
+            //  -- output --
+            '<p>Should remove <span><span class="some-class">attribute</span></span> newlines</p>');
+        test_fragment('<div><span>All</span> on <span>one</span> line</div>');
+        test_fragment('<span class="{{class_name}}">{{content}}</span>');
+        test_fragment('{{#if 1}}<span>{{content}}</span>{{/if}}');
+
+
+        //============================================================
         // content_unformatted to prevent formatting content
         reset_options();
         opts.content_unformatted = ['script', 'style', 'p', 'span', 'br'];

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -3116,8 +3116,8 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '<div> content <img> content </div>');
         bth('Text <a href="#">Link</a> Text');
 
-        var unformatted = opts.unformatted;
-        opts.unformatted = ['script', 'style'];
+        var content_unformatted = opts.content_unformatted;
+        opts.content_unformatted = ['script', 'style'];
         bth('<script id="javascriptTemplate" type="text/x-kendo-template">\n' +
             '  <ul>\n' +
             '  # for (var i = 0; i < data.length; i++) { #\n' +
@@ -3129,15 +3129,15 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '  body {background-color:lightgrey}\n' +
             '  h1   {color:blue}\n' +
             '</style>');
-        opts.unformatted = unformatted;
+        opts.content_unformatted = content_unformatted;
 
-        unformatted = opts.unformatted;
-        opts.unformatted = ['custom-element'];
+        inline_tags = opts.inline;
+        opts.inline = ['custom-element'];
         test_fragment('<div>should <custom-element>not</custom-element>' +
                       ' insert newlines</div>',
                       '<div>should <custom-element>not</custom-element>' +
                       ' insert newlines</div>');
-        opts.unformatted = unformatted;
+        opts.inline = inline_tags;
 
         // Tests that don't pass, but probably should.
         // bth('<div><span>content</span></div>');

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -3139,8 +3139,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
                       ' insert newlines</div>');
         opts.inline = inline_tags;
 
-        // Tests that don't pass, but probably should.
-        // bth('<div><span>content</span></div>');
+        bth('<div><span>content</span></div>');
 
         // Handlebars tests
         // Without the indent option on, handlebars are treated as content.

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -2884,6 +2884,30 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
+        // unformatted to prevent formatting changes
+        reset_options();
+        opts.unformatted = ['u'];
+        test_fragment('<u><div><div>Ignore block tags in unformatted regions</div></div></u>');
+        test_fragment('<div><u>Don\'t wrap unformatted regions with extra newlines</u></div>');
+        test_fragment(
+            '<u>  \n' +
+            '\n' +
+            '\n' +
+            '  Ignore extra whitespace  \n' +
+            '\n' +
+            '\n' +
+            '  </u>');
+        test_fragment(
+            '<u><div \n' +
+            '\n' +
+            'class="">Ignore whitespace in attributes</div></u>');
+        test_fragment(
+            '<u \n' +
+            '\n' +
+            'class="">Ignore whitespace in attributes</u>');
+
+
+        //============================================================
         // content_unformatted to prevent formatting content
         reset_options();
         opts.content_unformatted = ['script', 'style', 'p', 'span', 'br'];

--- a/test/data/html/node.mustache
+++ b/test/data/html/node.mustache
@@ -285,8 +285,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
                       ' insert newlines</div>');
         opts.inline = inline_tags;
 
-        // Tests that don't pass, but probably should.
-        // bth('<div><span>content</span></div>');
+        bth('<div><span>content</span></div>');
 
         // Handlebars tests
         // Without the indent option on, handlebars are treated as content.

--- a/test/data/html/node.mustache
+++ b/test/data/html/node.mustache
@@ -262,8 +262,8 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '<div> content <img> content </div>');
         bth('Text <a href="#">Link</a> Text');
 
-        var unformatted = opts.unformatted;
-        opts.unformatted = ['script', 'style'];
+        var content_unformatted = opts.content_unformatted;
+        opts.content_unformatted = ['script', 'style'];
         bth('<script id="javascriptTemplate" type="text/x-kendo-template">\n' +
             '  <ul>\n' +
             '  # for (var i = 0; i < data.length; i++) { #\n' +
@@ -275,15 +275,15 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '  body {background-color:lightgrey}\n' +
             '  h1   {color:blue}\n' +
             '</style>');
-        opts.unformatted = unformatted;
+        opts.content_unformatted = content_unformatted;
 
-        unformatted = opts.unformatted;
-        opts.unformatted = ['custom-element'];
+        inline_tags = opts.inline;
+        opts.inline = ['custom-element'];
         test_fragment('<div>should <custom-element>not</custom-element>' +
                       ' insert newlines</div>',
                       '<div>should <custom-element>not</custom-element>' +
                       ' insert newlines</div>');
-        opts.unformatted = unformatted;
+        opts.inline = inline_tags;
 
         // Tests that don't pass, but probably should.
         // bth('<div><span>content</span></div>');

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1010,23 +1010,23 @@ exports.test_data = {
             ]
         }, {
             fragment: true,
-            input: '<div><p>Beautify me</p></div><p><p>But not me</p></p>',
+            input: '<div><p>Beautify me</p></div><p><div>But not me</div></p>',
             output: [
                 '<div>',
                 '    <p>Beautify me</p>',
                 '</div>',
-                '<p><p>But not me</p></p>'
+                '<p><div>But not me</div></p>'
             ]
         }, {
             fragment: true,
-            input: '<div><p\n  class="beauty-me"\n>Beautify me</p></div><p><p\n  class="iamalreadybeauty"\n>But not me</p></p>',
+            input: '<div><p\n  class="beauty-me"\n>Beautify me</p></div><p><div\n  class="iamalreadybeauty"\n>But not me</div></p>',
             output: [
                 '<div>',
                 '    <p class="beauty-me">Beautify me</p>',
                 '</div>',
-                '<p><p',
+                '<p><div',
                 '  class="iamalreadybeauty"',
-                '>But not me</p></p>'
+                '>But not me</div></p>'
             ]
         }, {
             fragment: true,

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -990,6 +990,37 @@ exports.test_data = {
             unchanged: '<html>\n\n<head>\n<meta>\n</head>\n\n</html>'
         }]
     }, {
+        name: "Inline tags formatting",
+        description: "",
+        template: "^^^ $$$",
+        tests: [{
+            fragment: true,
+            unchanged: '<div><span></span></div><span><div></div></span>'
+        }, {
+            fragment: true,
+            input: '<div><div><span><span>Nested spans</span></span></div></div>',
+            output: [
+                '<div>',
+                '    <div><span><span>Nested spans</span></span></div>',
+                '</div>'
+            ]
+        }, {
+            fragment: true,
+            input: '<p>Should remove <span><span \n\nclass="some-class">attribute</span></span> newlines</p>',
+            output: [
+                '<p>Should remove <span><span class="some-class">attribute</span></span> newlines</p>'
+            ]
+        }, {
+            fragment: true,
+            unchanged: '<div><span>All</span> on <span>one</span> line</div>'
+        }, {
+            fragment: true,
+            unchanged: '<span class="{{class_name}}">{{content}}</span>'
+        }, {
+            fragment: true,
+            unchanged: '{{#if 1}}<span>{{content}}</span>{{/if}}'
+        }]
+    }, {
         name: "content_unformatted to prevent formatting content",
         description: "",
         options: [

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1021,6 +1021,28 @@ exports.test_data = {
             unchanged: '{{#if 1}}<span>{{content}}</span>{{/if}}'
         }]
     }, {
+        name: "unformatted to prevent formatting changes",
+        description: "",
+        options: [
+            { name: 'unformatted', value: "['u']" }
+        ],
+        tests: [{
+            fragment: true,
+            unchanged: '<u><div><div>Ignore block tags in unformatted regions</div></div></u>'
+        }, {
+            fragment: true,
+            unchanged: '<div><u>Don\\\'t wrap unformatted regions with extra newlines</u></div>'
+        }, {
+            fragment: true,
+            unchanged: '<u>  \n\n\n  Ignore extra whitespace  \n\n\n  </u>'
+        }, {
+            fragment: true,
+            unchanged: '<u><div \n\nclass="">Ignore whitespace in attributes</div></u>'
+        }, {
+            fragment: true,
+            unchanged: '<u \n\nclass="">Ignore whitespace in attributes</u>'
+        }]
+    }, {
         name: "content_unformatted to prevent formatting content",
         description: "",
         options: [

--- a/tools/template/beautify-html.begin.js
+++ b/tools/template/beautify-html.begin.js
@@ -47,8 +47,9 @@
     wrap_line_length (default 250)            -  maximum amount of characters per line (0 = disable)
     brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none"
             put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.
+    inline (defaults to inline tags) - list of tags to be considered inline tags
     unformatted (defaults to inline tags) - list of tags, that shouldn't be reformatted
-    content_unformatted (defaults to pre tag) - list of tags, whose content shouldn't be reformatted
+    content_unformatted (defaults to ["pre", "textarea"] tags) - list of tags, whose content shouldn't be reformatted
     indent_scripts (default normal)  - "keep"|"separate"|"normal"
     preserve_newlines (default true) - whether existing line breaks before elements should be preserved
                                         Only works before elements, not inside tags or for text.


### PR DESCRIPTION
Fixes https://github.com/beautify-web/js-beautify/issues/1033

Replaces concept of `unformatted` tags with `inline` tags, which are not wrapped. Previous `unformatted` functionality moved to `content_unformatted` tags. This allows us to format the attributes of inline tags correctly.