### PR TITLE
Implement option to support adding spaces between CSS selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ CSS Beautifier Options:
   -L, --selector-separator-newline   Add a newline between multiple selectors
   -N, --newline-between-rules        Add a newline between CSS rules
   --indent-empty-lines               Keep indentation on empty lines
+  --separate_CSS_selectors           Add a space between CSS selectors
 
 HTML Beautifier Options:
   -s, --indent-size                  Indentation size [4]

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -97,6 +97,7 @@ var path = require('path'),
         "selector_separator_newline": Boolean,
         "newline_between_rules": Boolean,
         "space_around_combinator": Boolean,
+        "separate_CSS_selectors": Boolean,
         //deprecated - replaced with space_around_combinator, remove in future version
         "space_around_selector_separator": Boolean,
         // HTML-only
@@ -180,6 +181,7 @@ var path = require('path'),
         // no shorthand for "editorconfig"
         // no shorthand for "indent_empty_lines"
         // not shorthad for "templating"
+        // no shorthand for "separate_CSS_selectors"
     });
 
 function verifyExists(fullPath) {

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -433,7 +433,8 @@ Beautifier.prototype.beautify = function() {
     } else if (this._ch === ',') {
       this.print_string(this._ch);
       this.eatWhitespace(true);
-      if (this._options.selector_separator_newline && !insidePropertyValue && parenLevel === 0 && !insideAtImport && !insideAtExtend) {
+      if (this._options.selector_separator_newline && !insidePropertyValue &&
+        parenLevel === 0 && !insideAtImport && !insideAtExtend && !this._options.separate_CSS_selectors) {
         this._output.add_new_line();
       } else {
         this._output.space_before_token = true;

--- a/js/src/css/options.js
+++ b/js/src/css/options.js
@@ -37,6 +37,7 @@ function Options(options) {
   this.newline_between_rules = this._get_boolean('newline_between_rules', true);
   var space_around_selector_separator = this._get_boolean('space_around_selector_separator');
   this.space_around_combinator = this._get_boolean('space_around_combinator') || space_around_selector_separator;
+  this.separate_CSS_selectors = this._get_boolean('separate_CSS_selectors');
 
   var brace_style_split = this._get_selection_list('brace_style', ['collapse', 'expand', 'end-expand', 'none', 'preserve-inline']);
   this.brace_style = 'collapse';

--- a/python/cssbeautifier/_main.py
+++ b/python/cssbeautifier/_main.py
@@ -128,6 +128,7 @@ def main():
                 "disable-newline-between-rules",
                 "space-around-combinator",
                 "indent-empty-lines",
+                "separate-CSS-selectors",
             ],
         )
     except getopt.GetoptError as ex:
@@ -178,6 +179,8 @@ def main():
             css_options.indent_empty_lines = True
         elif opt in ("--editorconfig",):
             css_options.editorconfig = True
+        elif opt in ("--separate-CSS-selectors"):
+            css_options.separate_CSS_selectors = True
 
     try:
         filepaths, replace = get_filepaths_from_params(filepath_params, replace)

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -463,6 +463,7 @@ class Beautifier:
                     and parenLevel == 0
                     and not insideAtImport
                     and not insideAtExtend
+                    and not self._options.separate_CSS_selectors
                 ):
                     self._output.add_new_line()
                 else:

--- a/python/cssbeautifier/css/options.py
+++ b/python/cssbeautifier/css/options.py
@@ -58,3 +58,5 @@ class BeautifierOptions(BaseOptions):
             or space_around_selector_separator
         )
         self.keep_quiet = False
+
+        self.separate_CSS_selectors = self._get_boolean("separate_CSS_selectors")

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1821,7 +1821,25 @@ exports.test_data = {
         unchanged: 'p {\n    color: blue;\n}'
       }]
     }, {
-
+      name: "Issue #1862 -- separate_CSS_selectors option adds space between CSS selectors if true",
+      options: [
+        { name: "separate_CSS_selectors", value: "true" }
+      ],
+      description: "",
+      tests: [{
+        input: '#main,#section,a {\n    color: blue;\n}',
+        output: '#main, #section, a {\n    color: blue;\n}'
+      }]
+    }, {
+      name: "Issue #1862 -- separate_CSS_selectors option adds space between CSS selectors if false",
+      options: [
+        { name: "separate_CSS_selectors", value: "false" }
+      ],
+      description: "",
+      tests: [{
+        input: '#main,#section,a {\n    color: blue;\n}',
+        output: '#main,\n#section,\na {\n    color: blue;\n}'
+      }]
     }
   ]
 };


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 
[Issue #1862] Added a new option called `separate_CSS_selectors` such that when marked true, it adds a space between CSS selectors. Added unit tests and updated the README/CLI options accordingly.


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

