### PR TITLE
fixed issue 1823

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -695,7 +695,7 @@ Beautifier.prototype._set_tag_position = function(printer, raw_token, parser_tok
     }
 
     // Don't add a newline before elements that should remain where they are.
-    if (parser_token.tag_name === '!--' && last_token.type === TOKEN.TAG_CLOSE &&
+    if ((parser_token.tag_name !== '!--' || parser_token.tag_name === '!--') && last_token.type === TOKEN.TAG_CLOSE &&
       last_tag_token.is_end_tag && parser_token.text.indexOf('\n') === -1) {
       //Do nothing. Leave comments on same line.
     } else {


### PR DESCRIPTION
# Description
- [ ✓ ] Source branch in your fork has meaningful name (not `main`)
Fixed if statement here: https://github.com/beautify-web/js-beautify/blob/master/js/src/html/beautifier.js#L698

Fixes Issue: 
1823: HTML formatter sends comments to a new line when the comment does not include a space as the first character


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [✓ ] JavaScript implementation
- [ NA] Python implementation (NA if HTML beautifier)
- [ NA Added Tests to data file(s)
- [ NA] Added command-line option(s) (NA if
- [NA ] README.md documents new feature/option(s)

