### PR TITLE
Adding missing test cases for special words followed by prefix operators on new line

### DIFF
--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3348,6 +3348,51 @@ exports.test_data = {
           ]
         },
         {
+          comment: "#1095 - Return without semicolon followed by prefix on a new line",
+          input: [
+            'function x(){',
+            'return',
+            '++a',
+            '}',
+            '',
+            'while(true) {',
+            'return',
+            '--b',
+            '}'
+          ],
+          output: [
+            'function x() {',
+            '    return ++a',
+            '}',
+            '',
+            'while (true) {',
+            '    return --b',
+            '}'
+          ]
+        },
+        {
+          comment: "#1095 - Return with semicolon followed by a prefix on a new line",
+          input: [
+            'function x(){',
+            'return; ++a',
+            '}',
+            '',
+            'while(true){return; --b',
+            '}'
+          ],
+          output: [
+            'function x() {',
+            '    return;',
+            '    ++a',
+            '}',
+            '',
+            'while (true) {',
+            '    return;',
+            '    --b',
+            '}'
+          ]
+        },
+        {
           comment: "#1838 - handle class word as an object property but with space after colon",
           input: [
             '{',


### PR DESCRIPTION
# Description
Adding missing test cases for special words followed by prefix operators on new line. This is related to #1095 since fixing that issue seems to break this functionality.
