### PR TITLE
Only look for coment and cdata wrappers

### DIFF
--- a/js/test/generated/beautify-html-tests.js
+++ b/js/test/generated/beautify-html-tests.js
@@ -416,6 +416,7 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
         // Tests for script and style Commented and cdata wapping (#1641)
         reset_options();
         set_name('Tests for script and style Commented and cdata wapping (#1641)');
+        opts.templating = 'php';
         bth(
             '<style><!----></style>',
             //  -- output --
@@ -564,6 +565,26 @@ function run_html_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_be
             '    console.log("</script>" + "</style>");\n' +
             '         console.log("</script>" + "</style>");\n' +
             '    ]]>\n' +
+            '</script>');
+        
+        // Issue #1687 - start with <?php ?>
+        bth(
+            '<script>\n' +
+            '<?php ?>\n' +
+            'var b={\n' +
+            'a:function _test( ){\n' +
+            'return 1;\n' +
+            '}\n' +
+            '}\n' +
+            '</script>',
+            //  -- output --
+            '<script>\n' +
+            '    <?php ?>\n' +
+            '    var b = {\n' +
+            '        a: function _test() {\n' +
+            '            return 1;\n' +
+            '        }\n' +
+            '    }\n' +
             '</script>');
 
 

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -217,6 +217,9 @@ exports.test_data = {
   }, {
     name: "Tests for script and style Commented and cdata wapping (#1641)",
     description: "Repect comment and cdata wrapping regardless of beautifier",
+    options: [
+      { name: "templating", value: "'php'" }
+    ],
     tests: [{
       input: [
         '<style><!----></style>'
@@ -403,6 +406,28 @@ exports.test_data = {
         '    console.log("</script>" + "</style>");',
         '         console.log("</script>" + "</style>");',
         '    ]]>',
+        '</script>'
+      ]
+    }, {
+      comment: "Issue #1687 - start with <?php ?>",
+      input: [
+        '<script>',
+        '<?php ?>',
+        'var b={',
+        'a:function _test( ){',
+        'return 1;',
+        '}',
+        '}',
+        '</script>'
+      ],
+      output: [
+        '<script>',
+        '    <?php ?>',
+        '    var b = {',
+        '        a: function _test() {',
+        '            return 1;',
+        '        }',
+        '    }',
         '</script>'
       ]
     }]


### PR DESCRIPTION
Style and script elements can have their contents wrapped in cdata or an html comment.
Do not treat other text, such as php tag as though it were one of the wrappers.

Fixes #1687 
