### PR TITLE
Add expand brace-style option to css beautifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ CSS Beautifier Options:
   -t, --indent-with-tabs             Indent with tabs, overrides -s and -c
   -e, --eol                          Character(s) to use as line terminators. (default newline - "\\n")
   -n, --end-with-newline             End output with newline
+  -b, --brace-style                  [collapse|expand] ["collapse"]
   -L, --selector-separator-newline   Add a newline between multiple selectors
   -N, --newline-between-rules        Add a newline between CSS rules
   --indent-empty-lines               Keep indentation on empty lines

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -392,6 +392,7 @@ function usage(err) {
             msg.push('  --unformatted_content_delimiter    Keep text content together between this string [""]');
             break;
         case "css":
+            msg.push('  -b, --brace-style                       [collapse|expand] ["collapse"]');
             msg.push('  -L, --selector-separator-newline        Add a newline between multiple selectors.');
             msg.push('  -N, --newline-between-rules             Add a newline between CSS rules.');
     }

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -291,23 +291,34 @@ Beautifier.prototype.beautify = function() {
         insidePropertyValue = false;
         this.outdent();
       }
-      this.indent();
-      this._output.space_before_token = true;
-      this.print_string(this._ch);
 
       // when entering conditional groups, only rulesets are allowed
       if (enteringConditionalGroup) {
         enteringConditionalGroup = false;
-        insideRule = (this._indentLevel > this._nestedLevel);
+        insideRule = (this._indentLevel >= this._nestedLevel);
       } else {
         // otherwise, declarations are also allowed
-        insideRule = (this._indentLevel >= this._nestedLevel);
+        insideRule = (this._indentLevel >= this._nestedLevel - 1);
       }
       if (this._options.newline_between_rules && insideRule) {
         if (this._output.previous_line && this._output.previous_line.item(-1) !== '{') {
           this._output.ensure_empty_line_above('/', ',');
         }
       }
+
+      this._output.space_before_token = true;
+
+      // The difference in print_string and indent order is necessary to indent the '{' correctly
+      if (this._options.brace_style === 'expand') {
+        this._output.add_new_line();
+        this.print_string(this._ch);
+        this.indent();
+        this._output.set_indent(this._indentLevel);
+      } else {
+        this.indent();
+        this.print_string(this._ch);
+      }
+
       this.eatWhitespace(true);
       this._output.add_new_line();
     } else if (this._ch === '}') {

--- a/js/src/css/options.js
+++ b/js/src/css/options.js
@@ -38,6 +38,16 @@ function Options(options) {
   var space_around_selector_separator = this._get_boolean('space_around_selector_separator');
   this.space_around_combinator = this._get_boolean('space_around_combinator') || space_around_selector_separator;
 
+  var brace_style_split = this._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline']);
+  this.brace_style = 'collapse';
+  for (var bs = 0; bs < brace_style_split.length; bs++) {
+    if (brace_style_split[bs] !== 'expand') {
+      // default to collapse, as only collapse|expand is implemented for now
+      this.brace_style = 'collapse';
+    } else {
+      this.brace_style = brace_style_split[bs];
+    }
+  }
 }
 Options.prototype = new BaseOptions();
 

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -51,6 +51,7 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
     default_opts.indent_size = 4;
     default_opts.indent_char = ' ';
     default_opts.selector_separator_newline = true;
+    default_opts.brace_style = 'collapse';
     default_opts.end_with_newline = false;
     default_opts.newline_between_rules = false;
     default_opts.space_around_combinator = false;
@@ -988,6 +989,78 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
             'a:first-child,\na:first-child {\n' +
             '    color: red;\n' +
             '    div:first-child,\n    div:hover {\n' +
+            '        color: black;\n' +
+            '    }\n' +
+            '}');
+
+        // Selector Separator - (selector_separator_newline = "true", selector_separator = ""  "", brace_style = ""expand"", newline_between_rules = "false")
+        reset_options();
+        set_name('Selector Separator - (selector_separator_newline = "true", selector_separator = ""  "", brace_style = ""expand"", newline_between_rules = "false")');
+        opts.selector_separator_newline = true;
+        opts.selector_separator = "  ";
+        opts.brace_style = "expand";
+        opts.newline_between_rules = false;
+        t(
+            '#bla, #foo{color:green}',
+            //  -- output --
+            '#bla,\n#foo\n{\n' +
+            '    color: green\n' +
+            '}');
+        t(
+            '#bla, #foo{color:green}\n' +
+            '#bla, #foo{color:green}',
+            //  -- output --
+            '#bla,\n#foo\n{\n' +
+            '    color: green\n' +
+            '}\n' +
+            '#bla,\n#foo\n{\n' +
+            '    color: green\n' +
+            '}');
+        t(
+            '@media print {.tab{}}',
+            //  -- output --
+            '@media print\n{\n' +
+            '    .tab\n    {}\n' +
+            '}');
+        
+        // This is bug #1489
+        t(
+            '@media print {.tab,.bat{}}',
+            //  -- output --
+            '@media print\n{\n' +
+            '    .tab,\n    .bat\n    {}\n' +
+            '}');
+        
+        // This is bug #1489
+        t(
+            '@media print {// comment\n' +
+            '//comment 2\n' +
+            '.bat{}}',
+            //  -- output --
+            '@media print\n{\n' +
+            '    // comment\n' +
+            '    //comment 2\n' +
+            '    .bat\n    {}\n' +
+            '}');
+        t(
+            '#bla, #foo{color:black}',
+            //  -- output --
+            '#bla,\n#foo\n{\n' +
+            '    color: black\n' +
+            '}');
+        t(
+            'a:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}\n' +
+            'a:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}',
+            //  -- output --
+            'a:first-child,\na:first-child\n{\n' +
+            '    color: red;\n' +
+            '    div:first-child,\n    div:hover\n    {\n' +
+            '        color: black;\n' +
+            '    }\n' +
+            '}\n' +
+            'a:first-child,\na:first-child\n{\n' +
+            '    color: red;\n' +
+            '    div:first-child,\n    div:hover\n    {\n' +
             '        color: black;\n' +
             '    }\n' +
             '}');
@@ -10782,6 +10855,135 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
             '    height: auto;\n' +
             '\n' +
             '}');
+
+
+        //============================================================
+        // brace_style = expand - (brace_style = ""expand"", selector_separator_newline = "false", newline_between_rules = "true")
+        reset_options();
+        set_name('brace_style = expand - (brace_style = ""expand"", selector_separator_newline = "false", newline_between_rules = "true")');
+        opts.brace_style = 'expand';
+        opts.selector_separator_newline = false;
+        opts.newline_between_rules = true;
+        t(
+            'a, b, .c {\n' +
+            '    width: auto;\n' +
+            '  \n' +
+            '    height: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '    width: auto;\n' +
+            '    height: auto;\n' +
+            '}');
+        
+        // edge case - empty line after { should not be indented without indent_empty_lines
+        t(
+            'a, b, .c {\n' +
+            '\n' +
+            '    width: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '    width: auto;\n' +
+            '}');
+        
+        // integration test of newline_between_rules, imports, and brace_style="expand"
+        t(
+            '.a{} @import "custom.css";.rule{}',
+            //  -- output --
+            '.a\n' +
+            '{}\n' +
+            '\n' +
+            '@import "custom.css";\n' +
+            '\n' +
+            '.rule\n' +
+            '{}');
+
+        // brace_style = expand - (brace_style = ""expand"", indent_empty_lines = "true", selector_separator_newline = "false", preserve_newlines = "true")
+        reset_options();
+        set_name('brace_style = expand - (brace_style = ""expand"", indent_empty_lines = "true", selector_separator_newline = "false", preserve_newlines = "true")');
+        opts.brace_style = 'expand';
+        opts.indent_empty_lines = true;
+        opts.selector_separator_newline = false;
+        opts.preserve_newlines = true;
+        t(
+            'a, b, .c {\n' +
+            '    width: auto;\n' +
+            '  \n' +
+            '    height: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '    width: auto;\n' +
+            '    \n    height: auto;\n' +
+            '}');
+        
+        // edge case - empty line after { should not be indented without indent_empty_lines
+        t(
+            'a, b, .c {\n' +
+            '\n' +
+            '    width: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '    \n    width: auto;\n' +
+            '}');
+        
+        // integration test of newline_between_rules, imports, and brace_style="expand"
+        t(
+            '.a{} @import "custom.css";.rule{}',
+            //  -- output --
+            '.a\n' +
+            '{}\n' +
+            '@import "custom.css";\n' +
+            '.rule\n' +
+            '{}');
+
+        // brace_style = expand - (brace_style = ""expand"", indent_empty_lines = "false", selector_separator_newline = "false", preserve_newlines = "true")
+        reset_options();
+        set_name('brace_style = expand - (brace_style = ""expand"", indent_empty_lines = "false", selector_separator_newline = "false", preserve_newlines = "true")');
+        opts.brace_style = 'expand';
+        opts.indent_empty_lines = false;
+        opts.selector_separator_newline = false;
+        opts.preserve_newlines = true;
+        t(
+            'a, b, .c {\n' +
+            '    width: auto;\n' +
+            '  \n' +
+            '    height: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '    width: auto;\n' +
+            '\n    height: auto;\n' +
+            '}');
+        
+        // edge case - empty line after { should not be indented without indent_empty_lines
+        t(
+            'a, b, .c {\n' +
+            '\n' +
+            '    width: auto;\n' +
+            '}',
+            //  -- output --
+            'a, b, .c\n' +
+            '{\n' +
+            '\n    width: auto;\n' +
+            '}');
+        
+        // integration test of newline_between_rules, imports, and brace_style="expand"
+        t(
+            '.a{} @import "custom.css";.rule{}',
+            //  -- output --
+            '.a\n' +
+            '{}\n' +
+            '@import "custom.css";\n' +
+            '.rule\n' +
+            '{}');
 
 
         //============================================================

--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -88,6 +88,7 @@ Output options:
       --preserve-newlines          Preserve existing line breaks.
       --disable-selector-separator-newline
                                    Do not print each selector on a separate line.
+ -b,  --brace-style=collapse       Brace style (collapse, expand)
  -n,  --end-with-newline           End output with newline
       --disable-newline-between-rules
                                    Do not print empty line between rules.
@@ -113,11 +114,12 @@ def main():
     argv = sys.argv[1:]
 
     try:
-        opts, args = getopt.getopt(argv, "hvio:rs:c:e:tn",
+        opts, args = getopt.getopt(argv, "hvio:rs:c:e:tnb:",
                                    ['help', 'usage', 'version', 'stdin', 'outfile=', 'replace',
                                     'indent-size=', 'indent-char=', 'eol=', 'indent-with-tabs',
-                                    'preserve-newlines', 'disable-selector-separator-newline',
-                                    'end-with-newline', 'disable-newline-between-rules',
+                                    'preserve-newlines', 'brace-style=',
+                                    'disable-selector-separator-newline', 'end-with-newline',
+                                    'disable-newline-between-rules',
                                     'space-around-combinator', 'indent-empty-lines'])
     except getopt.GetoptError as ex:
         print(ex, file=sys.stderr)
@@ -155,6 +157,8 @@ def main():
             css_options.preserve_newlines = True
         elif opt in ('--disable-selector-separator-newline'):
             css_options.selector_separator_newline = False
+        elif opt in ('--brace-style', '-b'):
+            css_options.brace_style = arg
         elif opt in ('--end-with-newline', '-n'):
             css_options.end_with_newline = True
         elif opt in ('--disable-newline-between-rules'):

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -314,24 +314,35 @@ class Beautifier:
                 if insidePropertyValue:
                     insidePropertyValue = False
                     self.outdent()
-                self.indent()
-                self._output.space_before_token = True
-                self.print_string(self._ch)
 
                 # when entering conditional groups, only rulesets are
                 # allowed
                 if enteringConditionalGroup:
                     enteringConditionalGroup = False
-                    insideRule = self._indentLevel > self._nestedLevel
+                    insideRule = self._indentLevel >= self._nestedLevel
                 else:
                     # otherwise, declarations are also allowed
-                    insideRule = self._indentLevel >= self._nestedLevel
+                    insideRule = self._indentLevel >= self._nestedLevel - 1
 
                 if self._options.newline_between_rules and insideRule:
                     if self._output.previous_line and \
                             not self._output.previous_line.is_empty() and \
                             self._output.previous_line.item(-1) != '{':
                         self._output.ensure_empty_line_above('/', ',')
+
+                self._output.space_before_token = True
+
+                # The difference in print_string and indent order
+                # is necessary to indent the '{' correctly
+                if self._options.brace_style == 'expand':
+                    self._output.add_new_line()
+                    self.print_string(self._ch)
+                    self.indent()
+                    self._output.set_indent(self._indentLevel)
+                else:
+                    self.indent()
+                    self.print_string(self._ch)
+
                 self.eatWhitespace(True)
                 self._output.add_new_line()
             elif self._ch == '}':

--- a/python/cssbeautifier/css/options.py
+++ b/python/cssbeautifier/css/options.py
@@ -32,6 +32,15 @@ class BeautifierOptions(BaseOptions):
         self.selector_separator_newline = self._get_boolean('selector_separator_newline', True)
         self.newline_between_rules = self._get_boolean('newline_between_rules', True)
 
+        brace_style_split = self._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline'])
+        self.brace_style = 'collapse'
+        for bs in brace_style_split:
+            if bs != 'expand':
+                # default to collapse, as only collapse|expand is implemented for now
+                self.brace_style = 'collapse'
+            else:
+                self.brace_style = bs
+
         # deprecated
         space_around_selector_separator = self._get_boolean('space_around_selector_separator')
 

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -29,6 +29,7 @@ exports.test_data = {
     { name: "indent_size", value: "4" },
     { name: "indent_char", value: "' '" },
     { name: "selector_separator_newline", value: "true" },
+    { name: "brace_style", value: "'collapse'" },
     { name: "end_with_newline", value: "false" },
     { name: "newline_between_rules", value: "false" },
     { name: "space_around_combinator", value: "false" },
@@ -289,6 +290,8 @@ exports.test_data = {
         ],
         separator: ' ',
         separator1: ' ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
         new_rule: '\n',
         first_nested_rule: ''
       }, {
@@ -299,6 +302,8 @@ exports.test_data = {
         ],
         separator: ' ',
         separator1: ' ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
         new_rule: '',
         first_nested_rule: ''
       }, {
@@ -310,6 +315,8 @@ exports.test_data = {
         // BUG: #713
         separator: ' ',
         separator1: ' ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
         new_rule: '',
         first_nested_rule: ''
       }, {
@@ -320,6 +327,8 @@ exports.test_data = {
         ],
         separator: '\\n',
         separator1: '\\n\    ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
         new_rule: '\n',
         first_nested_rule: '\n' // bug #1489
       }, {
@@ -330,6 +339,8 @@ exports.test_data = {
         ],
         separator: '\\n',
         separator1: '\\n\    ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
         new_rule: '',
         first_nested_rule: ''
       }, {
@@ -340,27 +351,79 @@ exports.test_data = {
         ],
         separator: '\\n',
         separator1: '\\n\    ',
+        curly_separator: ' ',
+        curly_separator2: ' ',
+        new_rule: '',
+        new_rule_bug: ''
+      }, {
+        options: [
+          { name: 'selector_separator_newline', value: 'true' },
+          { name: 'selector_separator', value: '"  "' },
+          { name: 'brace_style', value: '"expand"' },
+          { name: 'newline_between_rules', value: 'false' }
+        ],
+        separator: '\\n',
+        separator1: '\\n\    ',
+        curly_separator: '\\n',
+        curly_separator2: '\\n    ',
         new_rule: '',
         new_rule_bug: ''
       }],
-      tests: [
-        { input: '#bla, #foo{color:green}', output: '#bla,{{separator}}#foo {\n    color: green\n}' },
-        { input: '#bla, #foo{color:green}\n#bla, #foo{color:green}', output: '#bla,{{separator}}#foo {\n    color: green\n}{{new_rule}}\n#bla,{{separator}}#foo {\n    color: green\n}' },
-        { input: '@media print {.tab{}}', output: '@media print {\n    .tab {}\n}' },
-
+      tests: [{
+          input: '#bla, #foo{color:green}',
+          output: '#bla,{{separator}}#foo{{curly_separator}}{\n    color: green\n}'
+        },
+        {
+          input: '#bla, #foo{color:green}\n#bla, #foo{color:green}',
+          output: [
+            '#bla,{{separator}}#foo{{curly_separator}}{',
+            '    color: green',
+            '}{{new_rule}}',
+            '#bla,{{separator}}#foo{{curly_separator}}{',
+            '    color: green',
+            '}'
+          ]
+        },
+        {
+          input: '@media print {.tab{}}',
+          output: '@media print{{curly_separator}}{\n    .tab{{curly_separator2}}{}\n}'
+        },
         {
           comment: 'This is bug #1489',
           input: '@media print {.tab,.bat{}}',
-          output: '@media print {\n{{first_nested_rule}}    .tab,{{separator1}}.bat {}\n}'
+          output: '@media print{{curly_separator}}{\n{{first_nested_rule}}    .tab,{{separator1}}.bat{{curly_separator2}}{}\n}'
         },
         {
           comment: 'This is bug #1489',
           input: '@media print {// comment\n//comment 2\n.bat{}}',
-          output: '@media print {\n{{new_rule}}    // comment\n    //comment 2\n    .bat {}\n}'
+          output: [
+            '@media print{{curly_separator}}{',
+            '{{new_rule}}    // comment',
+            '    //comment 2',
+            '    .bat{{curly_separator2}}{}',
+            '}'
+          ]
         },
-        { input: '#bla, #foo{color:black}', output: '#bla,{{separator}}#foo {\n    color: black\n}' }, {
+        {
+          input: '#bla, #foo{color:black}',
+          output: '#bla,{{separator}}#foo{{curly_separator}}{\n    color: black\n}'
+        },
+        {
           input: 'a:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}\na:first-child,a:first-child{color:red;div:first-child,div:hover{color:black;}}',
-          output: 'a:first-child,{{separator}}a:first-child {\n    color: red;{{new_rule}}\n    div:first-child,{{separator1}}div:hover {\n        color: black;\n    }\n}\n{{new_rule}}a:first-child,{{separator}}a:first-child {\n    color: red;{{new_rule}}\n    div:first-child,{{separator1}}div:hover {\n        color: black;\n    }\n}'
+          output: [
+            'a:first-child,{{separator}}a:first-child{{curly_separator}}{',
+            '    color: red;{{new_rule}}',
+            '    div:first-child,{{separator1}}div:hover{{curly_separator2}}{',
+            '        color: black;',
+            '    }',
+            '}',
+            '{{new_rule}}a:first-child,{{separator}}a:first-child{{curly_separator}}{',
+            '    color: red;{{new_rule}}',
+            '    div:first-child,{{separator1}}div:hover{{curly_separator2}}{',
+            '        color: black;',
+            '    }',
+            '}'
+          ]
         }
       ]
     }, {
@@ -1601,6 +1664,77 @@ exports.test_data = {
           '    height: auto;',
           '',
           '}'
+        ]
+      }]
+    }, {
+      name: "brace_style = expand",
+      description: "",
+      matrix: [{
+        options: [
+          { name: "brace_style", value: "'expand'" },
+          { name: "selector_separator_newline", value: "false" },
+          { name: "newline_between_rules", value: "true" }
+        ],
+        empty_line_indent: '',
+        newline: '\n'
+      }, {
+        options: [
+          { name: "brace_style", value: "'expand'" },
+          { name: "indent_empty_lines", value: "true" },
+          { name: "selector_separator_newline", value: "false" },
+          { name: "preserve_newlines", value: "true" }
+        ],
+        empty_line_indent: '    \\n',
+        newline: ''
+      }, {
+        options: [
+          { name: "brace_style", value: "'expand'" },
+          { name: "indent_empty_lines", value: "false" },
+          { name: "selector_separator_newline", value: "false" },
+          { name: "preserve_newlines", value: "true" }
+        ],
+        empty_line_indent: '\\n',
+        newline: ''
+      }],
+
+      tests: [{
+        input: [
+          'a, b, .c {',
+          '    width: auto;',
+          '  ',
+          '    height: auto;',
+          '}'
+        ],
+        output: [
+          'a, b, .c',
+          '{',
+          '    width: auto;',
+          '{{empty_line_indent}}    height: auto;',
+          '}'
+        ]
+      }, {
+        comment: 'edge case - empty line after { should not be indented without indent_empty_lines',
+        input: [
+          'a, b, .c {',
+          '',
+          '    width: auto;',
+          '}'
+        ],
+        output: [
+          'a, b, .c',
+          '{',
+          '{{empty_line_indent}}    width: auto;',
+          '}'
+        ]
+      }, {
+        comment: 'integration test of newline_between_rules, imports, and brace_style="expand"',
+        input: '.a{} @import "custom.css";.rule{}',
+        output: [
+          '.a',
+          '{}',
+          '{{newline}}@import "custom.css";',
+          '{{newline}}.rule',
+          '{}'
         ]
       }]
     }, {


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `master`)


Fixes Issue: #1776 ( adding a newline before the opening curly brace of selector(s) )
#1353 

#1259 (partially, till the other options are implemented)


~Name of the new option: `curly-start-newline`~
~Shorthand: `-R` for the `cur` in `curly`~

Added `brace-style=expand` to the css beautifier

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

