### PR TITLE
Preserve new line at start of handlebars contents

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -60,23 +60,25 @@ Printer.prototype.add_raw_token = function(token) {
   this._output.add_raw_token(token);
 };
 
+Printer.prototype.print_preserved_newlines = function(raw_token) {
+  var newlines = 0;
+  if (raw_token.type !== TOKEN.TEXT && raw_token.previous.type !== TOKEN.TEXT) {
+    newlines = raw_token.newlines ? 1 : 0;
+  }
+
+  if (this.preserve_newlines) {
+    newlines = raw_token.newlines < this.max_preserve_newlines + 1 ? raw_token.newlines : this.max_preserve_newlines + 1;
+  }
+  for (var n = 0; n < newlines; n++) {
+    this.print_newline(n > 0);
+  }
+
+  return newlines !== 0;
+};
+
 Printer.prototype.traverse_whitespace = function(raw_token) {
   if (raw_token.whitespace_before || raw_token.newlines) {
-    var newlines = 0;
-
-    if (raw_token.type !== TOKEN.TEXT && raw_token.previous.type !== TOKEN.TEXT) {
-      newlines = raw_token.newlines ? 1 : 0;
-    }
-
-    if (this.preserve_newlines) {
-      newlines = raw_token.newlines < this.max_preserve_newlines + 1 ? raw_token.newlines : this.max_preserve_newlines + 1;
-    }
-
-    if (newlines) {
-      for (var n = 0; n < newlines; n++) {
-        this.print_newline(n > 0);
-      }
-    } else {
+    if (!this.print_preserved_newlines(raw_token)) {
       this._output.space_before_token = true;
       this.print_space_or_wrap(raw_token.text);
     }
@@ -339,16 +341,21 @@ Beautifier.prototype._handle_inside_tag = function(printer, raw_token, last_tag_
   printer.set_space_before_token(raw_token.newlines || raw_token.whitespace_before !== '');
   if (last_tag_token.is_unformatted) {
     printer.add_raw_token(raw_token);
+  } else if (last_tag_token.tag_start_char === '{' && raw_token.type === TOKEN.TEXT) {
+    // For the insides of handlebars allow newlines or a single space between open and contents
+    if (printer.print_preserved_newlines(raw_token)) {
+      printer.print_raw_text(raw_token.whitespace_before + raw_token.text);
+    } else {
+      printer.print_token(raw_token.text);
+    }
   } else {
-    if (last_tag_token.tag_start_char === '<') {
-      if (raw_token.type === TOKEN.ATTRIBUTE) {
-        printer.set_space_before_token(true);
-        last_tag_token.attr_count += 1;
-      } else if (raw_token.type === TOKEN.EQUALS) { //no space before =
-        printer.set_space_before_token(false);
-      } else if (raw_token.type === TOKEN.VALUE && raw_token.previous.type === TOKEN.EQUALS) { //no space before value
-        printer.set_space_before_token(false);
-      }
+    if (raw_token.type === TOKEN.ATTRIBUTE) {
+      printer.set_space_before_token(true);
+      last_tag_token.attr_count += 1;
+    } else if (raw_token.type === TOKEN.EQUALS) { //no space before =
+      printer.set_space_before_token(false);
+    } else if (raw_token.type === TOKEN.VALUE && raw_token.previous.type === TOKEN.EQUALS) { //no space before value
+      printer.set_space_before_token(false);
     }
 
     if (printer._output.space_before_token && last_tag_token.tag_start_char === '<') {

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -1859,6 +1859,22 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{em-input label="Type*" property="type" type="text" placeholder="(LTD)"}}\n' +
             '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. Just treated as text here.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            'label="Some Labe" property="amt"\n' +
+            'type="text" placeholder=""}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{#if callOn}}\n' +
             '{{#unless callOn}}\n' +
@@ -1906,6 +1922,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{{field}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{field}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{field}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{field}}\n' +
@@ -2144,6 +2178,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
@@ -2382,6 +2434,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{{! comment}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{! comment}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{! comment}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{! comment}}\n' +
@@ -2620,6 +2690,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{{!-- comment--}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- comment--}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- comment--}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{!-- comment--}}\n' +
@@ -2858,6 +2946,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{{Hello "woRld"}} {{!-- comment--}} {{heLloWorlD}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{Hello "woRld"}} {{!-- comment--}} {{heLloWorlD}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{Hello "woRld"}} {{!-- comment--}} {{heLloWorlD}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{Hello "woRld"}} {{!-- comment--}} {{heLloWorlD}}\n' +
@@ -3096,6 +3202,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             '{pre{{field1}} {{field2}} {{field3}}post\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{pre{{field1}} {{field2}} {{field3}}post\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{pre{{field1}} {{field2}} {{field3}}post\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{pre{{field1}} {{field2}} {{field3}}post\n' +
@@ -3346,6 +3470,32 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '     with spacing\n' +
             '}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{! \n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            '}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{! \n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            '}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{! \n' +
@@ -3755,6 +3905,32 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '     with spacing\n' +
             '--}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- \n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            '--}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- \n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            '--}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{!-- \n' +
@@ -4173,6 +4349,38 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '     with spacing\n' +
             ' {{/ component}}--}}\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- \n' +
+            ' mult-line\n' +
+            'comment \n' +
+            '{{#> component}}\n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            ' {{/ component}}--}}\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            '{{!-- \n' +
+            ' mult-line\n' +
+            'comment \n' +
+            '{{#> component}}\n' +
+            ' mult-line\n' +
+            'comment  \n' +
+            '     with spacing\n' +
+            ' {{/ component}}--}}\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             '{{!-- \n' +
@@ -4685,6 +4893,24 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{ myHelper someValue}}\n' +
             'content\n' +
             '{{value-title}}');
+        
+        // Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.
+        bth(
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            'content\n' +
+            '   {{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '       {{em-input label="Place*" property="place" type="text" placeholder=""}}',
+            //  -- output --
+            '{{em-input\n' +
+            '  label="Some Labe" property="amt"\n' +
+            '  type="text" placeholder=""}}\n' +
+            'content\n' +
+            '{{em-input label="Type*"\n' +
+            'property="type" type="text" placeholder="(LTD)"}}\n' +
+            '{{em-input label="Place*" property="place" type="text" placeholder=""}}');
         bth(
             '{{em-input label="Some Labe" property="amt" type="text" placeholder=""}}\n' +
             'content\n' +

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -780,6 +780,25 @@ exports.test_data = {
         ]
       },
       {
+        comment: "Issue #1469 - preserve newlines inside handlebars, including first one. Just treated as text here.",
+        input_: [
+          '{{em-input',
+          '  label="Some Labe" property="amt"',
+          '  type="text" placeholder=""}}',
+          '   {{em-input label="Type*"',
+          'property="type" type="text" placeholder="(LTD)"}}',
+          '       {{em-input label="Place*" property="place" type="text" placeholder=""}}'
+        ],
+        output: [
+          '{{em-input',
+          'label="Some Labe" property="amt"',
+          'type="text" placeholder=""}}',
+          '{{em-input label="Type*"',
+          'property="type" type="text" placeholder="(LTD)"}}',
+          '{{em-input label="Place*" property="place" type="text" placeholder=""}}'
+        ]
+      },
+      {
         input_: [
           '{{#if callOn}}',
           '{{#unless callOn}}',
@@ -897,6 +916,27 @@ exports.test_data = {
           '{{ myHelper someValue}}',
           '^^^&content$$$',
           '{{value-title}}'
+        ]
+      },
+      {
+        comment: "Issue #1469 - preserve newlines inside handlebars, including first one. BUG: does not fix indenting inside handlebars.",
+        input_: [
+          '{{em-input',
+          '  label="Some Labe" property="amt"',
+          '  type="text" placeholder=""}}',
+          '^^^&content$$$',
+          '   {{em-input label="Type*"',
+          'property="type" type="text" placeholder="(LTD)"}}',
+          '       {{em-input label="Place*" property="place" type="text" placeholder=""}}'
+        ],
+        output: [
+          '{{em-input',
+          '  label="Some Labe" property="amt"',
+          '  type="text" placeholder=""}}',
+          '^^^&content$$$',
+          '{{em-input label="Type*"',
+          'property="type" type="text" placeholder="(LTD)"}}',
+          '{{em-input label="Place*" property="place" type="text" placeholder=""}}'
         ]
       },
       {


### PR DESCRIPTION
Fixes #1469 

This change only makes it so new line is preserved for the first hbs attribute.  This doesn't fix or change deeper handlebars/hbs formatting, nor does it cause handlebars to be beautified better insides are still not reindented if they are off.  This only make the beautifier not undo user formatting. 
