### PR TITLE
Fixes #1095 - Prefix operator on newline

### DIFF
--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -1151,13 +1151,6 @@ Beautifier.prototype.handle_operator = function(current_token) {
     this.handle_whitespace_and_comments(current_token, preserve_statement_flags);
   }
 
-  if (reserved_array(this._flags.last_token, special_words)) {
-    // "return" had a special handling in TK_WORD. Now we need to return the favor
-    this._output.space_before_token = true;
-    this.print_token(current_token);
-    return;
-  }
-
   // hack for actionscript's import .*;
   if (current_token.text === '*' && this._flags.last_token.type === TOKEN.DOT) {
     this.print_token(current_token);
@@ -1285,7 +1278,11 @@ Beautifier.prototype.handle_operator = function(current_token) {
     // http://www.ecma-international.org/ecma-262/5.1/#sec-7.9.1
     // if there is a newline between -- or ++ and anything else we should preserve it.
     if (current_token.newlines && (current_token.text === '--' || current_token.text === '++' || current_token.text === '~')) {
-      this.print_newline(false, true);
+      var new_line_needed = reserved_array(this._flags.last_token, special_words) && current_token.newlines;
+      if (new_line_needed && (this._previous_flags.if_block || this._previous_flags.else_block)) {
+        this.restore_mode();
+      }
+      this.print_newline(new_line_needed, true);
     }
 
     if (this._flags.last_token.text === ';' && is_expression(this._flags.mode)) {

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -1307,12 +1307,6 @@ class Beautifier:
             preserve_statement_flags = not isGeneratorAsterisk
             self.handle_whitespace_and_comments(current_token, preserve_statement_flags)
 
-        if reserved_array(self._flags.last_token, _special_word_set):
-            # return had a special handling in TK_WORD
-            self._output.space_before_token = True
-            self.print_token(current_token)
-            return
-
         # hack for actionscript's import .*;
         if current_token.text == "*" and self._flags.last_token.type == TOKEN.DOT:
             self.print_token(current_token)
@@ -1449,7 +1443,15 @@ class Beautifier:
                 or current_token.text == "++"
                 or current_token.text == "~"
             ):
-                self.print_newline(preserve_statement_flags=True)
+                new_line_needed = (
+                    reserved_array(self._flags.last_token, _special_word_set)
+                    and current_token.newlines
+                )
+                if new_line_needed and (
+                    self._previous_flags.if_block or self._previous_flags.else_block
+                ):
+                    self.restore_mode()
+                self.print_newline(new_line_needed, True)
 
             if self._flags.last_token.text == ";" and self.is_expression(
                 self._flags.mode

--- a/test/data/javascript/tests.js
+++ b/test/data/javascript/tests.js
@@ -3331,6 +3331,81 @@ exports.test_data = {
           ]
         },
         {
+          comment: "#1095 - Return without semicolon followed by prefix on a new line",
+          input: [
+            'function x(){',
+            'return',
+            '++a',
+            '}',
+            '',
+            'while(true) {',
+            'return',
+            '--b',
+            '}'
+          ],
+          output: [
+            'function x() {',
+            '    return',
+            '    ++a',
+            '}',
+            '',
+            'while (true) {',
+            '    return',
+            '    --b',
+            '}'
+          ]
+        },
+        {
+          comment: "#1095",
+          input: [
+            'function test(){',
+            'if(x) return',
+            '++x',
+            'var y= 1;',
+            '}',
+            'function t1(){',
+            'if(cc) return;',
+            'else return',
+            '--cc',
+            '}'
+          ],
+          output: [
+            'function test() {',
+            '    if (x) return',
+            '    ++x',
+            '    var y = 1;',
+            '}',
+            '',
+            'function t1() {',
+            '    if (cc) return;',
+            '    else return',
+            '    --cc',
+            '}'
+          ]
+        },
+        {
+          comment: "#1095 - Return with semicolon followed by a prefix on a new line",
+          input: [
+            'function x(){',
+            'return; ++a',
+            '}',
+            '',
+            'while(true){return; --b',
+            '}'
+          ],
+          output: [
+            'function x() {',
+            '    return;',
+            '    ++a',
+            '}',
+            '',
+            'while (true) {',
+            '    return;',
+            '    --b',
+            '}'
+          ]
+        },
+        {
           comment: "#1838 - handle class and interface word as an object property",
           unchanged: [
             '{',


### PR DESCRIPTION
# Description
Fixes bug where special words like return without semicolon are followed by prefix operators on newlines


Fixes Issue: 
- Fixes #1095
