### PR TITLE
Fixes #2030 - Add a link to the python library on the main site

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       </p>
       <p>
         All of the source code is completely free and open, available on <a href="https://github.com/beautify-web/js-beautify">GitHub</a> under MIT licence,
-        <br>and we have a command-line version, python library and a <a href="https://npmjs.org/package/js-beautify">node package</a> as well.
+        <br>and we have a command-line version, <a href="https://pypi.org/project/jsbeautifier/">python library</a> and a <a href="https://npmjs.org/package/js-beautify">node package</a> as well.
       </p>
       <p>
         <select name="language" id="language">


### PR DESCRIPTION
# Description
Add a link to the python library on the main site


Fixes Issue: 
- #2030