### PR TITLE
Document Node 10 requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "Liam Newman <bitwiseman@beautifier.io>"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=10"
+  },
   "dependencies": {
     "config-chain": "^1.1.12",
     "editorconfig": "^0.15.3",


### PR DESCRIPTION
Follows https://github.com/beautify-web/js-beautify/pull/1745 which removed Node 8 from the test matrix.

Ref https://github.com/beautify-web/js-beautify/pull/1833.

