### PR TITLE
Add html/text support to script tag

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -170,6 +170,9 @@ var get_custom_beautifier_name = function(tag_check, start_token) {
     return 'javascript';
   } else if (typeAttribute.search(/(text|application|dojo)\/(x-)?(html)/) > -1) {
     return 'html';
+  } else if (typeAttribute.search(/test\/null/) > -1) {
+    // Test only mime-type for testing the beautifier when null is passed as beautifing function
+    return 'null';
   }
 
   return null;
@@ -479,11 +482,12 @@ Beautifier.prototype._print_custom_beatifier_text = function(printer, raw_token,
       text = _beautifier(indentation + text, child_options);
     } else {
       // simply indent the string otherwise
-      var white = text.match(/^\s*/)[0];
-      var _level = white.match(/[^\n\r]*$/)[0].split(this._options.indent_string).length - 1;
-      var reindent = this._get_full_indent(script_indent_level - _level);
-      text = (indentation + text.trim())
-        .replace(/\r\n|\r|\n/g, '\n' + reindent);
+      var white = raw_token.whitespace_before;
+      if (white) {
+        text = text.replace(new RegExp('\n(' + white + ')?', 'g'), '\n');
+      }
+
+      text = indentation + text.replace(/\n/g, '\n' + indentation);
     }
     if (text) {
       printer.print_raw_text(text);

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -444,6 +444,35 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '        <div></div>\n' +
             '    </div>\n' +
             '</script>');
+        
+        // null beatifier behavior - should still indent
+        test_fragment(
+            '<script type="test/null">\n' +
+            '    <div>\n' +
+            '  <div></div><div></div></div></script>',
+            //  -- output --
+            '<script type="test/null">\n' +
+            '    <div>\n' +
+            '      <div></div><div></div></div>\n' +
+            '</script>');
+        bth(
+            '<script type="test/null">\n' +
+            '   <div>\n' +
+            '     <div></div><div></div></div></script>',
+            //  -- output --
+            '<script type="test/null">\n' +
+            '    <div>\n' +
+            '      <div></div><div></div></div>\n' +
+            '</script>');
+        bth(
+            '<script type="test/null">\n' +
+            '<div>\n' +
+            '<div></div><div></div></div></script>',
+            //  -- output --
+            '<script type="test/null">\n' +
+            '    <div>\n' +
+            '    <div></div><div></div></div>\n' +
+            '</script>');
         bth(
             '<script>var foo = "bar";</script>',
             //  -- output --

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -187,49 +187,49 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         // Support Indent Level Options and Base Indent Autodetection - ()
         reset_options();
         set_name('Support Indent Level Options and Base Indent Autodetection - ()');
-        test_fragment('   a', 'a');
+        test_fragment('   a');
         test_fragment(
             '   <div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '   <div>\n' +
+            '       <p>This is my sentence.</p>\n' +
+            '   </div>');
         test_fragment(
             '   // This is a random comment\n' +
             '<div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '// This is a random comment\n' +
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '   // This is a random comment\n' +
+            '   <div>\n' +
+            '       <p>This is my sentence.</p>\n' +
+            '   </div>');
 
         // Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")
         reset_options();
         set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
         opts.indent_level = 0;
-        test_fragment('   a', 'a');
+        test_fragment('   a');
         test_fragment(
             '   <div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '   <div>\n' +
+            '       <p>This is my sentence.</p>\n' +
+            '   </div>');
         test_fragment(
             '   // This is a random comment\n' +
             '<div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '// This is a random comment\n' +
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '   // This is a random comment\n' +
+            '   <div>\n' +
+            '       <p>This is my sentence.</p>\n' +
+            '   </div>');
 
         // Support Indent Level Options and Base Indent Autodetection - (indent_level = "1")
         reset_options();
@@ -308,25 +308,25 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         reset_options();
         set_name('Support Indent Level Options and Base Indent Autodetection - (indent_level = "0")');
         opts.indent_level = 0;
-        test_fragment('\t   a', 'a');
+        test_fragment('\t   a');
         test_fragment(
             '\t   <div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '\t   <div>\n' +
+            '\t       <p>This is my sentence.</p>\n' +
+            '\t   </div>');
         test_fragment(
             '\t   // This is a random comment\n' +
             '<div>\n' +
             '  <p>This is my sentence.</p>\n' +
             '</div>',
             //  -- output --
-            '// This is a random comment\n' +
-            '<div>\n' +
-            '    <p>This is my sentence.</p>\n' +
-            '</div>');
+            '\t   // This is a random comment\n' +
+            '\t   <div>\n' +
+            '\t       <p>This is my sentence.</p>\n' +
+            '\t   </div>');
 
 
         //============================================================
@@ -430,6 +430,19 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             //  -- output --
             '<script>\n' +
             '    < div > < /div>\n' +
+            '</script>');
+        
+        // text/html should beautify as html
+        bth(
+            '<script type="text/html">\n' +
+            '<div>\n' +
+            '<div></div><div></div></div></script>',
+            //  -- output --
+            '<script type="text/html">\n' +
+            '    <div>\n' +
+            '        <div></div>\n' +
+            '        <div></div>\n' +
+            '    </div>\n' +
             '</script>');
         bth(
             '<script>var foo = "bar";</script>',
@@ -7311,10 +7324,10 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '    </div>',
             '<div>\n' +
             '</div>');
-        bth('    <div>\n' +
+        test_fragment('   <div>\n' +
             '    </div>',
-            '<div>\n' +
-            '</div>');
+            '   <div>\n' +
+            '   </div>');
         bth('<div>\n' +
             '</div>\n' +
             '    <div>\n' +
@@ -7323,10 +7336,10 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '</div>\n' +
             '<div>\n' +
             '</div>');
-        bth('    <div>\n' +
+        test_fragment('   <div>\n' +
             '</div>',
-            '<div>\n' +
-            '</div>');
+            '   <div>\n' +
+            '   </div>');
         bth('<div        >content</div>',
             '<div>content</div>');
         bth('<div     thinger="preserve  space  here"   ></div  >',

--- a/test/data/html/node.mustache
+++ b/test/data/html/node.mustache
@@ -235,10 +235,10 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '    </div>',
             '<div>\n' +
             '</div>');
-        bth('    <div>\n' +
+        test_fragment('   <div>\n' +
             '    </div>',
-            '<div>\n' +
-            '</div>');
+            '   <div>\n' +
+            '   </div>');
         bth('<div>\n' +
             '</div>\n' +
             '    <div>\n' +
@@ -247,10 +247,10 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '</div>\n' +
             '<div>\n' +
             '</div>');
-        bth('    <div>\n' +
+        test_fragment('   <div>\n' +
             '</div>',
-            '<div>\n' +
-            '</div>');
+            '   <div>\n' +
+            '   </div>');
         bth('<div        >content</div>',
             '<div>content</div>');
         bth('<div     thinger="preserve  space  here"   ></div  >',

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -85,14 +85,14 @@ exports.test_data = {
     matrix: [{
       options: [],
       input_start_indent: '   ',
-      output_start_of_base: '',
+      output_start_of_base: '   ',
       i: '    '
     }, {
       options: [
         { name: "indent_level", value: "0" }
       ],
       input_start_indent: '   ',
-      output_start_of_base: '',
+      output_start_of_base: '   ',
       i: '    '
     }, {
       options: [
@@ -121,7 +121,7 @@ exports.test_data = {
         { name: "indent_level", value: "0" }
       ],
       input_start_indent: '\t   ',
-      output_start_of_base: '',
+      output_start_of_base: '\t   ',
       i: '    '
     }],
     tests: [
@@ -236,6 +236,17 @@ exports.test_data = {
         output: [
           '<script>',
           '    < div > < /div>',
+          '</script>'
+        ]
+      }, {
+        comment: 'text/html should beautify as html',
+        input: '<script type="text/html">\n<div>\n<div></div><div></div></div></script>',
+        output: [
+          '<script type="text/html">',
+          '    <div>',
+          '        <div></div>',
+          '        <div></div>',
+          '    </div>',
           '</script>'
         ]
       }, {

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -250,6 +250,32 @@ exports.test_data = {
           '</script>'
         ]
       }, {
+        comment: 'null beatifier behavior - should still indent',
+        fragment: true,
+        input: '<script type="test/null">\n    <div>\n  <div></div><div></div></div></script>',
+        output: [
+          '<script type="test/null">',
+          '    <div>',
+          '      <div></div><div></div></div>',
+          '</script>'
+        ]
+      }, {
+        input: '<script type="test/null">\n   <div>\n     <div></div><div></div></div></script>',
+        output: [
+          '<script type="test/null">',
+          '    <div>',
+          '      <div></div><div></div></div>',
+          '</script>'
+        ]
+      }, {
+        input: '<script type="test/null">\n<div>\n<div></div><div></div></div></script>',
+        output: [
+          '<script type="test/null">',
+          '    <div>',
+          '    <div></div><div></div></div>',
+          '</script>'
+        ]
+      }, {
         input: '<script>var foo = "bar";</script>',
         output: [
           '<script>',


### PR DESCRIPTION
Fixes #1591

NOTE: This is a potentially breaking change to existing behavior.
Whitespace at the start of html used to be ignored.
Now it will be used as the base indent for the rest of the input.
This makes it consistent with the other beautifiers but may change
the behaviors of libraries that use the beautifier.