### PR TITLE
Add qml support

### DIFF
--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -88,6 +88,7 @@ var path = require('path'),
         "wrap_attributes": ["auto", "force", "force-aligned", "force-expand-multiline", "aligned-multiple", "preserve", "preserve-aligned"],
         "wrap_attributes_indent_size": Number,
         "e4x": Boolean,
+        "qml": Boolean,
         "end_with_newline": Boolean,
         "comma_first": Boolean,
         "operator_position": ["before-newline", "after-newline", "preserve-newline"],
@@ -371,6 +372,7 @@ function usage(err) {
             msg.push('  -x, --unescape-strings            Decode printable characters encoded in xNN notation');
             msg.push('  -w, --wrap-line-length            Wrap lines that exceed N characters [0]');
             msg.push('  -X, --e4x                         Pass E4X xml literals through untouched');
+            msg.push('  --qml                         Add Qml support');
             msg.push('  --good-stuff                      Warm the cockles of Crockford\'s heart');
             msg.push('  -C, --comma-first                 Put commas at the beginning of new line instead of end');
             msg.push('  -O, --operator-position           Set operator position (before-newline|after-newline|preserve-newline) [before-newline]');

--- a/js/src/javascript/beautifier.js
+++ b/js/src/javascript/beautifier.js
@@ -974,7 +974,7 @@ Beautifier.prototype.handle_word = function(current_token) {
   }
 
   if (reserved_array(current_token, line_starters) && this._flags.last_token.text !== ')') {
-    if (this._flags.inline_frame || this._flags.last_token.text === 'else' || this._flags.last_token.text === 'export') {
+    if (this._flags.inline_frame || this._flags.last_token.text === 'else' || this._flags.last_token.text === 'export' || (this._options.qml && this._flags.last_token.text === 'property')) {
       prefix = 'SPACE';
     } else {
       prefix = 'NEWLINE';

--- a/js/src/javascript/options.js
+++ b/js/src/javascript/options.js
@@ -74,6 +74,7 @@ function Options(options) {
   this.space_before_conditional = this._get_boolean('space_before_conditional', true);
   this.unescape_strings = this._get_boolean('unescape_strings');
   this.e4x = this._get_boolean('e4x');
+  this.qml = this._get_boolean('qml');
   this.comma_first = this._get_boolean('comma_first');
   this.operator_position = this._get_selection('operator_position', validPositionValues);
 

--- a/python/jsbeautifier/__init__.py
+++ b/python/jsbeautifier/__init__.py
@@ -124,6 +124,7 @@ Output options:
  -f,  --keep-function-indentation  Do not re-indent function bodies defined in var lines.
  -x,  --unescape-strings           Decode printable chars encoded in \\xNN notation.
  -X,  --e4x                        Pass E4X xml literals through untouched
+      --qml                        Add QML support
  -C,  --comma-first                Put commas at the beginning of new line instead of end.
  -m,
  --max-preserve-newlines=NUMBER    Number of line-breaks to be preserved in one chunk (default 10)
@@ -186,6 +187,7 @@ def main():
                 "operator-position=",
                 "outfile=",
                 "quiet",
+                "qml",
                 "replace",
                 "space-after-anon-function",
                 "space-after-named-function",
@@ -254,6 +256,8 @@ def main():
             js_options.unescape_strings = True
         elif opt in ("--e4x", "-X"):
             js_options.e4x = True
+        elif opt in ("--qml",):
+            js_options.qml = True
         elif opt in ("--end-with-newline", "-n"):
             js_options.end_with_newline = True
         elif opt in ("--comma-first", "-C"):

--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -1093,6 +1093,7 @@ class Beautifier:
                 self._flags.inline_frame
                 or self._flags.last_token.text == "else "
                 or self._flags.last_token.text == "export"
+                or (self._options.qml and self._flags.last_token.text == "property")
             ):
                 prefix = "SPACE"
             else:

--- a/python/jsbeautifier/javascript/options.py
+++ b/python/jsbeautifier/javascript/options.py
@@ -86,6 +86,7 @@ class BeautifierOptions(BaseOptions):
         )
         self.unescape_strings = self._get_boolean("unescape_strings")
         self.e4x = self._get_boolean("e4x")
+        self.qml = self._get_boolean("qml")
         self.comma_first = self._get_boolean("comma_first")
         self.operator_position = self._get_selection(
             "operator_position", OPERATOR_POSITION


### PR DESCRIPTION
# Description
Hello! My team want to add beautifier to "qbs-based" project. Qbs has light QML syntax similar to JS. So, I decide to look at qml and JS formatters, which can resolve my task.

Native qml formatters `qmlfmt` and `qmlformat` seem to me pretty unstable and have low level of customization, but js-beautify was a pretty good. 

I looked at know issues and found that only [one affects to my qbs code ](https://github.com/beautify-web/js-beautify/issues/1754), so I decided to resolve it. There is also [another qml issue](https://github.com/beautify-web/js-beautify/issues/876), but it doesn't affects qbs code, so I decided to leave it.

Fixes Issue: 

https://github.com/beautify-web/js-beautify/issues/1754


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

