### PR TITLE
Fix for obj?.[expr] optional chaining syntax

### DIFF
--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -546,7 +546,7 @@ Beautifier.prototype.handle_start_expr = function(current_token) {
       }
     }
 
-    if (!in_array(this._flags.last_token.type, [TOKEN.START_EXPR, TOKEN.END_EXPR, TOKEN.WORD, TOKEN.OPERATOR])) {
+    if (!in_array(this._flags.last_token.type, [TOKEN.START_EXPR, TOKEN.END_EXPR, TOKEN.WORD, TOKEN.OPERATOR, TOKEN.DOT])) {
       this._output.space_before_token = true;
     }
   } else {

--- a/js/test/generated/beautify-javascript-tests.js
+++ b/js/test/generated/beautify-javascript-tests.js
@@ -6936,6 +6936,11 @@ function run_javascript_tests(test_obj, Urlencoded, js_beautify, html_beautify, 
         // Issue 1727 - Optional chaining
         bt('true?.1:.2', 'true ? .1 : .2');
         
+        // Issue 1801 - Optional chaining w/ obj?.[expr] syntax
+        bt(
+            'let nestedProp = obj?.["prop" + "Name"];\n' +
+            'let arrayItem = arr?.[42];');
+        
         // Issue 406 - Multiline array
         bt(
             'var tempName = [\n' +

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -542,6 +542,7 @@ class Beautifier:
                 TOKEN.END_EXPR,
                 TOKEN.WORD,
                 TOKEN.OPERATOR,
+                TOKEN.DOT
             ]:
                 self._output.space_before_token = True
 

--- a/python/jsbeautifier/tests/generated/tests.py
+++ b/python/jsbeautifier/tests/generated/tests.py
@@ -6647,6 +6647,11 @@ class TestJSBeautifier(unittest.TestCase):
         # Issue 1727 - Optional chaining
         bt('true?.1:.2', 'true ? .1 : .2')
         
+        # Issue 1801 - Optional chaining w/ obj?.[expr] syntax
+        bt(
+            'let nestedProp = obj?.["prop" + "Name"];\n' +
+            'let arrayItem = arr?.[42];')
+        
         # Issue 406 - Multiline array
         bt(
             'var tempName = [\n' +

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3724,6 +3724,13 @@ exports.test_data = {
           ]
         },
         {
+          comment: "Issue 1801 - Optional chaining w/ obj?.[expr] syntax",
+          unchanged: [
+            'let nestedProp = obj?.["prop" + "Name"];',
+            'let arrayItem = arr?.[42];'
+          ]
+        },
+        {
           comment: "Issue 406 - Multiline array",
           unchanged: [
             'var tempName = [',


### PR DESCRIPTION
# Description
- [ ✅] Source branch in your fork has meaningful name (not `master`)

Fixes Issue: #1801 

Added a condition that ensures a space isn't added before the '['.


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ✅] JavaScript implementation
- [✅ ] Python implementation (NA if HTML beautifier)
- [ ✅] Added Tests to data file(s)
- [ N/A ] Added command-line option(s) (NA if
- [  N/A ] README.md documents new feature/option(s)

