### PR TITLE
Added option max_preserve_newlines in CSS beautifier

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -91,13 +91,12 @@ Beautifier.prototype.eatString = function(endChars) {
 // the first newline will be output
 Beautifier.prototype.eatWhitespace = function(allowAtLeastOneNewLine) {
   var result = whitespaceChar.test(this._input.peek());
-  var isFirstNewLine = true;
-
+  var newline_count = 0;
   while (whitespaceChar.test(this._input.peek())) {
     this._ch = this._input.next();
     if (allowAtLeastOneNewLine && this._ch === '\n') {
-      if (this._options.preserve_newlines || isFirstNewLine) {
-        isFirstNewLine = false;
+      if (newline_count === 0 || newline_count < this._options.max_preserve_newlines) {
+        newline_count++;
         this._output.add_new_line(true);
       }
     }

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -98,7 +98,7 @@ Beautifier.prototype.eatWhitespace = function(allowAtLeastOneNewLine) {
       if (newline_count === 0 || newline_count < this._options.max_preserve_newlines) {
         newline_count++;
         this._output.add_new_line(true);
-      } 
+      }
     }
   }
   return result;

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -98,7 +98,7 @@ Beautifier.prototype.eatWhitespace = function(allowAtLeastOneNewLine) {
       if (newline_count === 0 || newline_count < this._options.max_preserve_newlines) {
         newline_count++;
         this._output.add_new_line(true);
-      }
+      } 
     }
   }
   return result;

--- a/js/test/generated/beautify-css-tests.js
+++ b/js/test/generated/beautify-css-tests.js
@@ -11045,6 +11045,35 @@ function run_css_tests(test_obj, Urlencoded, js_beautify, html_beautify, css_bea
 
 
         //============================================================
+        // Preserve Newlines and max number of new lines
+        reset_options();
+        set_name('Preserve Newlines and max number of new lines');
+        opts.preserve_newlines = true;
+        opts.max_preserve_newlines = 2;
+        t(
+            'p {\n' +
+            '\n' +
+            '\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}',
+            //  -- output --
+            'p {\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}');
+        t(
+            'p {\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}');
+        t(
+            'p {\n' +
+            '    color: blue;\n' +
+            '}');
+
+
+        //============================================================
         // 
         reset_options();
         set_name('');

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -143,9 +143,12 @@ class Beautifier:
         while whitespaceChar.search(self._input.peek() or "") is not None:
             self._ch = self._input.next()
             if allowAtLeastOneNewLine and self._ch == "\n":
-                if newline_count == 0 or newline_count < self._options.max_preserve_newlines:
+                if (
+                    newline_count == 0 or
+                    newline_count < self._options.max_preserve_newlines
+                ):
                     newline_count += 1
-                    self._output.add_new_line(True)          
+                    self._output.add_new_line(True)
         return result
 
     # Nested pseudo-class if we are insideRule

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -139,13 +139,13 @@ class Beautifier:
     def eatWhitespace(self, allowAtLeastOneNewLine=False):
         result = whitespaceChar.search(self._input.peek() or "") is not None
         isFirstNewLine = True
-
+        newline_count = 0
         while whitespaceChar.search(self._input.peek() or "") is not None:
             self._ch = self._input.next()
             if allowAtLeastOneNewLine and self._ch == "\n":
-                if self._options.preserve_newlines or isFirstNewLine:
-                    isFirstNewLine = False
-                    self._output.add_new_line(True)
+                if newline_count == 0 or newline_count < self._options.max_preserve_newlines:
+                    newline_count += 1
+                    self._output.add_new_line(True)          
         return result
 
     # Nested pseudo-class if we are insideRule

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -144,8 +144,8 @@ class Beautifier:
             self._ch = self._input.next()
             if allowAtLeastOneNewLine and self._ch == "\n":
                 if (
-                    newline_count == 0 or
-                    newline_count < self._options.max_preserve_newlines
+                    newline_count == 0
+                    or newline_count < self._options.max_preserve_newlines
                 ):
                     newline_count += 1
                     self._output.add_new_line(True)

--- a/python/cssbeautifier/tests/generated/tests.py
+++ b/python/cssbeautifier/tests/generated/tests.py
@@ -10915,6 +10915,34 @@ class CSSBeautifierTest(unittest.TestCase):
 
 
         #============================================================
+        # Preserve Newlines and max number of new lines
+        self.reset_options()
+        self.options.preserve_newlines = true
+        self.options.max_preserve_newlines = 2
+        t(
+            'p {\n' +
+            '\n' +
+            '\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}',
+            #  -- output --
+            'p {\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}')
+        t(
+            'p {\n' +
+            '\n' +
+            '    color: blue;\n' +
+            '}')
+        t(
+            'p {\n' +
+            '    color: blue;\n' +
+            '}')
+
+
+        #============================================================
         # 
         self.reset_options()
 

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1800,6 +1800,21 @@ exports.test_data = {
         ]
       }]
     }, {
+      name: "Preserve Newlines and max number of new lines",
+      options: [
+        { name: "preserve_newlines", value: "true" },
+        { name: "max_preserve_newlines", value: "2" }
+      ],
+      description: "",
+      tests: [{
+        input: 'p {\n\n\n\n    color: blue;\n}',
+        output: 'p {\n\n    color: blue;\n}'
+      }, {
+        unchanged: 'p {\n\n    color: blue;\n}'
+      }, {
+        unchanged: 'p {\n    color: blue;\n}'
+      }]
+    }, {
 
     }
   ]


### PR DESCRIPTION
# Description
Added option max_preserve_newlines to CSS beautifier, as well tests with more lines, less lines and the same as the ones requested in the option.
- [x] Source branch in your fork has meaningful name (not `master`)


Fixes #1863: 


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

