### PR TITLE
solution to partials not seperated by spaces

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -608,19 +608,18 @@ var TagOpenParserToken = function(parent, raw_token) {
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
     } else {
       tag_check_match = raw_token.text.match(/^{{~?(?:[\^]|#\*?)?([^\s}]+)/);
-
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
 
       // handle "{{#> myPartial}}" or "{{~#> myPartial}}"
-      if ((raw_token.text === '{{#>' || raw_token.text === '{{~#>') && this.tag_check === '>' && raw_token.next !== null) {
-        this.tag_check = raw_token.next.text.split(' ')[0];
-      } else {
-        // handle "{{#>myPartial}}" or "{{~#>myPartial}}"
-        if (raw_token.text.slice(0, 4) === ('{{#>') || raw_token.text.slice(0, 5) === ('{{~#>') && this.tag_check[0] === '>') {
-          this.tag_check = raw_token.text.split('>')[1];
+      if ((raw_token.text.startsWith('{{#>') || raw_token.text.startsWith('{{~#>')) && this.tag_check[0] === '>') {
+        if(this.tag_check === '>' && raw_token.next !== null) {
+            this.tag_check = raw_token.next.text.split(' ')[0];
+        } else {
+             this.tag_check = raw_token.text.split('>')[1];
         }
       }
     }
+    
     this.tag_check = this.tag_check.toLowerCase();
 
     if (raw_token.type === TOKEN.COMMENT) {

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -608,11 +608,17 @@ var TagOpenParserToken = function(parent, raw_token) {
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
     } else {
       tag_check_match = raw_token.text.match(/^{{~?(?:[\^]|#\*?)?([^\s}]+)/);
+
       this.tag_check = tag_check_match ? tag_check_match[1] : '';
 
       // handle "{{#> myPartial}}" or "{{~#> myPartial}}"
       if ((raw_token.text === '{{#>' || raw_token.text === '{{~#>') && this.tag_check === '>' && raw_token.next !== null) {
         this.tag_check = raw_token.next.text.split(' ')[0];
+      } else {
+        // handle "{{#>myPartial}}" or "{{~#>myPartial}}"
+        if (raw_token.text.slice(0, 4) === ('{{#>') || raw_token.text.slice(0, 5) === ('{{~#>') && this.tag_check[0] === '>') {
+          this.tag_check = raw_token.text.split('>')[1];
+        }
       }
     }
     this.tag_check = this.tag_check.toLowerCase();

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -613,13 +613,13 @@ var TagOpenParserToken = function(parent, raw_token) {
       // handle "{{#> myPartial}}" or "{{~#> myPartial}}"
       if ((raw_token.text.startsWith('{{#>') || raw_token.text.startsWith('{{~#>')) && this.tag_check[0] === '>') {
         if (this.tag_check === '>' && raw_token.next !== null) {
-            this.tag_check = raw_token.next.text.split(' ')[0];
+          this.tag_check = raw_token.next.text.split(' ')[0];
         } else {
-             this.tag_check = raw_token.text.split('>')[1];
+          this.tag_check = raw_token.text.split('>')[1];
         }
       }
     }
-    
+
     this.tag_check = this.tag_check.toLowerCase();
 
     if (raw_token.type === TOKEN.COMMENT) {

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -612,7 +612,7 @@ var TagOpenParserToken = function(parent, raw_token) {
 
       // handle "{{#> myPartial}}" or "{{~#> myPartial}}"
       if ((raw_token.text.startsWith('{{#>') || raw_token.text.startsWith('{{~#>')) && this.tag_check[0] === '>') {
-        if(this.tag_check === '>' && raw_token.next !== null) {
+        if (this.tag_check === '>' && raw_token.next !== null) {
             this.tag_check = raw_token.next.text.split(' ')[0];
         } else {
              this.tag_check = raw_token.text.split('>')[1];

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -3592,7 +3592,7 @@ exports.test_data = {
       ]
     }]
   }, {
-    name: "Handle Partials Not Seperated by Spaces",
+    name: "Corrects Partial Behavior Involving Whitespace",
     description: "Handles partials that do not have a space before the tag",
     template: "^^^ $$$",
     options: [

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -3592,6 +3592,60 @@ exports.test_data = {
       ]
     }]
   }, {
+    name: "Handle Partials Not Seperated by Spaces",
+    description: "Handles partials that do not have a space before the tag",
+    template: "^^^ $$$",
+    options: [
+      { name: "nospace_partials", value: "true" }
+    ],
+    tests: [{
+      input: [
+        '{{#>row}}',
+        '    {{#>column}}',
+        '        <span>content</span>',
+        '        {{/column}}',
+        '        {{/row}}'
+      ],
+      output: [
+        '{{#>row}}',
+        '    {{#>column}}',
+        '        <span>content</span>',
+        '    {{/column}}',
+        '{{/row}}'
+      ]
+    }, {
+      input: [
+        '{{~#>row}}',
+        '{{#>column}}',
+        '<p>content</p>',
+        '{{/column}}',
+        '{{/row}}'
+      ],
+      output: [
+        '{{~#>row}}',
+        '    {{#>column}}',
+        '        <p>content</p>',
+        '    {{/column}}',
+        '{{/row}}'
+      ]
+    }, {
+      unchanged: [
+        '{{#>row}}',
+        '    {{#>column}}',
+        '        <span>content</span>',
+        '    {{/column}}',
+        '{{/row}}'
+      ]
+    }, {
+      unchanged: [
+        '{{#> row}}',
+        '    {{#> column}}',
+        '        <span>content</span>',
+        '    {{/column}}',
+        '{{/row}}'
+      ]
+    }]
+  }, {
     name: "New Test Suite"
   }]
 };

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -3595,9 +3595,6 @@ exports.test_data = {
     name: "Corrects Partial Behavior Involving Whitespace",
     description: "Handles partials that do not have a space before the tag",
     template: "^^^ $$$",
-    options: [
-      { name: "nospace_partials", value: "true" }
-    ],
     tests: [{
       input: [
         '{{#>row}}',


### PR DESCRIPTION
# Description
- [ ] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: #1869 "html formatter doesn't support handlebars partial blocks"

Created a new conditional that checks for '{{#>' and '{{~#>' at the beginning of an html block. If it finds either of these, separates the partial from the tag and properly assigns the tag.  

I added unit tests checking that issue 1869 was fixed for partials not separated by spaces as well as unit tests checking that partials separated by spaces still had correct behavior 


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [ X] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [ X] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

