### PR TITLE
feature: allow mac users to use command+enter for submit button

### DIFF
--- a/web/onload.js
+++ b/web/onload.js
@@ -44,7 +44,7 @@ $(function() {
     }
   });
 
-  if(typeof window.navigator !== "undefined" && typeof window.navigator.platform === "string" && window.navigator.platform.includes("Mac")) {
+  if (typeof window.navigator !== "undefined" && typeof window.navigator.platform === "string" && window.navigator.platform.includes("Mac")) {
     $(".submit em").text("(cmd-enter)");
   }
 

--- a/web/onload.js
+++ b/web/onload.js
@@ -39,10 +39,14 @@ $(function() {
 
 
   $(window).bind('keydown', function(e) {
-    if (e.ctrlKey && e.keyCode === 13) {
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 13) {
       beautify();
     }
   });
+
+  if(typeof window.navigator !== "undefined" && typeof window.navigator.platform === "string" && window.navigator.platform.includes("Mac")) {
+    $(".submit em").text("(cmd-enter)");
+  }
 
   $('.submit').click(beautify);
   $('select').change(beautify);


### PR DESCRIPTION
# Description
- [X] Added ability for mac users to use command + enter to submit
- [X] Mac users are shown "(cmd-enter)" text instead of "(ctrl-enter)"


Fixes Issue: 
#1985 