### PR TITLE
Support handlebars partial blocks with parameters

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -612,7 +612,7 @@ var TagOpenParserToken = function(parent, raw_token) {
 
       // handle "{{#> myPartial}}
       if (raw_token.text === '{{#>' && this.tag_check === '>' && raw_token.next !== null) {
-        this.tag_check = raw_token.next.text;
+        this.tag_check = raw_token.next.text.split(' ')[0];
       }
     }
     this.tag_check = this.tag_check.toLowerCase();

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1695,6 +1695,30 @@ exports.test_data = {
           '    <p>Unfortunately this condition is false.</p>',
           '{{/myPartial}}'
         ]
+      },
+      {
+        comment: "Issue #1946 - Indentation of partial blocks with whitespace following partial name",
+        unchanged: [
+          '{{#> myPartial }}',
+          '    <p>Unfortunately this condition is false.</p>',
+          '{{/myPartial}}'
+        ]
+      },
+      {
+        comment: "Issue #1946 - Indentation of partial blocks with parameters",
+        unchanged: [
+          '{{#> myPartial param="test"}}',
+          '    <p>Unfortunately this condition is false.</p>',
+          '{{/myPartial}}'
+        ]
+      },
+      {
+        comment: "Issue #1946 - Indentation of inline partials with parameters",
+        unchanged: [
+          '{{#*inline "myPartial" param="test"}}',
+          '    <p>Unfortunately this condition is false.</p>',
+          '{{/inline}}'
+        ]
       }
     ]
   }, {


### PR DESCRIPTION
# Description
Fix handling of handlebars partial blocks with whitespace or parameters following partial name.

- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: #1946


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

