### PR TITLE
stop reformatting valid css \! into invalid \ !

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -435,7 +435,7 @@ Beautifier.prototype.beautify = function() {
       if (whitespaceChar.test(this._ch)) {
         this._ch = '';
       }
-    } else if (this._ch === '!') { // !important
+    } else if (this._ch === '!' && !this._input.lookBack("\\")) { // !important
       this.print_string(' ');
       this.print_string(this._ch);
     } else {

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -10672,6 +10672,10 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
             'a {\n' +
             '\tcolor: blue !important;\n' +
             '}');
+        t(
+            '.blue\\! {\n' +
+            '\tcolor: blue !important;\n' +
+            '}');
 
 
         //============================================================

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -454,7 +454,7 @@ class Beautifier:
                 self.print_string('=')
                 if bool(whitespaceChar.search(self._ch)):
                     self._ch = ''
-            elif self._ch == '!':  # !important
+            elif self._ch == '!' and not (self._input.lookBack('\\')):  # !important
                 self.print_string(' ')
                 self.print_string(self._ch)
             else:

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -454,7 +454,8 @@ class Beautifier:
                 self.print_string('=')
                 if bool(whitespaceChar.search(self._ch)):
                     self._ch = ''
-            elif self._ch == '!' and not (self._input.lookBack('\\')):  # !important
+            elif self._ch == '!' and not (self._input.lookBack('\\')):
+                # !important
                 self.print_string(' ')
                 self.print_string(self._ch)
             else:

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -10550,6 +10550,10 @@ class CSSBeautifierTest(unittest.TestCase):
             'a {\n' +
             '\tcolor: blue !important;\n' +
             '}')
+        t(
+            '.blue\\! {\n' +
+            '\tcolor: blue !important;\n' +
+            '}')
 
 
         #============================================================

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1480,6 +1480,8 @@ exports.test_data = {
         output: 'a {\n\tcolor: blue !important;\n}'
       }, {
         unchanged: 'a {\n\tcolor: blue !important;\n}'
+      }, {
+        unchanged: '.blue\\\\! {\n\tcolor: blue !important;\n}'
       }]
     }, {
       name: "indent_empty_lines true",


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `master`)


Fixes Issue: 

CSS allows escape of the `!` character in class names i.e. `.blue\!`, which would be applied to

```<div class="blue!" />```

However, the logic to put a space before `!important` resulted in generating invalid css `.blue\! {` turned into `.blue\ ! {`

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
N/A --- Added command-line option(s) (NA if -- NA
N/A --- README.md documents new feature/option(s) -- NA

