### PR TITLE
Allow # to start identifier, such as private fields in classes

### DIFF
--- a/js/src/javascript/acorn.js
+++ b/js/src/javascript/acorn.js
@@ -17,11 +17,11 @@
 
 // acorn used char codes to squeeze the last bit of performance out
 // Beautifier is okay without that, so we're using regex
-// permit $ (36) and @ (64). @ is used in ES7 decorators.
+// permit # (23), $ (36), and @ (64). @ is used in ES7 decorators.
 // 65 through 91 are uppercase letters.
 // permit _ (95).
 // 97 through 123 are lowercase letters.
-var baseASCIIidentifierStartChars = "\\x24\\x40\\x41-\\x5a\\x5f\\x61-\\x7a";
+var baseASCIIidentifierStartChars = "\\x23\\x24\\x40\\x41-\\x5a\\x5f\\x61-\\x7a";
 
 // inside an identifier @ is not allowed but 0-9 are.
 var baseASCIIidentifierChars = "\\x24\\x30-\\x39\\x41-\\x5a\\x5f\\x61-\\x7a";

--- a/js/src/javascript/tokenizer.js
+++ b/js/src/javascript/tokenizer.js
@@ -274,6 +274,12 @@ Tokenizer.prototype._read_non_javascript = function(c) {
         this._input.next();
       }
       return this._create_token(TOKEN.WORD, sharp);
+    } else if (this._input.hasNext()) {
+      // Handle private field (ie. #privateExample)
+      resulting_string = this.__patterns.identifier.read();
+      if (resulting_string) {
+        return this._create_token(TOKEN.WORD, sharp + resulting_string);
+      }
     }
 
     this._input.back();

--- a/js/src/javascript/tokenizer.js
+++ b/js/src/javascript/tokenizer.js
@@ -163,13 +163,13 @@ Tokenizer.prototype._get_next_token = function(previous_token, open_token) { // 
     return this._create_token(TOKEN.EOF, '');
   }
 
+  token = token || this._read_non_javascript(c);
   token = token || this._read_string(c);
   token = token || this._read_word(previous_token);
   token = token || this._read_singles(c);
   token = token || this._read_comment(c);
   token = token || this._read_regexp(c, previous_token);
   token = token || this._read_xml(c, previous_token);
-  token = token || this._read_non_javascript(c);
   token = token || this._read_punctuation();
   token = token || this._create_token(TOKEN.UNKNOWN, this._input.next());
 
@@ -274,12 +274,6 @@ Tokenizer.prototype._read_non_javascript = function(c) {
         this._input.next();
       }
       return this._create_token(TOKEN.WORD, sharp);
-    } else if (this._input.hasNext()) {
-      // Handle private field (ie. #privateExample)
-      resulting_string = this.__patterns.identifier.read();
-      if (resulting_string) {
-        return this._create_token(TOKEN.WORD, sharp + resulting_string);
-      }
     }
 
     this._input.back();

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -405,9 +405,9 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
 
         //============================================================
-        // ES5 Class Private Fields
+        // Private Class Fields
         reset_options();
-        set_name('ES5 Class Private Fields');
+        set_name('Private Class Fields');
         bt('#foo');
         bt(
             'class X {\n' +
@@ -415,6 +415,12 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
             '    get foo() {\n' +
             '        return this.#foo;\n' +
             '    }\n' +
+            '}');
+        bt(
+            'class X {#foo=null;}',
+            //  -- output --
+            'class X {\n' +
+            '    #foo = null;\n' +
             '}');
 
 

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -405,6 +405,20 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
 
 
         //============================================================
+        // ES5 Class Private Fields
+        reset_options();
+        set_name('ES5 Class Private Fields');
+        bt('#foo');
+        bt(
+            'class X {\n' +
+            '    #foo = null;\n' +
+            '    get foo() {\n' +
+            '        return this.#foo;\n' +
+            '    }\n' +
+            '}');
+
+
+        //============================================================
         // ES7 Decorators
         reset_options();
         set_name('ES7 Decorators');

--- a/python/jsbeautifier/javascript/acorn.py
+++ b/python/jsbeautifier/javascript/acorn.py
@@ -20,11 +20,11 @@ six = __import__("six")
 
 # acorn used char codes to squeeze the last bit of performance out
 # Beautifier is okay without that, so we're using regex
-# permit $ (36) and @ (64). @ is used in ES7 decorators.
+# permit #(23), $ (36), and @ (64). @ is used in ES7 decorators.
 # 65 through 91 are uppercase letters.
 # permit _ (95).
 # 97 through 123 are lowercase letters.
-_baseASCIIidentifierStartChars = six.u(r"\x24\x40\x41-\x5a\x5f\x61-\x7a")
+_baseASCIIidentifierStartChars = six.u(r"\x23\x24\x40\x41-\x5a\x5f\x61-\x7a")
 
 # inside an identifier @ is not allowed but 0-9 are.
 _baseASCIIidentifierChars = six.u(r"\x24\x30-\x39\x41-\x5a\x5f\x61-\x7a")

--- a/python/jsbeautifier/javascript/tokenizer.py
+++ b/python/jsbeautifier/javascript/tokenizer.py
@@ -408,6 +408,11 @@ class Tokenizer(BaseTokenizer):
                     self._input.next()
 
                 return self._create_token(TOKEN.WORD, sharp)
+            elif self._input.hasNext():
+                # Handle private field (ie. #privateExample)
+                resulting_string = self._patterns.identifier.read()
+                if resulting_string:
+                    return self._create_token(TOKEN.WORD, sharp + resulting_string)
 
             self._input.back()
 

--- a/python/jsbeautifier/javascript/tokenizer.py
+++ b/python/jsbeautifier/javascript/tokenizer.py
@@ -191,13 +191,13 @@ class Tokenizer(BaseTokenizer):
         if c is None:
             token = self._create_token(TOKEN.EOF, '')
 
+        token = token or self._read_non_javascript(c)
         token = token or self._read_string(c)
         token = token or self._read_word(previous_token)
         token = token or self._read_singles(c)
         token = token or self._read_comment(c)
         token = token or self._read_regexp(c, previous_token)
         token = token or self._read_xml(c, previous_token)
-        token = token or self._read_non_javascript(c)
         token = token or self._read_punctuation()
         token = token or self._create_token(TOKEN.UNKNOWN, self._input.next())
 
@@ -408,11 +408,6 @@ class Tokenizer(BaseTokenizer):
                     self._input.next()
 
                 return self._create_token(TOKEN.WORD, sharp)
-            elif self._input.hasNext():
-                # Handle private field (ie. #privateExample)
-                resulting_string = self._patterns.identifier.read()
-                if resulting_string:
-                    return self._create_token(TOKEN.WORD, sharp + resulting_string)
 
             self._input.back()
 

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -212,7 +212,7 @@ class TestJSBeautifier(unittest.TestCase):
 
 
         #============================================================
-        # ES5 Class Private Fields
+        # Private Class Fields
         self.reset_options()
         bt('#foo')
         bt(
@@ -221,6 +221,12 @@ class TestJSBeautifier(unittest.TestCase):
             '    get foo() {\n' +
             '        return this.#foo;\n' +
             '    }\n' +
+            '}')
+        bt(
+            'class X {#foo=null;}',
+            #  -- output --
+            'class X {\n' +
+            '    #foo = null;\n' +
             '}')
 
 

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -212,6 +212,19 @@ class TestJSBeautifier(unittest.TestCase):
 
 
         #============================================================
+        # ES5 Class Private Fields
+        self.reset_options()
+        bt('#foo')
+        bt(
+            'class X {\n' +
+            '    #foo = null;\n' +
+            '    get foo() {\n' +
+            '        return this.#foo;\n' +
+            '    }\n' +
+            '}')
+
+
+        #============================================================
         # ES7 Decorators
         self.reset_options()
         bt('@foo')

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -170,6 +170,22 @@ exports.test_data = {
         }
       ]
     }, {
+      name: "ES5 Class Private Fields",
+      description: "Permit ES5 private class fields which are declared with a leading \"#\".",
+      tests: [
+        { unchanged: '#foo' },
+        {
+          unchanged: [
+            'class X {',
+            '    #foo = null;',
+            '    get foo() {',
+            '        return this.#foo;',
+            '    }',
+            '}'
+          ]
+        }
+      ]
+    }, {
       name: "ES7 Decorators",
       description: "Permit ES7 decorators, which are invoked with a leading \"@\".",
       tests: [

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -170,8 +170,8 @@ exports.test_data = {
         }
       ]
     }, {
-      name: "ES5 Class Private Fields",
-      description: "Permit ES5 private class fields which are declared with a leading \"#\".",
+      name: "Private Class Fields",
+      description: "Permit private class fields which are declared with a leading \"#\".",
       tests: [
         { unchanged: '#foo' },
         {
@@ -181,6 +181,14 @@ exports.test_data = {
             '    get foo() {',
             '        return this.#foo;',
             '    }',
+            '}'
+          ]
+        },
+        {
+          input: 'class X {#foo=null;}',
+          output: [
+            'class X {',
+            '    #foo = null;',
             '}'
           ]
         }


### PR DESCRIPTION
To resolve #1734 , this change modifies the tokenizer to recognize #+identifier as a single word. I first tried just adding # as a valid start character, but that broke existing tests, so this is the way I've been able to fix private fields without regressions.

# Description
- [x] Source branch in your fork has meaningful name (not `master`)


Fixes Issue: #1734 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

Ran `make ci` and all tests are passing including my newly added one.