### PR TITLE
issue #1683: fix switch case indentation

### DIFF
--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -870,7 +870,7 @@ Beautifier.prototype.handle_word = function(current_token) {
 
   if (this._flags.in_case_statement && reserved_array(current_token, ['case', 'default'])) {
     this.print_newline();
-    if ((this._flags.last_token.type !== TOKEN.END_BLOCK || (this._flags.last_token.type === TOKEN.END_BLOCK && !this._flags.case_block)) && (this._flags.case_body || this._options.jslint_happy)) {
+    if (!this._flags.case_block && (this._flags.case_body || this._options.jslint_happy)) {
       // switch cases following one another
       this.deindent();
     }

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -870,7 +870,7 @@ Beautifier.prototype.handle_word = function(current_token) {
 
   if (this._flags.in_case_statement && reserved_array(current_token, ['case', 'default'])) {
     this.print_newline();
-    if ((this._flags.last_token.type !== TOKEN.END_BLOCK || (this._flags.last_token.type === TOKEN.END_BLOCK && !this._flags.case_block ) ) && (this._flags.case_body || this._options.jslint_happy)) {
+    if ((this._flags.last_token.type !== TOKEN.END_BLOCK || (this._flags.last_token.type === TOKEN.END_BLOCK && !this._flags.case_block)) && (this._flags.case_body || this._options.jslint_happy)) {
       // switch cases following one another
       this.deindent();
     }

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -191,6 +191,7 @@ Beautifier.prototype.create_flags = function(flags_base, mode) {
     in_case_statement: false, // switch(..){ INSIDE HERE }
     in_case: false, // we're on the exact line with "case 0:"
     case_body: false, // the indented case-action block
+    case_block: false, // the indented case-action block is wrapped with {}
     indentation_level: next_indent_level,
     alignment: 0,
     line_indent_level: flags_base ? flags_base.line_indent_level : next_indent_level,
@@ -869,7 +870,7 @@ Beautifier.prototype.handle_word = function(current_token) {
 
   if (this._flags.in_case_statement && reserved_array(current_token, ['case', 'default'])) {
     this.print_newline();
-    if (this._flags.last_token.type !== TOKEN.END_BLOCK && (this._flags.case_body || this._options.jslint_happy)) {
+    if ((this._flags.last_token.type !== TOKEN.END_BLOCK || (this._flags.last_token.type === TOKEN.END_BLOCK && !this._flags.case_block ) ) && (this._flags.case_body || this._options.jslint_happy)) {
       // switch cases following one another
       this.deindent();
     }
@@ -1183,7 +1184,9 @@ Beautifier.prototype.handle_operator = function(current_token) {
     if (this._tokens.peek().type !== TOKEN.START_BLOCK) {
       this.indent();
       this.print_newline();
+      this._flags.case_block = false;
     } else {
+      this._flags.case_block = true;
       this._output.space_before_token = true;
     }
     return;

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -946,11 +946,9 @@ class Beautifier:
             current_token, ["case", "default"]
         ):
             self.print_newline()
-            if (
-                self._flags.last_token.type != TOKEN.END_BLOCK
-                or self._flags.last_token.type == TOKEN.END_BLOCK
-                and not self._flags.case_block
-            ) and (self._flags.case_body or self._options.jslint_happy):
+            if (not self._flags.case_block) and (
+                self._flags.case_body or self._options.jslint_happy
+            ):
                 self.deindent()
             self._flags.case_body = False
             self.print_token(current_token)

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -54,6 +54,7 @@ class BeautifierFlags:
         self.in_case = False
         self.in_case_statement = False
         self.case_body = False
+        self.case_block = False
         self.indentation_level = 0
         self.alignment = 0
         self.line_indent_level = 0
@@ -945,9 +946,11 @@ class Beautifier:
             current_token, ["case", "default"]
         ):
             self.print_newline()
-            if self._flags.last_token.type != TOKEN.END_BLOCK and (
-                self._flags.case_body or self._options.jslint_happy
-            ):
+            if (
+                self._flags.last_token.type != TOKEN.END_BLOCK
+                or self._flags.last_token.type == TOKEN.END_BLOCK
+                and not self._flags.case_block
+            ) and (self._flags.case_body or self._options.jslint_happy):
                 self.deindent()
             self._flags.case_body = False
             self.print_token(current_token)
@@ -1331,8 +1334,10 @@ class Beautifier:
             if self._tokens.peek().type != TOKEN.START_BLOCK:
                 self.indent()
                 self.print_newline()
+                self._flags.case_block = False
             else:
                 self._output.space_before_token = True
+                self._flags.case_block = True
 
             return
 

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3444,6 +3444,11 @@ exports.test_data = {
           ]
         },
         {
+          comment: "Issue #1683 - switch-case wrong indentation",
+          input: 'switch (x) { case 0: if (y == z) { a(); } else { b(); } case 1: c(); }',
+          output: 'switch (x) {\n    case 0:\n        if (y == z) {\n            a();\n        } else {\n            b();\n        }\n    case 1:\n        c();\n}'
+        },
+        {
           comment: "Issue 485 - ensure function declarations behave the same in arrays as elsewhere",
           unchanged: [
             'var v = ["a",',

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3446,7 +3446,18 @@ exports.test_data = {
         {
           comment: "Issue #1683 - switch-case wrong indentation",
           input: 'switch (x) { case 0: if (y == z) { a(); } else { b(); } case 1: c(); }',
-          output: 'switch (x) {\n    case 0:\n        if (y == z) {\n            a();\n        } else {\n            b();\n        }\n    case 1:\n        c();\n}'
+          output: [
+            'switch (x) {',
+            '    case 0:',
+            '        if (y == z) {',
+            '            a();',
+            '        } else {',
+            '            b();',
+            '        }',
+            '    case 1:',
+            '        c();',
+            '}'
+          ]
         },
         {
           comment: "Issue 485 - ensure function declarations behave the same in arrays as elsewhere",


### PR DESCRIPTION
# Issue
Wrong indentation observed when the last line in a case is a right brace.
# Input
```
switch (x) {
    case 0:
        if (y == z) {
            a();
        } else {
            b();
        }
    case 1:
        c();
}
```
# Expected Output

(same as input)
```
switch (x) {
    case 0:
        if (y == z) {
            a();
        } else {
            b();
        }
    case 1:
        c();
}
```
# Actual Output
```
switch (x) {
    case 0:
        if (y == z) {
            a();
        } else {
            b();
        }
        case 1:
            c();
}
```

# Solution 
Deindent for case/default token is skipped whenever the previous
token is a right brace.
However this logic doesn't always work as highlighted in the issue.
Added code to skip deindent only if the closing right brace corresponds to
opening left brace of case action block.

# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: https://github.com/beautify-web/js-beautify/issues/1683



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [NA] Added command-line option(s) (NA if
- [NA] README.md documents new feature/option(s)

