### PR TITLE
Fix indenting of Handlebars/Mustache inverted sections

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -561,7 +561,7 @@ var TagOpenParserToken = function(parent, raw_token) {
       tag_check_match = raw_token.text.match(/^<([^\s>]*)/);
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
     } else {
-      tag_check_match = raw_token.text.match(/^{{\#?([^\s}]+)/);
+      tag_check_match = raw_token.text.match(/^{{[#\^]?([^\s}]+)/);
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
     }
     this.tag_check = this.tag_check.toLowerCase();

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -6067,6 +6067,8 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{else}}\n' +
             '    <p>Unfortunately no clinics found.</p>\n' +
             '{{/each}}');
+        
+        // Issue #1623 - Fix indentation of `^` inverted section tags in Handlebars/Mustache code
         bth(
             '{{^inverted-condition}}\n' +
             '    <p>Unfortunately this condition is false.</p>\n' +

--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -6029,9 +6029,9 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
 
 
         //============================================================
-        // Handlebars Else If and Each tag indenting
+        // Handlebars Else If, Each, and Inverted Section tag indenting
         reset_options();
-        set_name('Handlebars Else If and Each tag indenting');
+        set_name('Handlebars Else If, Each, and Inverted Section tag indenting');
         opts.indent_handlebars = true;
         bth(
             '{{#if test}}<div></div>{{else}}<div></div>{{/if}}',
@@ -6067,6 +6067,10 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '{{else}}\n' +
             '    <p>Unfortunately no clinics found.</p>\n' +
             '{{/each}}');
+        bth(
+            '{{^inverted-condition}}\n' +
+            '    <p>Unfortunately this condition is false.</p>\n' +
+            '{{/inverted-condition}}');
 
 
         //============================================================

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1393,8 +1393,9 @@ exports.test_data = {
             '{{/each}}'
           ]
         },
-        // Inverted section handling
+        // Inverted section handling.
         {
+          comment: "Issue #1623 - Fix indentation of `^` inverted section tags in Handlebars/Mustache code",
           unchanged: [
             '{{^inverted-condition}}',
             '    <p>Unfortunately this condition is false.</p>',

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1349,8 +1349,8 @@ exports.test_data = {
         }
       ]
     }, {
-      name: "Handlebars Else If and Each tag indenting",
-      description: "Handlebar Else If and Each Handling tags should be newlined after formatted tags",
+      name: "Handlebars Else If, Each, and Inverted Section tag indenting",
+      description: "Handlebar Else If, Each, and Inverted Section handling tags should be newlined after formatted tags",
       template: "^^^ $$$",
       options: [
         { name: "indent_handlebars", value: "true" }
@@ -1391,6 +1391,14 @@ exports.test_data = {
             '{{else}}',
             '    <p>Unfortunately no clinics found.</p>',
             '{{/each}}'
+          ]
+        },
+        // Inverted section handling
+        {
+          unchanged: [
+            '{{^inverted-condition}}',
+            '    <p>Unfortunately this condition is false.</p>',
+            '{{/inverted-condition}}'
           ]
         }
       ]


### PR DESCRIPTION
Fixes https://github.com/beautify-web/js-beautify/issues/1623

The regexp update matches that on line 580 of the same file. As an aside, `#` does not need to be escaped because it is not a special regular expression character.

The js tests have been updated to ensure this works.

I did not see any Python HTML beautifier, so I could not port anything to that language.

Thanks for taking the time to maintain this package!