### PR TITLE
Use native mkdirSync instead of 'mkdirp' package

### DIFF
--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -40,7 +40,6 @@ var debug = process.env.DEBUG_JSBEAUTIFY || process.env.JSBEAUTIFY_DEBUG ? funct
 var fs = require('fs'),
     cc = require('config-chain'),
     beautify = require('../index'),
-    mkdirp = require('mkdirp'),
     nopt = require('nopt'),
     glob = require('glob');
 
@@ -485,7 +484,7 @@ function writePretty(err, pretty, outfile, config) {
     }
 
     if (outfile) {
-        mkdirp.sync(path.dirname(outfile));
+        fs.mkdirSync(path.dirname(outfile), { recursive: true });
 
         if (isFileDifferent(outfile, pretty)) {
             try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "config-chain": "^1.1.12",
         "editorconfig": "^0.15.3",
         "glob": "^7.1.3",
-        "mkdirp": "^1.0.4",
         "nopt": "^5.0.0"
       },
       "bin": {
@@ -1766,17 +1765,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/mocha": {
       "version": "8.3.2",
@@ -4686,11 +4674,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "config-chain": "^1.1.12",
     "editorconfig": "^0.15.3",
     "glob": "^7.1.3",
-    "mkdirp": "^1.0.4",
     "nopt": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

In Node.js 10 and later, recursive mkdir is available in core. No longer needs the `mkdirp` package.
<https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_mkdirsync_path_options>

# Before Merge Checklist 

- [x] Source branch in your fork has meaningful name (not `master`)
- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s)
- [x] README.md documents new feature/option(s)


Ref https://github.com/11ty/eleventy/issues/1375.