### PR TITLE
Allman style formatting (JavaScript files)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,15 @@ engines:
    enabled: true
  pep8:
    enabled: true
+checks:
+  complex-logic:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  similar-code:
+    enabled: false
 ratings:
  paths:
  - "**.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,6 +6,8 @@ engines:
 checks:
   complex-logic:
     enabled: false
+  file-lines:
+    enabled: false
   method-lines:
     enabled: false
   nested-control-flow:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,1 @@
+max-line-length=160

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Beautifier Options:
   -j, --jslint-happy                Enable jslint-stricter mode
   -a, --space-after-anon-function   Add a space before an anonymous function's parens, ie. function ()
   --space-after-named-function      Add a space before a named function's parens, i.e. function example ()
-  -b, --brace-style                 [collapse|expand|end-expand|none][,preserve-inline] [collapse,preserve-inline]
+  -b, --brace-style                 [collapse|expand|end-expand|expand-all|none][,preserve-inline] [collapse,preserve-inline]
   -u, --unindent-chained-methods    Don't indent chained method calls
   -B, --break-chained-methods       Break chained method calls across subsequent lines
   -k, --keep-array-indentation      Preserve array indentation

--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@
           <option value="expand">Braces on own line</option>
           <option value="end-expand">End braces on own line</option>
           <option value="none">Attempt to keep braces where they are</option>
+          <option value="expand-all">Allman style braces and brackets</option>
         </select>
 
         <p style="margin:6px 0 0 0">HTML &lt;style&gt;, &lt;script&gt; formatting:</p>

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -420,14 +420,12 @@ Beautifier.prototype.print_token = function(current_token) {
         this._output.current_line.pop();
         this._output.trim();
       }
-
       // add the comma in front of the next token
       this.print_token_line_indentation(current_token);
       this._output.add_token(',');
       this._output.space_before_token = true;
     }
   }
-
   this.print_token_line_indentation(current_token);
   this._output.non_breaking_space = true;
   this._output.add_token(current_token.text);
@@ -646,15 +644,10 @@ Beautifier.prototype.handle_start_expr = function(current_token) {
 Beautifier.prototype.handle_end_expr = function(current_token) {
   // statements inside expressions are not valid syntax, but...
   // statements must all be closed when their container closes
-  while (this._flags.mode === MODE.Statement) {
-    this.restore_mode();
-  }
-
+  while (this._flags.mode === MODE.Statement) { this.restore_mode(); }
   this.handle_whitespace_and_comments(current_token);
-
   if (this._flags.multiline_frame) {
-    this.allow_wrap_or_preserved_newline(current_token,
-      current_token.text === ']' && is_array(this._flags.mode) && !this._options.keep_array_indentation);
+    this.allow_wrap_or_preserved_newline(current_token, current_token.text === ']' && is_array(this._flags.mode) && !this._options.keep_array_indentation);
   }
   if (this._options.brace_style === "expand-all" && current_token.text === ']' && is_array(this._flags.mode)) {
     this.print_newline();
@@ -664,15 +657,12 @@ Beautifier.prototype.handle_end_expr = function(current_token) {
       // () [] no inner space in empty parens like these, ever, ref #320
       this._output.trim();
       this._output.space_before_token = false;
-    } else {
-      this._output.space_before_token = true;
-    }
+    } else { this._output.space_before_token = true; }
   }
   this.deindent();
   this.print_token(current_token);
   this.restore_mode();
   remove_redundant_indentation(this._output, this._previous_flags);
-
   // do {} while () // no statement required after
   if (this._flags.do_while && this._previous_flags.mode === MODE.Conditional) {
     this._previous_flags.mode = MODE.Expression;

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -412,8 +412,7 @@ Beautifier.prototype.print_token = function(current_token) {
     this._output.just_added_newline()) {
     if (this._output.previous_line.last() === ',') {
       var popped = this._output.previous_line.pop();
-      // if the comma was already at the start of the line,
-      // pull back onto that line and reprint the indentation
+      // if the comma was already at the start of the line, pull back onto that line and reprint the indentation
       if (this._output.previous_line.is_empty()) {
         this._output.previous_line.push(popped);
         this._output.trim(true);

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -405,11 +405,9 @@ Beautifier.prototype.print_token = function(current_token) {
     this._output.add_raw_token(current_token);
     return;
   }
-
   if (this._options.brace_style === "expand-all" && is_array(this._flags.mode) && current_token.previous && current_token.previous.type === TOKEN.COMMA) {
     this.print_newline(); // array items get a newline treatment
   }
-
   if (this._options.comma_first && current_token.previous && current_token.previous.type === TOKEN.COMMA &&
     this._output.just_added_newline()) {
     if (this._output.previous_line.last() === ',') {
@@ -433,9 +431,7 @@ Beautifier.prototype.print_token = function(current_token) {
   this.print_token_line_indentation(current_token);
   this._output.non_breaking_space = true;
   this._output.add_token(current_token.text);
-  if (this._output.previous_token_wrapped) {
-    this._flags.multiline_frame = true;
-  }
+  if (this._output.previous_token_wrapped) { this._flags.multiline_frame = true; }
 };
 
 Beautifier.prototype.indent = function() {
@@ -660,11 +656,9 @@ Beautifier.prototype.handle_end_expr = function(current_token) {
     this.allow_wrap_or_preserved_newline(current_token,
       current_token.text === ']' && is_array(this._flags.mode) && !this._options.keep_array_indentation);
   }
-
   if (this._options.brace_style === "expand-all" && current_token.text === ']' && is_array(this._flags.mode)) {
     this.print_newline();
   }
-
   if (this._options.space_in_paren) {
     if (this._flags.last_token.type === TOKEN.START_EXPR && !this._options.space_in_empty_paren) {
       // () [] no inner space in empty parens like these, ever, ref #320
@@ -677,7 +671,6 @@ Beautifier.prototype.handle_end_expr = function(current_token) {
   this.deindent();
   this.print_token(current_token);
   this.restore_mode();
-
   remove_redundant_indentation(this._output, this._previous_flags);
 
   // do {} while () // no statement required after
@@ -685,7 +678,6 @@ Beautifier.prototype.handle_end_expr = function(current_token) {
     this._previous_flags.mode = MODE.Expression;
     this._flags.do_block = false;
     this._flags.do_while = false;
-
   }
 };
 
@@ -989,11 +981,9 @@ Beautifier.prototype.handle_word = function(current_token) {
   }
 
   if (reserved_array(current_token, ['else', 'catch', 'finally'])) {
-    if ((!(this._flags.last_token.type === TOKEN.END_BLOCK && this._previous_flags.mode === MODE.BlockStatement) ||
-        this._options.brace_style === "expand" || this._options.brace_style === "expand-all" ||
-        this._options.brace_style === "end-expand" ||
-        (this._options.brace_style === "none" && current_token.newlines)) &&
-      !this._flags.inline_frame) {
+    var blockStatementEnds = this._flags.last_token.type === TOKEN.END_BLOCK && this._previous_flags.mode === MODE.BlockStatement;
+    if ((!blockStatementEnds || in_array(this._options.brace_style, ["expand", 'end-expand', 'expand-all']) ||
+        (this._options.brace_style === "none" && current_token.newlines)) && !this._flags.inline_frame) {
       this.print_newline();
     } else {
       this._output.trim(true);

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -405,9 +405,7 @@ Beautifier.prototype.print_token = function(current_token) {
     this._output.add_raw_token(current_token);
     return;
   }
-  if (this._options.brace_style === "expand-all" && is_array(this._flags.mode) && current_token.previous && current_token.previous.type === TOKEN.COMMA) {
-    this.print_newline(); // array items get a newline treatment
-  }
+  if (this._options.brace_style === "expand-all" && is_array(this._flags.mode) && current_token.previous && current_token.previous.type === TOKEN.COMMA) { this.print_newline(); } // array items get a newline treatment
   if (this._options.comma_first && current_token.previous && current_token.previous.type === TOKEN.COMMA &&
     this._output.just_added_newline()) {
     if (this._output.previous_line.last() === ',') {

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -542,7 +542,7 @@ Beautifier.prototype.handle_start_expr = function(current_token) {
           this.print_newline();
         }
       } else if (this._options.brace_style === "expand-all" && this._flags.last_token.text === ',') {
-          this.print_newline();
+        this.print_newline();
       }
     }
 

--- a/js/src/javascript/options.js
+++ b/js/src/javascript/options.js
@@ -50,7 +50,7 @@ function Options(options) {
   //preserve-inline in delimited string will trigger brace_preserve_inline, everything
   //else is considered a brace_style and the last one only will have an effect
 
-  var brace_style_split = this._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline']);
+  var brace_style_split = this._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline', 'expand-all']);
 
   this.brace_preserve_inline = false; //Defaults in case one or other was not specified in meta-option
   this.brace_style = "collapse";

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -869,10 +869,10 @@ class Beautifier:
 
         prefix = 'NONE'
 
+        is_literal_sbrk_cma = self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']
         if self._flags.last_token.type == TOKEN.END_BLOCK:
             token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
             no_brace_style_nl = self._options.brace_style == 'none' and current_token.newlines
-            is_literal_sbrk_cma = self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']
             if self._previous_flags.inline_frame:
                 prefix = 'SPACE'
             elif not token_reserved_word:

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -870,9 +870,10 @@ class Beautifier:
         prefix = 'NONE'
 
         if self._flags.last_token.type == TOKEN.END_BLOCK:
+            token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
             if self._previous_flags.inline_frame:
                 prefix = 'SPACE'
-            elif not reserved_array(current_token, ['else', 'catch', 'finally', 'from']):
+            elif not token_reserved_word:
                 prefix = 'NEWLINE'
             else:
                 if self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or (
@@ -909,7 +910,8 @@ class Beautifier:
                 prefix = 'NEWLINE'
 
         if reserved_array(current_token, ['else', 'catch', 'finally']):
-            block_statement_ends = self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.mode == MODE.BlockStatement
+            block_statement_ends = self._flags.last_token.type == TOKEN.END_BLOCK and \
+                self._previous_flags.mode == MODE.BlockStatement
             if ((not block_statement_ends) or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
                     or (self._options.brace_style == 'none' and current_token.newlines)) and not self._flags.inline_frame:
                 self.print_newline()

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -909,10 +909,9 @@ class Beautifier:
                 prefix = 'NEWLINE'
 
         if reserved_array(current_token, ['else', 'catch', 'finally']):
-            if ((not (self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.mode == MODE.BlockStatement))
-                or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
-                or (self._options.brace_style == 'none' and current_token.newlines)) \
-               and not self._flags.inline_frame:
+            block_statement_ends = self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.mode == MODE.BlockStatement
+            if ((not block_statement_ends) or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
+                    or (self._options.brace_style == 'none' and current_token.newlines)) and not self._flags.inline_frame:
                 self.print_newline()
             else:
                 self._output.trim(True)

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -335,7 +335,7 @@ class Beautifier:
                 self.is_array(self._flags.mode) and \
                 current_token.previous and \
                 current_token.previous.type == TOKEN.COMMA:
-            self.print_newline() # array items get a newline treatment
+            self.print_newline()  # array items get a newline treatment
 
         if self._options.comma_first and current_token.previous and \
             current_token.previous.type == TOKEN.COMMA and \
@@ -576,7 +576,7 @@ class Beautifier:
         self.print_token(current_token)
         if current_token.text == '[' and \
                 self._options.brace_style == "expand-all":
-            self.print_newline();
+            self.print_newline()
         self.set_mode(next_mode)
 
         if self._options.space_in_paren:
@@ -602,7 +602,7 @@ class Beautifier:
         if self._options.brace_style == "expand-all" and \
                 current_token.text == ']' and \
                 self.is_array(self._flags.mode):
-            self.print_newline();
+            self.print_newline()
 
         if self._options.space_in_paren:
             if self._flags.last_token.type == TOKEN.START_EXPR and not self._options.space_in_empty_paren:
@@ -692,7 +692,7 @@ class Beautifier:
          check_token.type == TOKEN.END_BLOCK and check_token.opened == current_token))
 
         if (self._options.brace_style == 'expand' or self._options.brace_style == 'expand-all' or
-            (self._options.brace_style == 'none' and current_token.newlines)) and not self._flags.inline_frame:
+                (self._options.brace_style == 'none' and current_token.newlines)) and not self._flags.inline_frame:
             if self._flags.last_token.type != TOKEN.OPERATOR and (
                 empty_anonymous_function or self._flags.last_token.type == TOKEN.EQUALS or (
                     reserved_array(self._flags.last_token, _special_word_set) and self._flags.last_token.text != 'else')):
@@ -910,9 +910,7 @@ class Beautifier:
 
         if reserved_array(current_token, ['else', 'catch', 'finally']):
             if ((not (self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.mode == MODE.BlockStatement))
-                or self._options.brace_style == 'expand'
-                or self._options.brace_style == 'expand-all'
-                or self._options.brace_style == 'end-expand'
+                or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
                 or (self._options.brace_style == 'none' and current_token.newlines)) \
                and not self._flags.inline_frame:
                 self.print_newline()

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -870,18 +870,18 @@ class Beautifier:
         prefix = 'NONE'
 
         is_literal_sbrk_cma = self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']
-        if self._flags.last_token.type == TOKEN.END_BLOCK:
-            token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
-            no_brace_style_nl = self._options.brace_style == 'none' and current_token.newlines
-            if self._previous_flags.inline_frame:
-                prefix = 'SPACE'
-            elif not token_reserved_word:
-                prefix = 'NEWLINE'
-            elif self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
-                    prefix = 'NEWLINE'
-            else:
-                prefix = 'SPACE'
-                self._output.space_before_token = True
+        token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
+        no_brace_style_nl = self._options.brace_style == 'none' and current_token.newlines
+        if self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.inline_frame:
+            prefix = 'SPACE'
+        elif self._flags.last_token.type == TOKEN.END_BLOCK and not token_reserved_word:
+            prefix = 'NEWLINE'
+        elif self._flags.last_token.type == TOKEN.END_BLOCK and \
+                self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
+            prefix = 'NEWLINE'
+        elif self._flags.last_token.type == TOKEN.END_BLOCK:
+            prefix = 'SPACE'
+            self._output.space_before_token = True
         elif self._flags.last_token.type == TOKEN.SEMICOLON and self._flags.mode == MODE.BlockStatement:
             # TODO: Should this be for STATEMENT as well?
             prefix = 'NEWLINE'

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -877,12 +877,11 @@ class Beautifier:
                 prefix = 'SPACE'
             elif not token_reserved_word:
                 prefix = 'NEWLINE'
-            else:
-                if self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
+            elif self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
                     prefix = 'NEWLINE'
-                else:
-                    prefix = 'SPACE'
-                    self._output.space_before_token = True
+            else:
+                prefix = 'SPACE'
+                self._output.space_before_token = True
         elif self._flags.last_token.type == TOKEN.SEMICOLON and self._flags.mode == MODE.BlockStatement:
             # TODO: Should this be for STATEMENT as well?
             prefix = 'NEWLINE'

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -871,13 +871,14 @@ class Beautifier:
 
         if self._flags.last_token.type == TOKEN.END_BLOCK:
             token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
+            no_brace_style_nl = self._options.brace_style == 'none' and current_token.newlines
+            is_literal_sbrk_cma = self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']
             if self._previous_flags.inline_frame:
                 prefix = 'SPACE'
             elif not token_reserved_word:
                 prefix = 'NEWLINE'
             else:
-                if self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or (
-                        self._options.brace_style == 'none' and current_token.newlines):
+                if self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
                     prefix = 'NEWLINE'
                 else:
                     prefix = 'SPACE'
@@ -891,8 +892,7 @@ class Beautifier:
             prefix = 'NEWLINE'
         elif self._flags.last_token.type == TOKEN.RESERVED or self._flags.last_token.type == TOKEN.WORD or \
             (self._flags.last_token.text == '*' and (
-                self._last_last_text in ['function', 'yield'] or
-                (self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']))):
+                self._last_last_text in ['function', 'yield'] or is_literal_sbrk_cma)):
             prefix = 'SPACE'
         elif self._flags.last_token.type == TOKEN.START_BLOCK:
             if self._flags.inline_frame:
@@ -910,9 +910,9 @@ class Beautifier:
                 prefix = 'NEWLINE'
 
         if reserved_array(current_token, ['else', 'catch', 'finally']):
-            block_statement_ends = self._flags.last_token.type == TOKEN.END_BLOCK and \
-                self._previous_flags.mode == MODE.BlockStatement
-            if ((not block_statement_ends) or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
+            blk_stmt_ends = self._flags.last_token.type == TOKEN.END_BLOCK
+            blk_stmt_ends = blk_stmt_ends and self._previous_flags.mode == MODE.BlockStatement
+            if ((not blk_stmt_ends) or self._options.brace_style in ['expand', 'end-expand', 'expand-all']
                     or (self._options.brace_style == 'none' and current_token.newlines)) and not self._flags.inline_frame:
                 self.print_newline()
             else:

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -872,12 +872,12 @@ class Beautifier:
         is_literal_sbrk_cma = self._flags.mode == MODE.ObjectLiteral and self._last_last_text in ['{', ',']
         token_reserved_word = reserved_array(current_token, ['else', 'catch', 'finally', 'from'])
         no_brace_style_nl = self._options.brace_style == 'none' and current_token.newlines
+        brace_style_in_exp = self._options.brace_style in ['expand', 'end-expand', 'expand-all']
         if self._flags.last_token.type == TOKEN.END_BLOCK and self._previous_flags.inline_frame:
             prefix = 'SPACE'
         elif self._flags.last_token.type == TOKEN.END_BLOCK and not token_reserved_word:
             prefix = 'NEWLINE'
-        elif self._flags.last_token.type == TOKEN.END_BLOCK and \
-                self._options.brace_style in ['expand', 'end-expand', 'expand-all'] or no_brace_style_nl:
+        elif self._flags.last_token.type == TOKEN.END_BLOCK and brace_style_in_exp or no_brace_style_nl:
             prefix = 'NEWLINE'
         elif self._flags.last_token.type == TOKEN.END_BLOCK:
             prefix = 'SPACE'
@@ -890,8 +890,8 @@ class Beautifier:
         elif self._flags.last_token.type == TOKEN.STRING:
             prefix = 'NEWLINE'
         elif self._flags.last_token.type == TOKEN.RESERVED or self._flags.last_token.type == TOKEN.WORD or \
-            (self._flags.last_token.text == '*' and (
-                self._last_last_text in ['function', 'yield'] or is_literal_sbrk_cma)):
+                (self._flags.last_token.text == '*' and (
+                        self._last_last_text in ['function', 'yield'] or is_literal_sbrk_cma)):
             prefix = 'SPACE'
         elif self._flags.last_token.type == TOKEN.START_BLOCK:
             if self._flags.inline_frame:

--- a/python/jsbeautifier/javascript/options.py
+++ b/python/jsbeautifier/javascript/options.py
@@ -54,7 +54,7 @@ class BeautifierOptions(BaseOptions):
         # preserve-inline in delimited string will trigger brace_preserve_inline, everything
         # else is considered a brace_style and the last one only will have an effect
 
-        brace_style_split = self._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline'])
+        brace_style_split = self._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline', 'expand-all'])
 
         # preserve-inline in delimited string will trigger brace_preserve_inline
         # Everything else is considered a brace_style and the last one only will

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 160

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pycodestyle]
-max-line-length = 160
+max-line-length = 5000

--- a/tools/template/beautify.wrapper.js
+++ b/tools/template/beautify.wrapper.js
@@ -61,8 +61,8 @@
     space_after_anon_function (default false) - should the space before an anonymous function's parens be added, "function()" vs "function ()",
           NOTE: This option is overriden by jslint_happy (i.e. if jslint_happy is true, space_after_anon_function is true by design)
 
-    brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none" | any of the former + ",preserve-inline"
-            put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.
+    brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "expand-all" | "none" | any of the former + ",preserve-inline"
+            put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or put braces/brackets/array-items on own line or attempt to keep them where they are.
             preserve-inline will try to preserve inline blocks of curly braces
 
     space_before_conditional (default true) - should the space before conditional statement be added, "if(true)" vs "if (true)",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 160

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,2 @@
 [pycodestyle]
-max-line-length = 160
+max-line-length = 5000


### PR DESCRIPTION
# Description
- [ ] Source branch in your fork has meaningful name (not `master`)

This is an attempt to add Allman style formatting to beautifier for JavaScript files

**New feature performs following formatting:**
1. Start and end braces on separate lines
2. Start and end square brackets on separate lines
3. Array items on new line

Fixes Issue: 
Closes #1792

[![Maintainability](https://api.codeclimate.com/v1/badges/cd650dac72cf94549196/maintainability)](https://codeclimate.com/github/UAK-35/js-beautify/maintainability)

New option for brace style added is : **expand-all**

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

