### PR TITLE
Move to beauitifier.io

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at team@jsbeautifier.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at team@beautifier.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Files related to the JavaScript implementations of the beautifiers.
 Files related to the Python implementations of the beautifiers.
 
 ## `web`
-Files related to http://jsbeautifier.org/.
+Files related to https://beautifier.io/.
 
 ## `test`
 Test data files and support files used to generate implementation-specific test files.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JavaScript, unpack scripts packed by Dean Edward’s popular packer,
 as well as partly deobfuscate scripts processed by the npm package
 [javascript-obfuscator](https://github.com/javascript-obfuscator/javascript-obfuscator).
 
-Open [jsbeautifier.org](http://jsbeautifier.org/) to try it out.  Options are available via the UI.
+Open [beautifier.io](https://beautifier.io/) to try it out.  Options are available via the UI.
 
 # Contributors Needed
 I'm putting this front and center above because existing owners have very limited time to work on this project currently.
@@ -92,7 +92,7 @@ $ pip install jsbeautifier
 You can beautify javascript using JS Beautifier in your web browser, or on the command-line using node.js or python.
 
 ## Web Browser
-Open [jsbeautifier.org](http://jsbeautifier.org/).  Options are available via the UI.
+Open [beautifier.io](https://beautifier.io/).  Options are available via the UI.
 
 ## Web Libary
 The script tags above expose three functions: `js_beautify`, `css_beautify`, and `html_beautify`.
@@ -365,10 +365,10 @@ You are free to use this in any way you want, in case you find this useful or wo
 
 # Credits
 
-* Created by Einar Lielmanis, <einar@jsbeautifier.org>
+* Created by Einar Lielmanis, <einar@beautifier.io>
 * Python version flourished by Stefano Sanfilippo <a.little.coder@gmail.com>
 * Command-line for node.js by Daniel Stockman <daniel.stockman@gmail.com>
-* Maintained and expanded by Liam Newman <bitwiseman@gmail.com>
+* Maintained and expanded by Liam Newman <bitwiseman@beautifier.io>
 
 Thanks also to Jason Diamond, Patrick Hof, Nochum Sossonko, Andreas Schneider, Dave
 Vasilevsky, Vital Batmanov, Ron Baldwin, Gabriel Harrison, Chris J. Shull,

--- a/index.html
+++ b/index.html
@@ -190,8 +190,10 @@
     <div class="col-6">
       <ul class="uses">
 
-        <li>A <a href="javascript:(function(){s=document.getElementsByTagName('SCRIPT');tx='';sr=[];for(i=0;i<s.length;i++){with(s.item(i)){t=text;if(t){tx+=t;}else{sr.push(src)};}};with(window.open()){document.write('<textarea id=&quot;t&quot;>'+(sr.join(&quot;\n&quot;))+&quot;\n\n-----\n\n&quot;+tx+'</textarea><script src=&quot;https://beautifier.io/beautify.js&quot;></script><script>with(document.getElementById(&quot;t&quot;)){value=js_beautify(value);with(style){width=&quot;99%&quot;;height=&quot;99%&quot;;borderStyle=&quot;none&quot;;}};</script>');document.close();}})();"><strong>bookmarklet</strong></a> (drag
-          it to your bookmarks) by Ichiro Hiroshi to see all scripts used on the page,</li>
+        <li>A
+          <a href="javascript:(function(){s=document.getElementsByTagName('SCRIPT');tx='';sr=[];for(i=0;i<s.length;i++){with(s.item(i)){t=text;if(t){tx+=t;}else{sr.push(src)};}};with(window.open()){document.write('<textarea id=&quot;t&quot;>'+(sr.join(&quot;\n&quot;))+&quot;\n\n-----\n\n&quot;+tx+'</textarea><script src=&quot;https://beautifier.io/js/lib/beautify.js&quot;></script><script>with(document.getElementById(&quot;t&quot;)){value=js_beautify(value);with(style){width=&quot;99%&quot;;height=&quot;99%&quot;;borderStyle=&quot;none&quot;;}};</script>');document.close();}})();">
+            <strong>bookmarklet</strong></a>
+          (drag it to your bookmarks) by Ichiro Hiroshi to see all scripts used on the page,</li>
 
         <li><strong>Chrome</strong>, in case the built-in CSS and javascript formatting isn't enough for you:<br>
           — <a href="https://chrome.google.com/webstore/detail/cfmcghennfbpmhemnnfjhkdmnbidpanb">Quick source viewer</a> by Tomi Mickelsson (<a href="https://github.com/tomimick/chrome-ext-view-src">github</a>, <a href="http://tomicloud.com/2012/07/viewsrc-chrome-ext">blog</a>),<br>

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
     <div class="col-6">
       <ul class="uses">
 
-        <li>A <a href="javascript:(function(){s=document.getElementsByTagName('SCRIPT');tx='';sr=[];for(i=0;i<s.length;i++){with(s.item(i)){t=text;if(t){tx+=t;}else{sr.push(src)};}};with(window.open()){document.write('<textarea id=&quot;t&quot;>'+(sr.join(&quot;\n&quot;))+&quot;\n\n-----\n\n&quot;+tx+'</textarea><script src=&quot;http://jsbeautifier.org/beautify.js&quot;></script><script>with(document.getElementById(&quot;t&quot;)){value=js_beautify(value);with(style){width=&quot;99%&quot;;height=&quot;99%&quot;;borderStyle=&quot;none&quot;;}};</script>');document.close();}})();"><strong>bookmarklet</strong></a> (drag
+        <li>A <a href="javascript:(function(){s=document.getElementsByTagName('SCRIPT');tx='';sr=[];for(i=0;i<s.length;i++){with(s.item(i)){t=text;if(t){tx+=t;}else{sr.push(src)};}};with(window.open()){document.write('<textarea id=&quot;t&quot;>'+(sr.join(&quot;\n&quot;))+&quot;\n\n-----\n\n&quot;+tx+'</textarea><script src=&quot;https://beautifier.io/beautify.js&quot;></script><script>with(document.getElementById(&quot;t&quot;)){value=js_beautify(value);with(style){width=&quot;99%&quot;;height=&quot;99%&quot;;borderStyle=&quot;none&quot;;}};</script>');document.close();}})();"><strong>bookmarklet</strong></a> (drag
           it to your bookmarks) by Ichiro Hiroshi to see all scripts used on the page,</li>
 
         <li><strong>Chrome</strong>, in case the built-in CSS and javascript formatting isn't enough for you:<br>
@@ -246,7 +246,7 @@
         <li><a href="http://liveditor.com/">LIVEditor</a>, a live-editing HTML/CSS/JS IDE (commercial, Windows-only) uses the library,</li>
       </ul>
     </div>
-    <p>Doing anything interesting? Write us to <b>team@jsbeautifier.org</b> so we can add your project to the list.</p>
+    <p>Doing anything interesting? Write us to <b>team@beautifier.io</b> so we can add your project to the list.</p>
 
     <p class="contributor-sep">Written by <a href="https://github.com/einars">Einar Lielmanis</a>, maintained and evolved by <a href="https://github.com/bitwiseman/">Liam Newman</a>.</p>
     <p>We use the wonderful <a href="http://codemirror.net">CodeMirror</a> syntax highlighting editor, written by Marijn Haverbeke.

--- a/js/src/unpackers/javascriptobfuscator_unpacker.js
+++ b/js/src/unpackers/javascriptobfuscator_unpacker.js
@@ -27,7 +27,7 @@
 
 //
 // simple unpacker/deobfuscator for scripts messed up with javascriptobfuscator.com
-// written by Einar Lielmanis <einar@jsbeautifier.org>
+// written by Einar Lielmanis <einar@beautifier.io>
 //
 // usage:
 //

--- a/js/src/unpackers/myobfuscate_unpacker.js
+++ b/js/src/unpackers/myobfuscate_unpacker.js
@@ -43,7 +43,7 @@
 
 */
 //
-// written by Einar Lielmanis <einar@jsbeautifier.org>
+// written by Einar Lielmanis <einar@beautifier.io>
 //
 // usage:
 //

--- a/js/src/unpackers/urlencode_unpacker.js
+++ b/js/src/unpackers/urlencode_unpacker.js
@@ -30,7 +30,7 @@
 
 //
 // trivial bookmarklet/escaped script detector for the javascript beautifier
-// written by Einar Lielmanis <einar@jsbeautifier.org>
+// written by Einar Lielmanis <einar@beautifier.io>
 //
 // usage:
 //

--- a/js/test/sanitytest.js
+++ b/js/test/sanitytest.js
@@ -1,6 +1,6 @@
 //
 // simple testing interface
-// written by Einar Lielmanis, einar@jsbeautifier.org
+// written by Einar Lielmanis, einar@beautifier.io
 //
 // usage:
 //

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-beautify",
   "version": "1.8.4",
-  "description": "jsbeautifier.org for node",
+  "description": "beautifier.io for node",
   "main": "js/index.js",
   "bin": {
     "css-beautify": "./js/bin/css-beautify.js",
@@ -21,7 +21,7 @@
   ],
   "scripts": {},
   "bugs": "https://github.com/beautify-web/js-beautify/issues",
-  "homepage": "http://jsbeautifier.org/",
+  "homepage": "https://beautifier.io/",
   "repository": {
     "type": "git",
     "url": "git://github.com/beautify-web/js-beautify.git"
@@ -31,7 +31,7 @@
     "beautifier",
     "code-quality"
   ],
-  "author": "Einar Lielmanis <einar@jsbeautifier.org>",
+  "author": "Einar Lielmanis <einar@beautifier.io>",
   "contributors": [
     "Vital Batmanov <vital76@gmail.com>",
     "Chris J. Shull <chrisjshull@gmail.com>",
@@ -41,7 +41,7 @@
     "Daniel Stockman <daniel.stockman@gmail.com>",
     "Harutyun Amirjanyan <amirjanyan@gmail.com>",
     "Nochum Sossonko <nsossonko@hotmail.com>",
-    "Liam Newman <bitwiseman@gmail.com>"
+    "Liam Newman <bitwiseman@beautifier.io>"
   ],
   "license": "MIT",
   "dependencies": {

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -68,7 +68,7 @@ def usage(stream=sys.stdout):
 
     print("cssbeautifier.py@" + __version__ + """
 
-CSS beautifier (http://jsbeautifier.org/)
+CSS beautifier (https://beautifier.io/)
 
 Usage: cssbeautifier.py [options] <infile>
 

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -68,7 +68,7 @@ def usage(stream=sys.stdout):
 
     print("cssbeautifier.py@" + __version__ + """
 
-CSS beautifier (http://jsbeautifier.org/)
+CSS beautifier (https://beautifier.io/)
 
 """, file=stream)
     if stream == sys.stderr:

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -37,9 +37,9 @@ from jsbeautifier.javascript.beautifier import Beautifier
 # SOFTWARE.
 #
 # Originally written by Einar Lielmanis et al.,
-# Conversion to python by Einar Lielmanis, einar@jsbeautifier.org,
+# Conversion to python by Einar Lielmanis, einar@beautifier.io,
 # Parsing improvement for brace-less and semicolon-less statements
-#    by Liam Newman <bitwiseman@gmail.com>
+#    by Liam Newman <bitwiseman@beautifier.io>
 # Python is not my native language, feel free to push things around.
 #
 # Use either from command line (script displays its usage when run
@@ -130,7 +130,7 @@ def usage(stream=sys.stdout):
 
     print("jsbeautifier.py@" + __version__ + """
 
-Javascript beautifier (http://jsbeautifier.org/)
+Javascript beautifier (https://beautifier.io/)
 
 Usage: jsbeautifier.py [options] <infile>
 

--- a/python/jsbeautifier/unpackers/evalbased.py
+++ b/python/jsbeautifier/unpackers/evalbased.py
@@ -1,6 +1,6 @@
 #
 # Unpacker for eval() based packers, a part of javascript beautifier
-# by Einar Lielmanis <einar@jsbeautifier.org>
+# by Einar Lielmanis <einar@beautifier.io>
 #
 #     written by Stefano Sanfilippo <a.little.coder@gmail.com>
 #

--- a/python/jsbeautifier/unpackers/javascriptobfuscator.py
+++ b/python/jsbeautifier/unpackers/javascriptobfuscator.py
@@ -2,7 +2,7 @@
 # simple unpacker/deobfuscator for scripts messed up with
 # javascriptobfuscator.com
 #
-#     written by Einar Lielmanis <einar@jsbeautifier.org>
+#     written by Einar Lielmanis <einar@beautifier.io>
 #     rewritten in Python by Stefano Sanfilippo <a.little.coder@gmail.com>
 #
 # Will always return valid javascript: if `detect()` is false, `code` is

--- a/python/jsbeautifier/unpackers/myobfuscate.py
+++ b/python/jsbeautifier/unpackers/myobfuscate.py
@@ -1,6 +1,6 @@
 #
 # deobfuscator for scripts messed up with myobfuscate.com
-# by Einar Lielmanis <einar@jsbeautifier.org>
+# by Einar Lielmanis <einar@beautifier.io>
 #
 #     written by Stefano Sanfilippo <a.little.coder@gmail.com>
 #

--- a/python/jsbeautifier/unpackers/packer.py
+++ b/python/jsbeautifier/unpackers/packer.py
@@ -1,6 +1,6 @@
 #
 # Unpacker for Dean Edward's p.a.c.k.e.r, a part of javascript beautifier
-# by Einar Lielmanis <einar@jsbeautifier.org>
+# by Einar Lielmanis <einar@beautifier.io>
 #
 #     written by Stefano Sanfilippo <a.little.coder@gmail.com>
 #

--- a/python/jsbeautifier/unpackers/urlencode.py
+++ b/python/jsbeautifier/unpackers/urlencode.py
@@ -1,6 +1,6 @@
 #
 # Trivial bookmarklet/escaped script detector for the javascript beautifier
-#     written by Einar Lielmanis <einar@jsbeautifier.org>
+#     written by Einar Lielmanis <einar@beautifier.io>
 #     rewritten in Python by Stefano Sanfilippo <a.little.coder@gmail.com>
 #
 # Will always return valid javascript: if `detect()` is false, `code` is

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,8 +32,8 @@ setup(name='jsbeautifier',
       long_description=('Beautify, unpack or deobfuscate JavaScript. '
                         'Handles popular online obfuscators.'),
       author='Liam Newman, Einar Lielmanis, et al.',
-      author_email='team@jsbeautifier.org',
-      url='http://jsbeautifier.org',
+      author_email='team@beautifier.io',
+      url='https://beautifier.io',
       entry_points={
           'console_scripts': [
               'js-beautify = jsbeautifier:main'

--- a/tools/template/beautify-css.wrapper.js
+++ b/tools/template/beautify-css.wrapper.js
@@ -31,8 +31,8 @@
 
     Written by Harutyun Amirjanyan, (amirjanyan@gmail.com)
 
-    Based on code initially developed by: Einar Lielmanis, <einar@jsbeautifier.org>
-        http://jsbeautifier.org/
+    Based on code initially developed by: Einar Lielmanis, <einar@beautifier.io>
+        https://beautifier.io/
 
     Usage:
         css_beautify(source_text);

--- a/tools/template/beautify-html.wrapper.js
+++ b/tools/template/beautify-html.wrapper.js
@@ -31,8 +31,8 @@
 
   Written by Nochum Sossonko, (nsossonko@hotmail.com)
 
-  Based on code initially developed by: Einar Lielmanis, <einar@jsbeautifier.org>
-    http://jsbeautifier.org/
+  Based on code initially developed by: Einar Lielmanis, <einar@beautifier.io>
+    https://beautifier.io/
 
   Usage:
     style_html(html_source);

--- a/tools/template/beautify.wrapper.js
+++ b/tools/template/beautify.wrapper.js
@@ -29,12 +29,12 @@
 ---------------
 
 
-  Written by Einar Lielmanis, <einar@jsbeautifier.org>
-      http://jsbeautifier.org/
+  Written by Einar Lielmanis, <einar@beautifier.io>
+      https://beautifier.io/
 
   Originally converted to javascript by Vital, <vital76@gmail.com>
   "End braces on own line" added by Chris J. Shull, <chrisjshull@gmail.com>
-  Parsing improvements for brace-less statements by Liam Newman <bitwiseman@gmail.com>
+  Parsing improvements for brace-less statements by Liam Newman <bitwiseman@beautifier.io>
 
 
   Usage:


### PR DESCRIPTION
http://jsbeautifier.org now forwards to https://beautifier.io
So does http://jsbeautifier.com.   

This change redirects all emails and other references to beautifier.io.  

Also fix broken bookmarklet.  Added issue to track testing to protect this in future - #1542.

Closes #1399 - https is now on. 