### PR TITLE
Prevent editor panel from going crazy wide

### DIFF
--- a/web/common-style.css
+++ b/web/common-style.css
@@ -89,6 +89,7 @@ input[type="checkbox"], select, button {
 
 .editor {
   grid-area: editor;
+  width: 62vw;
 }
 
 .options {


### PR DESCRIPTION
# Description
- [ ] Adding width to the Editor panel


Fixes Issue: 
Corrects problem where pasting code with no line wraps pushes the Options panel far offscreen to the right.


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

