### PR TITLE
python: fix argument parsing, missing css-beautify config option

### DIFF
--- a/python/cssbeautifier/_main.py
+++ b/python/cssbeautifier/_main.py
@@ -162,21 +162,21 @@ def main():
             css_options.eol = arg
         elif opt in ("--indent-with-tabs", "-t"):
             css_options.indent_with_tabs = True
-        elif opt in ("--preserve-newlines"):
+        elif opt in ("--preserve-newlines",):
             css_options.preserve_newlines = True
-        elif opt in ("--disable-selector-separator-newline"):
+        elif opt in ("--disable-selector-separator-newline",):
             css_options.selector_separator_newline = False
         elif opt in ("--brace-style", "-b"):
             css_options.brace_style = arg
         elif opt in ("--end-with-newline", "-n"):
             css_options.end_with_newline = True
-        elif opt in ("--disable-newline-between-rules"):
+        elif opt in ("--disable-newline-between-rules",):
             css_options.newline_between_rules = False
-        elif opt in ("--space-around-combinator"):
+        elif opt in ("--space-around-combinator",):
             css_options.space_around_combinator = True
-        elif opt in ("--indent-empty-lines"):
+        elif opt in ("--indent-empty-lines",):
             css_options.indent_empty_lines = True
-        elif opt in ("--editorconfig"):
+        elif opt in ("--editorconfig",):
             css_options.editorconfig = True
 
     try:

--- a/python/cssbeautifier/css/options.py
+++ b/python/cssbeautifier/css/options.py
@@ -57,3 +57,4 @@ class BeautifierOptions(BaseOptions):
             self._get_boolean("space_around_combinator")
             or space_around_selector_separator
         )
+        self.keep_quiet = True

--- a/python/cssbeautifier/css/options.py
+++ b/python/cssbeautifier/css/options.py
@@ -57,4 +57,4 @@ class BeautifierOptions(BaseOptions):
             self._get_boolean("space_around_combinator")
             or space_around_selector_separator
         )
-        self.keep_quiet = True
+        self.keep_quiet = False

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -216,7 +216,7 @@ def main():
             filepath_params.append(arg)
         elif opt in ("--keep-array-indentation", "-k"):
             js_options.keep_array_indentation = True
-        elif opt in ("--keep-function-indentation"):
+        elif opt in ("--keep-function-indentation",):
             js_options.keep_function_indentation = True
         elif opt in ("--outfile", "-o"):
             outfile_param = arg
@@ -242,11 +242,11 @@ def main():
             js_options.jslint_happy = True
         elif opt in ("--space-after-anon-function", "-a"):
             js_options.space_after_anon_function = True
-        elif opt in ("--space-after-named-function"):
+        elif opt in ("--space-after-named-function",):
             js_options.space_after_named_function = True
-        elif opt in ("--eval-code"):
+        elif opt in ("--eval-code",):
             js_options.eval_code = True
-        elif opt in ("--quiet"):
+        elif opt in ("--quiet",):
             js_options.keep_quiet = True
         elif opt in ("--brace-style", "-b"):
             js_options.brace_style = arg
@@ -262,14 +262,14 @@ def main():
             js_options.operator_position = arg
         elif opt in ("--wrap-line-length ", "-w"):
             js_options.wrap_line_length = int(arg)
-        elif opt in ("--indent-empty-lines"):
+        elif opt in ("--indent-empty-lines",):
             js_options.indent_empty_lines = True
-        elif opt in ("--templating"):
+        elif opt in ("--templating",):
             js_options.templating = arg.split(",")
         elif opt in ("--stdin", "-i"):
             # stdin is the default if no files are passed
             filepath_params = []
-        elif opt in ("--editorconfig"):
+        elif opt in ("--editorconfig",):
             js_options.editorconfig = True
         elif opt in ("--version", "-v"):
             return print(__version__)

--- a/python/jsbeautifier/cli/__init__.py
+++ b/python/jsbeautifier/cli/__init__.py
@@ -228,7 +228,9 @@ def write_beautified_output(pretty, local_options, outfile):
             # python automatically converts newlines in text to "\r\n" when on windows
             # set newline to empty to prevent this
             with io.open(outfile, "wt", newline="", encoding="UTF-8") as f:
-                print("beautified " + outfile, file=sys.stdout)
+                if not local_options.keep_quiet:
+                    print("beautified " + outfile, file=sys.stdout)
+
                 try:
                     f.write(pretty)
                 except TypeError:

--- a/python/jsbeautifier/tests/shell-test.sh
+++ b/python/jsbeautifier/tests/shell-test.sh
@@ -147,9 +147,20 @@ test_cli_js_beautify()
         cleanup 1
     }
 
+
     # ensure new line settings work
     $CLI_SCRIPT -o $TEST_TEMP/js-beautify-n.js -e '\n' $SCRIPT_DIR/../../../js/bin/js-beautify.js
     $CLI_SCRIPT -o $TEST_TEMP/js-beautify-rn.js -e '\r\n' $TEST_TEMP/js-beautify-n.js
+
+    # regression check #1925, short option failed due to string search instead of tuple
+    # before fix -n would match inside "--space-after**-n**amed-function"
+    $CLI_SCRIPT -o $TEST_TEMP/js-beautify-eof.js -n -f $TEST_TEMP/js-beautify-n.js
+    $CLI_SCRIPT -o $TEST_TEMP/js-beautify-eof2.js --end-with-newline -f $TEST_TEMP/js-beautify-n.js
+    diff -q $TEST_TEMP/js-beautify-eof.js $TEST_TEMP/js-beautify-eof2.js || {
+        diff $TEST_TEMP/js-beautify-eof.js $TEST_TEMP/js-beautify-eof2.js | cat -t -e
+        echo "js-beautify output for $TEST_TEMP/js-beautify-eof.js and $TEST_TEMP/js-beautify-eof2.js was expected to be the same."
+        cleanup 1
+    }
 
     # ensure eol processed correctly
     $CLI_SCRIPT -o $TEST_TEMP/js-beautify-n-dash.js --indent-size 2 --eol '\n' $TEST_TEMP/js-beautify-n.js


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)

Please do notice that the default value of `keep_quiet` is different from js-beautify as there's no option to control it and I decided not to make it - python's part of the project doesn't seem very active anyway.

Fixes Issues: 
`-n` matching incorrect option. `("--preserve**-n**ewlines")` is not a tuple but a string.
```python3
>>> '-n' in ("--preserve-newlines")
True
>>> '-n' in ("--preserve-newlines",)
False
```

missing config option appearing if there are no changes:
```
'BeautifierOptions' object has no attribute 'keep_quiet'
```

keep_quiet didn't actually quiet `beautified FILE` message


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

