### PR TITLE
Fix test 'Do not remove whitespace after number'

### DIFF
--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -1603,7 +1603,7 @@ class Beautifier:
             self.handle_whitespace_and_comments(current_token, True)
 
         if re.search("^([0-9])+$", self._flags.last_token.text):
-            self._flags.whitespace_before = True
+            self._output.space_before_token = True
 
         if reserved_array(self._flags.last_token, _special_word_set):
             self._output.space_before_token = False


### PR DESCRIPTION
The Python version changed the wrong variable, which means that the
test fails.

This patch changes the variable from '_flags.whitespace_before' to
'_output.space_before_token'.

This test was executed from package downloaded from PyPI.
```
======================================================================
FAIL: test_beautifier (jsbeautifier.tests.generated.tests.TestJSBeautifier)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/jsbeautifier/tests/generated/tests.py", line 8028, in test_beautifier
    bt('1000000000000001000 .toFixed(0)!==1000000000000001024', '1000000000000001000 .toFixed(0) !== 1000000000000001024')
  File "/<<PKGBUILDDIR>>/jsbeautifier/tests/generated/tests.py", line 10337, in bt
    self.decodesto(input, expectation)
  File "/<<PKGBUILDDIR>>/jsbeautifier/tests/generated/tests.py", line 10299, in decodesto
    self.assertMultiLineEqual(
AssertionError: '1000000000000001000.toFixed(0) !== 1000000000000001024' != '1000000000000001000 .toFixed(0) !== 1000000000000001024'
- 1000000000000001000.toFixed(0) !== 1000000000000001024
+ 1000000000000001000 .toFixed(0) !== 1000000000000001024
?                    +
```


Fixes Issue: 
Failed test, no issue created


This feature was requested as #1950 and implemented as #2011