### PR TITLE
Add grid-template-areas to NON_SEMICOLON_NEWLINE_PROPERTY list

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -68,6 +68,7 @@ function Beautifier(source_text, options) {
     "@document": true
   };
   this.NON_SEMICOLON_NEWLINE_PROPERTY = [
+    "grid-template-areas",
     "grid-template"
   ];
 

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -119,7 +119,7 @@ class Beautifier:
             "@document",
         }
         self.CONDITIONAL_GROUP_RULE = {"@media", "@supports", "@document"}
-        self.NON_SEMICOLON_NEWLINE_PROPERTY = ["grid-template"]
+        self.NON_SEMICOLON_NEWLINE_PROPERTY = ["grid-template-areas", "grid-template"]
 
     def eatString(self, endChars):
         result = ""

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1534,6 +1534,21 @@ exports.test_data = {
       }, {
         input: [
           'div {',
+          'grid-template-areas: "a"',
+          ' "b" ',
+          '                    "c";',
+          '}'
+        ],
+        output: [
+          'div {',
+          '    grid-template-areas: "a"',
+          '        "b"',
+          '        "c";',
+          '}'
+        ]
+      }, {
+        input: [
+          'div {',
           'grid-template: "a a a" 20%',
           ' [main-top] "b b b" 1fr',
           '                    "b b b" auto;',


### PR DESCRIPTION
# Description
Add grid-template-areas to NON_SEMICOLON_NEWLINE_PROPERTY list. The significance of this change is visible when we start comparing entire string tokens. Right now we compare character by character and in that case `grid-template` and `grid-template-areas` will both pass the check but when we start comparing entire tokens the property name needs to be correct. 

