### PR TITLE
Fix formatting related to the <menu> element

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -765,7 +765,7 @@ Beautifier.prototype._calcluate_parent_multiline = function(printer, parser_toke
 };
 
 //To be used for <p> tag special case:
-var p_closers = ['address', 'article', 'aside', 'blockquote', 'details', 'div', 'dl', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'main', 'nav', 'ol', 'p', 'pre', 'section', 'table', 'ul'];
+var p_closers = ['address', 'article', 'aside', 'blockquote', 'details', 'div', 'dl', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'main', 'menu', 'nav', 'ol', 'p', 'pre', 'section', 'table', 'ul'];
 var p_parent_excludes = ['a', 'audio', 'del', 'ins', 'map', 'noscript', 'video'];
 
 Beautifier.prototype._do_optional_end_element = function(parser_token) {
@@ -788,7 +788,7 @@ Beautifier.prototype._do_optional_end_element = function(parser_token) {
 
   } else if (parser_token.tag_name === 'li') {
     // An li element’s end tag may be omitted if the li element is immediately followed by another li element or if there is no more content in the parent element.
-    result = result || this._tag_stack.try_pop('li', ['ol', 'ul']);
+    result = result || this._tag_stack.try_pop('li', ['ol', 'ul', 'menu']);
 
   } else if (parser_token.tag_name === 'dd' || parser_token.tag_name === 'dt') {
     // A dd element’s end tag may be omitted if the dd element is immediately followed by another dd element or a dt element, or if there is no more content in the parent element.

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1760,6 +1760,14 @@ exports.test_data = {
       ]
     }, {
       unchanged: [
+        '<menu>',
+        '    <li>test content',
+        '    <li>test content',
+        '    <li>test content',
+        '</menu>'
+      ]
+    }, {
+      unchanged: [
         '<ol>',
         '    <li>',
         '        test content',
@@ -1772,6 +1780,30 @@ exports.test_data = {
         '    <li>',
         '        test content',
         '</ol>'
+      ]
+    }, {
+      unchanged: [
+        '<menu>',
+        '    <li>',
+        '        test content',
+        '    <li>',
+        '        <ol>',
+        '            <li> level 1 check',
+        '            <li>',
+        '                <menu>',
+        '                    <li> level 2 check',
+        '                    <li>',
+        '                        <ul>',
+        '                            <li> level 3 check',
+        '                        </ul>',
+        '                    <li>',
+        '                        test content',
+        '                </menu>',
+        '        </ol>',
+        '    <li> test content',
+        '    <li>',
+        '        test content',
+        '</menu>'
       ]
     }, {
       unchanged: [


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has a meaningful name (not `main`)

A minor patch for:
- correctly formatting nested `<menu>` tags, such as `<li>` tags inside `<menu>` tags inside `<li>` tags;
- allowing unclosed `<p>` tags followed by a `<menu>` tag.

Basically, `<menu>` elements should be treated as identical to `<ul>` elements.

References:

> *The `menu` element is simply a semantic alternative to [`ul`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element) to express an unordered list of commands (a "toolbar").*
> (https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element)

> A `p` element's end tag can be omitted if the `p` element is immediately followed by an `address`, `article`, ..., `main`, **`menu`**, `nav`, `ol`, ..., `table`, or `ul` element, or...
> (https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element)

**Current output**:
```html
<div>
    <p>
        <menu>
            <li>
                <menu>
            <li>
        </menu>
        </li>
        </menu>

    <p>
        <menu></menu>
</div>
```
**After applying the changes proposed in this PR**:
```html
<div>
    <p>
    <menu>
        <li>
            <menu>
                <li>
            </menu>
        </li>
    </menu>

    <p>
    <menu></menu>
</div>
```
---
Fixes Issue: 
- microsoft/vscode-html-languageservice#135
- Fix formatting for unclosed `<p>` tags immediately followed by a `<menu>` tag


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- <del>Python implementation (NA if HTML beautifier)</del> `NA`
- [x] Added tests to data file(s)
- <del>Added command-line option(s) (NA if</del> `NA`
- <del>README.md documents new feature/option(s)</del> `NA`

