### PR TITLE
fix invalid json being generated with wrap_line_length

### DIFF
--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -311,7 +311,10 @@ class Beautifier:
         if shouldPreserveOrForce:
             self.print_newline(preserve_statement_flags=True)
         elif self._options.wrap_line_length > 0:
-            if reserved_array(self._flags.last_token, self._newline_restricted_tokens):
+            if (
+                reserved_array(self._flags.last_token, self._newline_restricted_tokens)
+                or self._flags.last_token.type == TOKEN.OPERATOR
+            ):
                 # These tokens should never have a newline inserted between
                 # them and the following expression.
                 return

--- a/python/jsbeautifier/tests/core/test_wrap_line_length.py
+++ b/python/jsbeautifier/tests/core/test_wrap_line_length.py
@@ -1,0 +1,25 @@
+import jsbeautifier
+import json
+import unittest
+
+
+class TestWrapLineLength(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def test_wrap_line_does_not_create_invalid_json(self):
+        options = jsbeautifier.default_options()
+        options.indent_size = 4
+        options.brace_style = "expand"
+        options.wrap_line_length = 40
+        obj = {
+            "1234567891234567891234567891234": -4
+        }
+        # make sure exception is not raised due to bad json (line break after -):
+        # {
+        #   "1234567891234567891234567891234": -
+        #   4
+        # }
+        # json.decoder.JSONDecodeError: Expecting value: line 2 column 40 (char 41)
+        json.loads(jsbeautifier.beautify(json.dumps(obj), options))


### PR DESCRIPTION
was creating json that split the line between "-" and the numeric value.

ex.

{
  "1234567891234567891234567891234": -
  4
}

# Description
- [ ] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

