### PR TITLE
[LESS] Fixing issues with spacing when an object literal lives inside a mixin

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -314,7 +314,12 @@ Beautifier.prototype.beautify = function() {
         this.indent();
         this._output.set_indent(this._indentLevel);
       } else {
-        this.indent();
+        // inside mixin and first param is object
+        if (previous_ch === '(') {
+          this._output.space_before_token = false;
+        } else if (previous_ch !== ',') {
+          this.indent();
+        }
         this.print_string(this._ch);
       }
 
@@ -343,6 +348,12 @@ Beautifier.prototype.beautify = function() {
 
       if (this._options.newline_between_rules && !this._output.just_added_blankline()) {
         if (this._input.peek() !== '}') {
+          this._output.add_new_line(true);
+        }
+      }
+      if (this._input.peek() === ')') {
+        this._output.trim(true);
+        if (this._options.brace_style === "expand") {
           this._output.add_new_line(true);
         }
       }

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -343,7 +343,11 @@ class Beautifier:
                     self.indent()
                     self._output.set_indent(self._indentLevel)
                 else:
-                    self.indent()
+                    # inside mixin and first param is object
+                    if previous_ch == "(":
+                        self._output.space_before_token = False
+                    elif previous_ch != ",":
+                        self.indent()
                     self.print_string(self._ch)
 
                 self.eatWhitespace(True)
@@ -371,6 +375,10 @@ class Beautifier:
                     and not self._output.just_added_blankline()
                 ):
                     if self._input.peek() != "}":
+                        self._output.add_new_line(True)
+                if self._input.peek() == ")":
+                    self._output.trim(True)
+                    if self._options.brace_style == "expand":
                         self._output.add_new_line(True)
             elif self._ch == ":":
                 if (

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1801,7 +1801,7 @@ exports.test_data = {
           '        a: b;',
           '    }',
           '});'
-        ]    
+        ]
       }, {
         comment: 'Ensure simple closing parens do not break behavior',
         unchanged: [

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1793,6 +1793,16 @@ exports.test_data = {
           '    });',
           '}'
         ]
+    }, {
+        unchanged: [
+          '@selectors: blue, green, red;',
+          '',
+          'each(@selectors, {',
+          '    .sel-@{value} {',
+          '          a: b;',
+          '    }',
+          '});'
+        ]    
       }, {
         comment: 'Ensure simple closing parens do not break behavior',
         unchanged: [

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1360,9 +1360,8 @@ exports.test_data = {
             '}',
             '.set {',
             '    each(@set, {',
-            '            @{key}-@{index}: @value;',
-            '        }',
-            '    );',
+            '        @{key}-@{index}: @value;',
+            '    });',
             '}'
           ]
         },
@@ -1733,6 +1732,20 @@ exports.test_data = {
           '}'
         ]
       }, {
+        comment: 'mixins call with object notation, and brace_style="expand"',
+        input: [
+          '.example({',
+          '    color:red;',
+          '});'
+        ],
+        output: [
+          '.example(',
+          '    {',
+          '        color:red;',
+          '    }',
+          ');'
+        ]
+      }, {
         comment: 'integration test of newline_between_rules, imports, and brace_style="expand"',
         input: '.a{} @import "custom.css";.rule{}',
         output: [
@@ -1756,6 +1769,28 @@ exports.test_data = {
           '}',
           'strong {',
           '    &:extend(a:hover);',
+          '}'
+        ]
+      }, {
+        unchanged: [
+          '.test {',
+          '    .example({',
+          '        color:red;',
+          '    });',
+          '}'
+        ]
+      }, {
+        unchanged: [
+          '.example2({',
+          '    display:none;',
+          '});'
+        ]
+      }, {
+        unchanged: [
+          '.aa {',
+          '    .mq-medium(a, {',
+          '        background: red;',
+          '    });',
           '}'
         ]
       }, {

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1796,7 +1796,6 @@ exports.test_data = {
       }, {
         unchanged: [
           '@selectors: blue, green, red;',
-          '',
           'each(@selectors, {',
           '    .sel-@{value} {',
           '        a: b;',

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1799,7 +1799,7 @@ exports.test_data = {
           '',
           'each(@selectors, {',
           '    .sel-@{value} {',
-          '          a: b;',
+          '        a: b;',
           '    }',
           '});'
         ]    

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1793,7 +1793,7 @@ exports.test_data = {
           '    });',
           '}'
         ]
-    }, {
+      }, {
         unchanged: [
           '@selectors: blue, green, red;',
           '',


### PR DESCRIPTION
# Description
Fix issues with spacing in LESS code when using object literals inside mixins. The changes in this PR could be considered breaking since but I believe they are correct.

Fixes Issue: 
- https://github.com/beautify-web/js-beautify/issues/722
- https://github.com/beautify-web/js-beautify/issues/2016
- https://github.com/microsoft/vscode/issues/146693

Fixes #722
Fixes #2016
