### PR TITLE
Add indent level options functionality with tests

### DIFF
--- a/js/src/core/options.js
+++ b/js/src/core/options.js
@@ -39,6 +39,7 @@ function Options(options, merge_child_field) {
   this.end_with_newline = this._get_boolean('end_with_newline');
   this.indent_size = this._get_number('indent_size', 4);
   this.indent_char = this._get_characters('indent_char', ' ');
+  this.indent_level = this._get_number('indent_level');
 
   this.preserve_newlines = this._get_boolean('preserve_newlines', true);
   this.max_preserve_newlines = this.max_preserve_newlines = this._get_number('max_preserve_newlines', 32786);
@@ -55,6 +56,11 @@ function Options(options, merge_child_field) {
   this.indent_string = this.indent_char;
   if (this.indent_size > 1) {
     this.indent_string = new Array(this.indent_size + 1).join(this.indent_char);
+  }
+  // Set to null to continue support for auto detection of base indent level.
+  this.base_indent_string = null;
+  if (this.indent_level > 0) {
+    this.base_indent_string = new Array(this.indent_level + 1).join(this.indent_string);
   }
 
   // Backwards compat with 1.3.x

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -174,13 +174,11 @@ Beautifier.prototype.beautify = function() {
 
   // reset
   var baseIndentString = '';
-  var preindent_index = 0;
-  if (source_text && source_text.length) {
-    while ((source_text.charAt(preindent_index) === ' ' || source_text.charAt(preindent_index) === '\t')) {
-      preindent_index += 1;
-    }
-    baseIndentString = source_text.substring(0, preindent_index);
-    source_text = source_text.substring(preindent_index);
+  if (this._options.base_indent_string) {
+    baseIndentString = this._options.base_indent_string;
+  } else {
+    var match = source_text.match(/^[\t ]*/);
+    baseIndentString = match[0];
   }
 
   this._output = new Output(this._options.indent_string, baseIndentString);

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -36,7 +36,7 @@ var TOKEN = require('../html/tokenizer').TOKEN;
 var lineBreak = /\r\n|[\r\n]/;
 var allLineBreaks = /\r\n|[\r\n]/g;
 
-var Printer = function(indent_string, wrap_line_length, max_preserve_newlines, preserve_newlines) { //handles input/output and some other printing functions
+var Printer = function(indent_string, base_indent_string, wrap_line_length, max_preserve_newlines, preserve_newlines) { //handles input/output and some other printing functions
 
   this.indent_level = 0;
   this.alignment_size = 0;
@@ -44,7 +44,7 @@ var Printer = function(indent_string, wrap_line_length, max_preserve_newlines, p
   this.max_preserve_newlines = max_preserve_newlines;
   this.preserve_newlines = preserve_newlines;
 
-  this._output = new Output(indent_string, '');
+  this._output = new Output(indent_string, base_indent_string);
 
 };
 
@@ -261,6 +261,15 @@ Beautifier.prototype.beautify = function() {
 
   // HACK: newline parsing inconsistent. This brute force normalizes the input.
   source_text = source_text.replace(allLineBreaks, '\n');
+  var baseIndentString = '';
+
+  if (this._options.base_indent_string) {
+    baseIndentString = this._options.base_indent_string;
+  } else {
+    //  Including commented out text would change existing beautifier behavior for v1.8.1 to autodetect base indent.
+    //    var match = source_text.match(/^[\t ]*/);
+    //    baseIndentString = match[0];
+  }
 
   var last_token = {
     text: '',
@@ -269,7 +278,7 @@ Beautifier.prototype.beautify = function() {
 
   var last_tag_token = new TagOpenParserToken();
 
-  var printer = new Printer(this._options.indent_string,
+  var printer = new Printer(this._options.indent_string, baseIndentString,
     this._options.wrap_line_length, this._options.max_preserve_newlines, this._options.preserve_newlines);
   var tokens = new Tokenizer(source_text, this._options).tokenize();
 

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -194,15 +194,13 @@ Beautifier.prototype.create_flags = function(flags_base, mode) {
 Beautifier.prototype._reset = function(source_text) {
   var baseIndentString = '';
 
-  var preindent_index = 0;
-  if (source_text && source_text.length) {
-    while ((source_text.charAt(preindent_index) === ' ' ||
-        source_text.charAt(preindent_index) === '\t')) {
-      preindent_index += 1;
-    }
-    baseIndentString = source_text.substring(0, preindent_index);
-    source_text = source_text.substring(preindent_index);
+  if (this._options.base_indent_string) {
+    baseIndentString = this._options.base_indent_string;
+  } else {
+    var match = source_text.match(/^[\t ]*/);
+    baseIndentString = match[0];
   }
+
 
   this._last_type = TOKEN.START_BLOCK; // last token type
   this._last_last_text = ''; // pre-last token text

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -176,6 +176,169 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
 
 
         //============================================================
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = false;
+        test_fragment('   a');
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '   // This is a random comment\n' +
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = false;
+        opts.indent_level = 0;
+        test_fragment('   a');
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '   // This is a random comment\n' +
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "1")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "1")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = false;
+        opts.indent_level = 1;
+        test_fragment('   a', '    a');
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '    .a {\n' +
+            '        text-align: right;\n' +
+            '    }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '    // This is a random comment\n' +
+            '    .a {\n' +
+            '        text-align: right;\n' +
+            '    }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "2")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = false;
+        opts.indent_level = 2;
+        test_fragment('a', '        a');
+        test_fragment(
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '        .a {\n' +
+            '            text-align: right;\n' +
+            '        }');
+        test_fragment(
+            '// This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '        // This is a random comment\n' +
+            '        .a {\n' +
+            '            text-align: right;\n' +
+            '        }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "true", indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "true", indent_level = "2")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = true;
+        opts.indent_level = 2;
+        test_fragment('a', '\t\ta');
+        test_fragment(
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '\t\t.a {\n' +
+            '\t\t\ttext-align: right;\n' +
+            '\t\t}');
+        test_fragment(
+            '// This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '\t\t// This is a random comment\n' +
+            '\t\t.a {\n' +
+            '\t\t\ttext-align: right;\n' +
+            '\t\t}');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")');
+        opts.indent_size = 4;
+        opts.indent_char = ' ';
+        opts.indent_with_tabs = false;
+        opts.indent_level = 0;
+        test_fragment('\t   a');
+        test_fragment(
+            '\t   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '\t   .a {\n' +
+            '\t       text-align: right;\n' +
+            '\t   }');
+        test_fragment(
+            '\t   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            //  -- output --
+            '\t   // This is a random comment\n' +
+            '\t   .a {\n' +
+            '\t       text-align: right;\n' +
+            '\t   }');
+
+
+        //============================================================
         // Empty braces
         reset_options();
         set_name('Empty braces');

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -183,6 +183,152 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
+        // Support Indent Level Options and Base Indent Autodetection - ()
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - ()');
+        test_fragment('   a', 'a');
+        test_fragment(
+            '   <div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '// This is a random comment\n' +
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
+        opts.indent_level = 0;
+        test_fragment('   a', 'a');
+        test_fragment(
+            '   <div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '// This is a random comment\n' +
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")');
+        opts.indent_level = 1;
+        test_fragment('   a', '    a');
+        test_fragment(
+            '   <div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '    <div>\n' +
+            '        <p>This is my sentence.</p>\n' +
+            '    </div>');
+        test_fragment(
+            '   // This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '    // This is a random comment\n' +
+            '    <div>\n' +
+            '        <p>This is my sentence.</p>\n' +
+            '    </div>');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "2")');
+        opts.indent_level = 2;
+        test_fragment('a', '        a');
+        test_fragment(
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '        <div>\n' +
+            '            <p>This is my sentence.</p>\n' +
+            '        </div>');
+        test_fragment(
+            '// This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '        // This is a random comment\n' +
+            '        <div>\n' +
+            '            <p>This is my sentence.</p>\n' +
+            '        </div>');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_with_tabs = "true", indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_with_tabs = "true", indent_level = "2")');
+        opts.indent_with_tabs = true;
+        opts.indent_level = 2;
+        test_fragment('a', '\t\ta');
+        test_fragment(
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '\t\t<div>\n' +
+            '\t\t\t<p>This is my sentence.</p>\n' +
+            '\t\t</div>');
+        test_fragment(
+            '// This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '\t\t// This is a random comment\n' +
+            '\t\t<div>\n' +
+            '\t\t\t<p>This is my sentence.</p>\n' +
+            '\t\t</div>');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
+        opts.indent_level = 0;
+        test_fragment('\t   a', 'a');
+        test_fragment(
+            '\t   <div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+        test_fragment(
+            '\t   // This is a random comment\n' +
+            '<div>\n' +
+            '  <p>This is my sentence.</p>\n' +
+            '</div>',
+            //  -- output --
+            '// This is a random comment\n' +
+            '<div>\n' +
+            '    <p>This is my sentence.</p>\n' +
+            '</div>');
+
+
+        //============================================================
         // Custom Extra Liners (empty) - (extra_liners = "[]")
         reset_options();
         set_name('Custom Extra Liners (empty) - (extra_liners = "[]")');

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -486,6 +486,152 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
 
         //============================================================
+        // Support Indent Level Options and Base Indent Autodetection - ()
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - ()');
+        test_fragment('   a');
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '   // This is a random comment\n' +
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
+        opts.indent_level = 0;
+        test_fragment('   a');
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '   // This is a random comment\n' +
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")');
+        opts.indent_level = 1;
+        test_fragment('   a', '    a');
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '    function test() {\n' +
+            '        console.log("this is a test");\n' +
+            '    }');
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '    // This is a random comment\n' +
+            '    function test() {\n' +
+            '        console.log("this is a test");\n' +
+            '    }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "2")');
+        opts.indent_level = 2;
+        test_fragment('a', '        a');
+        test_fragment(
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '        function test() {\n' +
+            '            console.log("this is a test");\n' +
+            '        }');
+        test_fragment(
+            '// This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '        // This is a random comment\n' +
+            '        function test() {\n' +
+            '            console.log("this is a test");\n' +
+            '        }');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_with_tabs = "true", indent_level = "2")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_with_tabs = "true", indent_level = "2")');
+        opts.indent_with_tabs = true;
+        opts.indent_level = 2;
+        test_fragment('a', '\t\ta');
+        test_fragment(
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '\t\tfunction test() {\n' +
+            '\t\t\tconsole.log("this is a test");\n' +
+            '\t\t}');
+        test_fragment(
+            '// This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '\t\t// This is a random comment\n' +
+            '\t\tfunction test() {\n' +
+            '\t\t\tconsole.log("this is a test");\n' +
+            '\t\t}');
+
+        // Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        reset_options();
+        set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
+        opts.indent_level = 0;
+        test_fragment('\t   a');
+        test_fragment(
+            '\t   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '\t   function test() {\n' +
+            '\t       console.log("this is a test");\n' +
+            '\t   }');
+        test_fragment(
+            '\t   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            //  -- output --
+            '\t   // This is a random comment\n' +
+            '\t   function test() {\n' +
+            '\t       console.log("this is a test");\n' +
+            '\t   }');
+
+
+        //============================================================
         // Support simple language specific option inheritance/overriding - (js = "{ "indent_size": 3 }", css = "{ "indent_size": 5 }")
         reset_options();
         set_name('Support simple language specific option inheritance/overriding - (js = "{ "indent_size": 3 }", css = "{ "indent_size": 5 }")');

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -206,8 +206,11 @@ class Beautifier:
         # input newlines.
         source_text = re.sub(self.allLineBreaks, '\n', source_text)
 
-        m = re.search("^[\t ]*", source_text)
-        baseIndentString = m.group(0)
+        if self._options.base_indent_string is not None:
+            baseIndentString = self._options.base_indent_string
+        else:
+            m = re.search("^[\t ]*", source_text)
+            baseIndentString = m.group(0)
 
         self._output = Output(self._options.indent_string, baseIndentString)
 

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -110,6 +110,163 @@ class CSSBeautifierTest(unittest.TestCase):
 
 
         #============================================================
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = false
+        test_fragment('   a')
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '   // This is a random comment\n' +
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = false
+        self.options.indent_level = 0
+        test_fragment('   a')
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '   // This is a random comment\n' +
+            '   .a {\n' +
+            '       text-align: right;\n' +
+            '   }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "1")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = false
+        self.options.indent_level = 1
+        test_fragment('   a', '    a')
+        test_fragment(
+            '   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '    .a {\n' +
+            '        text-align: right;\n' +
+            '    }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '    // This is a random comment\n' +
+            '    .a {\n' +
+            '        text-align: right;\n' +
+            '    }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "2")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = false
+        self.options.indent_level = 2
+        test_fragment('a', '        a')
+        test_fragment(
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '        .a {\n' +
+            '            text-align: right;\n' +
+            '        }')
+        test_fragment(
+            '// This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '        // This is a random comment\n' +
+            '        .a {\n' +
+            '            text-align: right;\n' +
+            '        }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "true", indent_level = "2")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = true
+        self.options.indent_level = 2
+        test_fragment('a', '\t\ta')
+        test_fragment(
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '\t\t.a {\n' +
+            '\t\t\ttext-align: right;\n' +
+            '\t\t}')
+        test_fragment(
+            '// This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '\t\t// This is a random comment\n' +
+            '\t\t.a {\n' +
+            '\t\t\ttext-align: right;\n' +
+            '\t\t}')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_size = "4", indent_char = "" "", indent_with_tabs = "false", indent_level = "0")
+        self.reset_options()
+        self.options.indent_size = 4
+        self.options.indent_char = ' '
+        self.options.indent_with_tabs = false
+        self.options.indent_level = 0
+        test_fragment('\t   a')
+        test_fragment(
+            '\t   .a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '\t   .a {\n' +
+            '\t       text-align: right;\n' +
+            '\t   }')
+        test_fragment(
+            '\t   // This is a random comment\n' +
+            '.a {\n' +
+            '  text-align: right;\n' +
+            '}',
+            #  -- output --
+            '\t   // This is a random comment\n' +
+            '\t   .a {\n' +
+            '\t       text-align: right;\n' +
+            '\t   }')
+
+
+        #============================================================
         # Empty braces
         self.reset_options()
         t('.tabs{}', '.tabs {}')

--- a/python/jsbeautifier/core/options.py
+++ b/python/jsbeautifier/core/options.py
@@ -42,6 +42,7 @@ class Options:
         self.end_with_newline = self._get_boolean('end_with_newline')
         self.indent_size = self._get_number('indent_size', 4)
         self.indent_char = self._get_characters('indent_char', ' ')
+        self.indent_level = self._get_number('indent_level')
 
         self.preserve_newlines = self._get_boolean('preserve_newlines', True)
         # TODO: fix difference in js and python
@@ -55,6 +56,11 @@ class Options:
             self.indent_size = 1
 
         self.indent_string = self.indent_char * self.indent_size
+
+        # Set to null to continue support for auto detection of base levelself.
+        self.base_indent_string = None
+        if self.indent_level > 0:
+            self.base_indent_string = self.indent_level * self.indent_string
 
         # Backwards compat with 1.3.x
         self.wrap_line_length = self._get_number('wrap_line_length', self._get_number('max_char'))

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -130,13 +130,11 @@ class Beautifier:
         self._last_type = TOKEN.START_BLOCK  # last token type
         self._last_last_text = ''         # pre-last token text
 
-        preindent_index = 0
-        if js_source_text is not None and len(js_source_text) > 0:
-            while preindent_index < len(js_source_text) and \
-                    js_source_text[preindent_index] in [' ', '\t']:
-                baseIndentString += js_source_text[preindent_index]
-                preindent_index += 1
-            js_source_text = js_source_text[preindent_index:]
+        if self._options.base_indent_string is not None:
+            baseIndentString = self._options.base_indent_string
+        else:
+            match = re.search("^[\t ]*", js_source_text)
+            baseIndentString = match.group(0)
 
         self._output = Output(self._options.indent_string, baseIndentString)
         # If testing the ignore directive, start with output disable set to

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -287,6 +287,146 @@ class TestJSBeautifier(unittest.TestCase):
 
 
         #============================================================
+        # Support Indent Level Options and Base Indent Autodetection - ()
+        self.reset_options()
+        test_fragment('   a')
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '   // This is a random comment\n' +
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        self.reset_options()
+        self.options.indent_level = 0
+        test_fragment('   a')
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '   // This is a random comment\n' +
+            '   function test() {\n' +
+            '       console.log("this is a test");\n' +
+            '   }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")
+        self.reset_options()
+        self.options.indent_level = 1
+        test_fragment('   a', '    a')
+        test_fragment(
+            '   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '    function test() {\n' +
+            '        console.log("this is a test");\n' +
+            '    }')
+        test_fragment(
+            '   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '    // This is a random comment\n' +
+            '    function test() {\n' +
+            '        console.log("this is a test");\n' +
+            '    }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_level = "2")
+        self.reset_options()
+        self.options.indent_level = 2
+        test_fragment('a', '        a')
+        test_fragment(
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '        function test() {\n' +
+            '            console.log("this is a test");\n' +
+            '        }')
+        test_fragment(
+            '// This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '        // This is a random comment\n' +
+            '        function test() {\n' +
+            '            console.log("this is a test");\n' +
+            '        }')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_with_tabs = "true", indent_level = "2")
+        self.reset_options()
+        self.options.indent_with_tabs = true
+        self.options.indent_level = 2
+        test_fragment('a', '\t\ta')
+        test_fragment(
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '\t\tfunction test() {\n' +
+            '\t\t\tconsole.log("this is a test");\n' +
+            '\t\t}')
+        test_fragment(
+            '// This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '\t\t// This is a random comment\n' +
+            '\t\tfunction test() {\n' +
+            '\t\t\tconsole.log("this is a test");\n' +
+            '\t\t}')
+
+        # Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
+        self.reset_options()
+        self.options.indent_level = 0
+        test_fragment('\t   a')
+        test_fragment(
+            '\t   function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '\t   function test() {\n' +
+            '\t       console.log("this is a test");\n' +
+            '\t   }')
+        test_fragment(
+            '\t   // This is a random comment\n' +
+            'function test(){\n' +
+            '  console.log("this is a test");\n' +
+            '}',
+            #  -- output --
+            '\t   // This is a random comment\n' +
+            '\t   function test() {\n' +
+            '\t       console.log("this is a test");\n' +
+            '\t   }')
+
+
+        #============================================================
         # Support simple language specific option inheritance/overriding - (js = "{ "indent_size": 3 }", css = "{ "indent_size": 5 }")
         self.reset_options()
         self.options.js = { 'indent_size': 3 }

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -57,6 +57,99 @@ exports.test_data = {
         { fragment: true, input: '\n', output: '{{eof}}' }
       ]
     }, {
+      name: "Support Indent Level Options and Base Indent Autodetection",
+      description: "If user specifies indent level, use it. If not, autodetect indent level from starting whitespace.",
+      matrix: [{
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "false" }
+        ],
+        input_start_indent: '   ',
+        output_start_of_base: '   ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "false" },
+          { name: "indent_level", value: "0" }
+        ],
+        input_start_indent: '   ',
+        output_start_of_base: '   ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "false" },
+          { name: "indent_level", value: "1" }
+        ],
+        input_start_indent: '   ',
+        output_start_of_base: '    ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "false" },
+          { name: "indent_level", value: "2" }
+        ],
+        input_start_indent: '',
+        output_start_of_base: '        ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "true" },
+          { name: "indent_level", value: "2" }
+        ],
+        input_start_indent: '',
+        output_start_of_base: '\t\t',
+        i: '\t'
+      }, {
+        options: [
+          { name: "indent_size", value: "4" },
+          { name: "indent_char", value: "' '" },
+          { name: "indent_with_tabs", value: "false" },
+          { name: "indent_level", value: "0" }
+        ],
+        input_start_indent: '\t   ',
+        output_start_of_base: '\t   ',
+        i: '    '
+      }],
+      tests: [
+        { fragment: true, input: '{{input_start_indent}}a', output: '{{output_start_of_base}}a' },
+        {
+          fragment: true,
+          input: [
+            '{{input_start_indent}}.a {',
+            '  text-align: right;',
+            '}'
+          ],
+          output: [
+            '{{output_start_of_base}}.a {',
+            '{{output_start_of_base}}{{i}}text-align: right;',
+            '{{output_start_of_base}}}'
+          ]
+        }, {
+          fragment: true,
+          input: [
+            '{{input_start_indent}}// This is a random comment',
+            '.a {',
+            '  text-align: right;',
+            '}'
+          ],
+          output: [
+            '{{output_start_of_base}}// This is a random comment',
+            '{{output_start_of_base}}.a {',
+            '{{output_start_of_base}}{{i}}text-align: right;',
+            '{{output_start_of_base}}}'
+          ]
+        }
+      ]
+    }, {
       name: "Empty braces",
       description: "",
       tests: [

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -80,6 +80,81 @@ exports.test_data = {
       { fragment: true, input: '\n', output: '{{eof}}' }
     ]
   }, {
+    name: "Support Indent Level Options and Base Indent Autodetection",
+    description: "If user specifies indent level, use it; otherwise start at zero indent.",
+    matrix: [{
+      options: [],
+      input_start_indent: '   ',
+      output_start_of_base: '',
+      i: '    '
+    }, {
+      options: [
+        { name: "indent_level", value: "0" }
+      ],
+      input_start_indent: '   ',
+      output_start_of_base: '',
+      i: '    '
+    }, {
+      options: [
+        { name: "indent_level", value: "1" }
+      ],
+      input_start_indent: '   ',
+      output_start_of_base: '    ',
+      i: '    '
+    }, {
+      options: [
+        { name: "indent_level", value: "2" }
+      ],
+      input_start_indent: '',
+      output_start_of_base: '        ',
+      i: '    '
+    }, {
+      options: [
+        { name: "indent_with_tabs", value: "true" },
+        { name: "indent_level", value: "2" }
+      ],
+      input_start_indent: '',
+      output_start_of_base: '\t\t',
+      i: '\t'
+    }, {
+      options: [
+        { name: "indent_level", value: "0" }
+      ],
+      input_start_indent: '\t   ',
+      output_start_of_base: '',
+      i: '    '
+    }],
+    tests: [
+      { fragment: true, input: '{{input_start_indent}}a', output: '{{output_start_of_base}}a' },
+      {
+        fragment: true,
+        input: [
+          '{{input_start_indent}}<div>',
+          '  <p>This is my sentence.</p>',
+          '</div>'
+        ],
+        output: [
+          '{{output_start_of_base}}<div>',
+          '{{output_start_of_base}}{{i}}<p>This is my sentence.</p>',
+          '{{output_start_of_base}}</div>'
+        ]
+      }, {
+        fragment: true,
+        input: [
+          '{{input_start_indent}}// This is a random comment',
+          '<div>',
+          '  <p>This is my sentence.</p>',
+          '</div>'
+        ],
+        output: [
+          '{{output_start_of_base}}// This is a random comment',
+          '{{output_start_of_base}}<div>',
+          '{{output_start_of_base}}{{i}}<p>This is my sentence.</p>',
+          '{{output_start_of_base}}</div>'
+        ]
+      }
+    ]
+  }, {
     name: "Custom Extra Liners (empty)",
     description: "",
     matrix: [{

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -188,6 +188,81 @@ exports.test_data = {
         { fragment: true, input: '\n', output: '{{eof}}' }
       ]
     }, {
+      name: "Support Indent Level Options and Base Indent Autodetection",
+      description: "If user specifies indent level, use it. If not, autodetect indent level from starting whitespace.",
+      matrix: [{
+        options: [],
+        input_start_indent: '   ',
+        output_start_of_base: '   ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_level", value: "0" }
+        ],
+        input_start_indent: '   ',
+        output_start_of_base: '   ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_level", value: "1" }
+        ],
+        input_start_indent: '   ',
+        output_start_of_base: '    ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_level", value: "2" }
+        ],
+        input_start_indent: '',
+        output_start_of_base: '        ',
+        i: '    '
+      }, {
+        options: [
+          { name: "indent_with_tabs", value: "true" },
+          { name: "indent_level", value: "2" }
+        ],
+        input_start_indent: '',
+        output_start_of_base: '\t\t',
+        i: '\t'
+      }, {
+        options: [
+          { name: "indent_level", value: "0" }
+        ],
+        input_start_indent: '\t   ',
+        output_start_of_base: '\t   ',
+        i: '    '
+      }],
+      tests: [
+        { fragment: true, input: '{{input_start_indent}}a', output: '{{output_start_of_base}}a' },
+        {
+          fragment: true,
+          input: [
+            '{{input_start_indent}}function test(){',
+            '  console.log("this is a test");',
+            '}'
+          ],
+          output: [
+            '{{output_start_of_base}}function test() {',
+            '{{output_start_of_base}}{{i}}console.log("this is a test");',
+            '{{output_start_of_base}}}'
+          ]
+        }, {
+          fragment: true,
+          input: [
+            '{{input_start_indent}}// This is a random comment',
+            'function test(){',
+            '  console.log("this is a test");',
+            '}'
+          ],
+          output: [
+            '{{output_start_of_base}}// This is a random comment',
+            '{{output_start_of_base}}function test() {',
+            '{{output_start_of_base}}{{i}}console.log("this is a test");',
+            '{{output_start_of_base}}}'
+          ]
+        }
+      ]
+    }, {
       name: "Support simple language specific option inheritance/overriding",
       description: "Support simple language specific option inheritance/overriding",
       matrix: [{


### PR DESCRIPTION
Fixes #724

This fix addresses most of the functionality with one major exception. If you set the indent level to zero in CSS and JS, the beautifier still autodetects the indentation of the inputted code. I will be filing a bug for this specific functionality. 