### PR TITLE
'class' as a object property name

### DIFF
--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -691,10 +691,10 @@ Beautifier.prototype.handle_start_block = function(current_token) {
     )) {
     // We don't support TypeScript,but we didn't break it for a very long time.
     // We'll try to keep not breaking it.
-    if (!in_array(this._last_last_text, ['class', 'interface'])) {
-      this.set_mode(MODE.ObjectLiteral);
-    } else {
+    if (in_array(this._last_last_text, ['class', 'interface']) && !!second_token.whitespace_before) {
       this.set_mode(MODE.BlockStatement);
+    } else {
+      this.set_mode(MODE.ObjectLiteral);
     }
   } else if (this._flags.last_token.type === TOKEN.OPERATOR && this._flags.last_token.text === '=>') {
     // arrow function: (param1, paramN) => { statements }

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -691,7 +691,7 @@ Beautifier.prototype.handle_start_block = function(current_token) {
     )) {
     // We don't support TypeScript,but we didn't break it for a very long time.
     // We'll try to keep not breaking it.
-    if (in_array(this._last_last_text, ['class', 'interface']) && !!second_token.whitespace_before) {
+    if (in_array(this._last_last_text, ['class', 'interface']) && !in_array(second_token.text, [':', ','])) {
       this.set_mode(MODE.BlockStatement);
     } else {
       this.set_mode(MODE.ObjectLiteral);

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -729,10 +729,10 @@ class Beautifier:
         ):
             # We don't support TypeScript,but we didn't break it for a very long time.
             # We'll try to keep not breaking it.
-            if (
-                self._last_last_text in ["class", "interface"]
-                and second_token.whitespace_before
-            ):
+            if self._last_last_text in [
+                "class",
+                "interface",
+            ] and second_token.text not in [":", ","]:
                 self.set_mode(MODE.BlockStatement)
             else:
                 self.set_mode(MODE.ObjectLiteral)

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -729,10 +729,13 @@ class Beautifier:
         ):
             # We don't support TypeScript,but we didn't break it for a very long time.
             # We'll try to keep not breaking it.
-            if self._last_last_text not in ["class", "interface"]:
-                self.set_mode(MODE.ObjectLiteral)
-            else:
+            if (
+                self._last_last_text in ["class", "interface"]
+                and second_token.whitespace_before
+            ):
                 self.set_mode(MODE.BlockStatement)
+            else:
+                self.set_mode(MODE.ObjectLiteral)
         elif (
             self._flags.last_token.type == TOKEN.OPERATOR
             and self._flags.last_token.text == "=>"

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -230,18 +230,7 @@ exports.test_data = {
     }, {
       name: "Object literal shorthand functions",
       description: "Object literal shorthand functions",
-      tests: [{
-          comment: "#1838 - handle class word as an object property",
-          unchanged: [
-            '{\n',
-            '    class: {\n',
-            '        a: 1,\n',
-            '        b: 2,\n',
-            '        c: 3,\n',
-            '    }\n',
-            '}'
-          ]
-        },
+      tests: [
         { unchanged: 'return {\n    foo() {\n        return 42;\n    }\n}' },
         {
           unchanged: [
@@ -3301,6 +3290,42 @@ exports.test_data = {
             '    /* howdy',
             '    ',
             '    */',
+            '}'
+          ]
+        },
+        {
+          comment: "#1838 - handle class and interface word as an object property",
+          unchanged: [
+            '{',
+            '    class: {',
+            '        a: 1,',
+            '        b: 2,',
+            '        c: 3,',
+            '    }',
+            '    interface: {',
+            '        a: 1,',
+            '        b: 2,',
+            '        c: 3,',
+            '    }',
+            '}'
+          ]
+        },
+        {
+          comment: "#1838 - handle class word as an object property but with space after colon",
+          input: [
+            '{',
+            '    class : { a: 1,',
+            'b: 2,c : 3',
+            '    }',
+            '}'
+          ],
+          output: [
+            '{',
+            '    class: {',
+            '        a: 1,',
+            '        b: 2,',
+            '        c: 3',
+            '    }',
             '}'
           ]
         },

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3330,6 +3330,32 @@ exports.test_data = {
           ]
         },
         {
+          comment: "#1838 - handle class word as an object property but without spaces",
+          input: '{class:{a:1,b:2,c:3,}}',
+          output: [
+            '{',
+            '    class: {',
+            '        a: 1,',
+            '        b: 2,',
+            '        c: 3,',
+            '    }',
+            '}'
+          ]
+        },
+        {
+          comment: "#1838 - handle class word as a nested object property",
+          input: '{x:{a:1,class:2,c:3,}}',
+          output: [
+            '{',
+            '    x: {',
+            '        a: 1,',
+            '        class: 2,',
+            '        c: 3,',
+            '    }',
+            '}'
+          ]
+        },
+        {
           unchanged: [
             'obj',
             '    .last(a, function() {',

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -230,7 +230,18 @@ exports.test_data = {
     }, {
       name: "Object literal shorthand functions",
       description: "Object literal shorthand functions",
-      tests: [
+      tests: [{
+          comment: "#1838 - handle class word as an object property",
+          unchanged: [
+            '{\n',
+            '    class: {\n',
+            '        a: 1,\n',
+            '        b: 2,\n',
+            '        c: 3,\n',
+            '    }\n',
+            '}'
+          ]
+        },
         { unchanged: 'return {\n    foo() {\n        return 42;\n    }\n}' },
         {
           unchanged: [


### PR DESCRIPTION
Checking to make sure that the token with text 'class' or 'interface' has whitespace after it to be considered a block statement, otherwise treat as object literal

# Description
- [X] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 
#1838