### PR TITLE
Added space_in_paren to the CSS options

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -405,14 +405,24 @@ Beautifier.prototype.beautify = function() {
     } else if (this._ch === '(') { // may be a url
       if (this._input.lookBack("url")) {
         this.print_string(this._ch);
-        this.eatWhitespace();
+        if (this._options.space_in_paren) {
+          this._output.space_before_token = true;
+        }
+        else {
+          this.eatWhitespace();
+        }
         parenLevel++;
         this.indent();
         this._ch = this._input.next();
         if (this._ch === ')' || this._ch === '"' || this._ch === '\'') {
           this._input.back();
         } else if (this._ch) {
-          this.print_string(this._ch + this.eatString(')'));
+          if(this._options.space_in_paren) {
+            this.print_string(this._ch + this.eatString(')').slice(0, -1) + ' )' );
+          }
+          else {
+            this.print_string(this._ch + this.eatString(')'));
+          }
           if (parenLevel) {
             parenLevel--;
             this.outdent();
@@ -421,7 +431,12 @@ Beautifier.prototype.beautify = function() {
       } else {
         this.preserveSingleSpace(isAfterSpace);
         this.print_string(this._ch);
-        this.eatWhitespace();
+        if (this._options.space_in_paren){
+          this._output.space_before_token = true;
+        }
+        else {
+          this.eatWhitespace();
+        }
         parenLevel++;
         this.indent();
       }
@@ -429,6 +444,9 @@ Beautifier.prototype.beautify = function() {
       if (parenLevel) {
         parenLevel--;
         this.outdent();
+      }
+      if (this._options.space_in_paren){
+        this._output.space_before_token = true;
       }
       this.print_string(this._ch);
     } else if (this._ch === ',') {

--- a/js/src/css/options.js
+++ b/js/src/css/options.js
@@ -35,6 +35,7 @@ function Options(options) {
 
   this.selector_separator_newline = this._get_boolean('selector_separator_newline', true);
   this.newline_between_rules = this._get_boolean('newline_between_rules', true);
+  this.space_in_paren = this._get_boolean('space_in_paren',false);
   var space_around_selector_separator = this._get_boolean('space_around_selector_separator');
   this.space_around_combinator = this._get_boolean('space_around_combinator') || space_around_selector_separator;
 

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -11045,6 +11045,40 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
 
 
         //============================================================
+        // space_in_paren true
+        reset_options();
+        set_name('space_in_paren true');
+        opts.space_in_paren = true;
+        test_fragment(
+            'a {\n' +
+            'width: min(100%,100vw);\n' +
+            'height: calc( 100vh - 100px );\n' +
+            '}',
+            //  -- output --
+            'a {\n' +
+            '    width: min( 100%, 100vw );\n' +
+            '    height: calc( 100vh - 100px );\n' +
+            '}');
+
+
+        //============================================================
+        // space_in_paren false
+        reset_options();
+        set_name('space_in_paren false');
+        opts.space_in_paren = false;
+        test_fragment(
+            'a {\n' +
+            'width: min(100%,100vw);\n' +
+            'height: calc( 100vh - 100px );\n' +
+            '}',
+            //  -- output --
+            'a {\n' +
+            '    width: min(100%, 100vw);\n' +
+            '    height: calc(100vh - 100px);\n' +
+            '}');
+
+
+        //============================================================
         // 
         reset_options();
         set_name('');

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -429,27 +429,40 @@ class Beautifier:
                 # may be a url
                 if self._input.lookBack("url"):
                     self.print_string(self._ch)
-                    self.eatWhitespace()
+                    if self._options.space_in_paren:
+                        self._output.space_before_token = True
+                    else:
+                        self.eatWhitespace()
                     parenLevel += 1
                     self.indent()
                     self._ch = self._input.next()
                     if self._ch in {")", '"', "'"}:
                         self._input.back()
                     elif self._ch is not None:
-                        self.print_string(self._ch + self.eatString(")"))
+                        if self._options.space_in_paren:
+                            self.print_string(
+                                self._ch + self.eatString(")")[0:-1] + " )"
+                            )
+                        else:
+                            self.print_string(self._ch + self.eatString(")"))
                         if parenLevel:
                             parenLevel -= 1
                             self.outdent()
                 else:
                     self.preserveSingleSpace(isAfterSpace)
                     self.print_string(self._ch)
-                    self.eatWhitespace()
+                    if self._options.space_in_paren:
+                        self._output.space_before_token = True
+                    else:
+                        self.eatWhitespace()
                     parenLevel += 1
                     self.indent()
             elif self._ch == ")":
                 if parenLevel:
                     parenLevel -= 1
                     self.outdent()
+                if self._options.space_in_paren:
+                    self._output.space_before_token = True
                 self.print_string(self._ch)
             elif self._ch == ",":
                 self.print_string(self._ch)

--- a/python/cssbeautifier/css/options.py
+++ b/python/cssbeautifier/css/options.py
@@ -34,6 +34,7 @@ class BeautifierOptions(BaseOptions):
             "selector_separator_newline", True
         )
         self.newline_between_rules = self._get_boolean("newline_between_rules", True)
+        self.space_in_paren = self._get_boolean("space_in_paren", False)
 
         brace_style_split = self._get_selection_list(
             "brace_style",

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -10915,6 +10915,38 @@ class CSSBeautifierTest(unittest.TestCase):
 
 
         #============================================================
+        # space_in_paren true
+        self.reset_options()
+        self.options.space_in_paren = true
+        test_fragment(
+            'a {\n' +
+            'width: min(100%,100vw);\n' +
+            'height: calc( 100vh - 100px );\n' +
+            '}',
+            #  -- output --
+            'a {\n' +
+            '    width: min( 100%, 100vw );\n' +
+            '    height: calc( 100vh - 100px );\n' +
+            '}')
+
+
+        #============================================================
+        # space_in_paren false
+        self.reset_options()
+        self.options.space_in_paren = false
+        test_fragment(
+            'a {\n' +
+            'width: min(100%,100vw);\n' +
+            'height: calc( 100vh - 100px );\n' +
+            '}',
+            #  -- output --
+            'a {\n' +
+            '    width: min(100%, 100vw);\n' +
+            '    height: calc(100vh - 100px);\n' +
+            '}')
+
+
+        #============================================================
         # 
         self.reset_options()
 

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -1440,12 +1440,16 @@ class Beautifier:
             elif self._flags.last_token.type == TOKEN.OPERATOR:
                 # a++ + ++b
                 # a - -b
-                space_before = current_token.text in [
-                    "--",
-                    "-",
-                    "++",
-                    "+",
-                ] and self._flags.last_token.text in ["--", "-", "++", "+"]
+                space_before = (
+                    current_token.text
+                    in [
+                        "--",
+                        "-",
+                        "++",
+                        "+",
+                    ]
+                    and self._flags.last_token.text in ["--", "-", "++", "+"]
+                )
                 # + and - are not unary when preceeded by -- or ++ operator
                 # a-- + b
                 # a * +b

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1800,6 +1800,48 @@ exports.test_data = {
         ]
       }]
     }, {
+      name: "space_in_paren true",
+      description: "",
+      options: [
+        { name: "space_in_paren", value: "true" }
+      ],
+      tests: [{
+        fragment: true,
+        input: [
+          'a {',
+          'width: min(100%,100vw);',
+          'height: calc( 100vh - 100px );',
+          '}'
+        ],
+        output: [
+          'a {',
+          '    width: min( 100%, 100vw );',
+          '    height: calc( 100vh - 100px );',
+          '}'
+        ]
+      }]
+    }, {
+      name: "space_in_paren false",
+      description: "",
+      options: [
+        { name: "space_in_paren", value: "false" }
+      ],
+      tests: [{
+        fragment: true,
+        input: [
+          'a {',
+          'width: min(100%,100vw);',
+          'height: calc( 100vh - 100px );',
+          '}'
+        ],
+        output: [
+          'a {',
+          '    width: min(100%, 100vw);',
+          '    height: calc(100vh - 100px);',
+          '}'
+        ]
+      }]
+    }, {
 
     }
   ]


### PR DESCRIPTION
The default value is false to keep the current behaviour as-is
Added both JS and Py implementations
Added unit tests for the space_in_paren option

# Description
- [x] Source branch in your fork has meaningful name (not `master`)


Fixes Issue: 
#1856


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [ ] Added command-line option(s) - It's already documented, but was not applied for CSS beautification.
- [ ] README.md documents new feature/option(s) - It's already documented, but was not applied for CSS beautification.

