### PR TITLE
Fixed #1610 issue

### DIFF
--- a/js/src/unpackers/javascriptobfuscator_unpacker.js
+++ b/js/src/unpackers/javascriptobfuscator_unpacker.js
@@ -61,6 +61,7 @@ var JavascriptObfuscator = {
   },
 
   _fix_quotes: function(str) {
+    str = str.replace('$', '$$$$');
     var matches = /^"(.*)"$/.exec(str);
     if (matches) {
       str = matches[1];
@@ -127,6 +128,5 @@ var JavascriptObfuscator = {
     t.expect('var _0x1234=["a","b"]', true);
     return t;
   }
-
 
 };


### PR DESCRIPTION
# Description
Bug was caused by js replace function - double $ must be passed as a second argument to work properly.
Because replace method is called two times, I replaced all $ occurrences with 4 $

Fixes Issue: 
#1610 


- [x] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
