### PR TITLE
docs: Fix a few typos

### DIFF
--- a/python/jsbeautifier/javascript/beautifier.py
+++ b/python/jsbeautifier/javascript/beautifier.py
@@ -1208,7 +1208,7 @@ class Beautifier:
                 or current_token.previous.text == ")"
             )
         ):
-            # This conditionial checks backtick strings and makes no changes
+            # This conditional checks backtick strings and makes no changes
             pass
         elif self.start_of_statement(current_token):
             # The conditional starts the statement if appropriate.

--- a/tools/template/beautify.wrapper.js
+++ b/tools/template/beautify.wrapper.js
@@ -59,7 +59,7 @@
             }                   }
 
     space_after_anon_function (default false) - should the space before an anonymous function's parens be added, "function()" vs "function ()",
-          NOTE: This option is overriden by jslint_happy (i.e. if jslint_happy is true, space_after_anon_function is true by design)
+          NOTE: This option is overridden by jslint_happy (i.e. if jslint_happy is true, space_after_anon_function is true by design)
 
     brace_style (default "collapse") - "collapse" | "expand" | "end-expand" | "none" | any of the former + ",preserve-inline"
             put braces on the same line as control statements (default), or put braces on own line (Allman / ANSI style), or just put end braces on own line, or attempt to keep them where they are.


### PR DESCRIPTION
There are small typos in:
- python/jsbeautifier/javascript/beautifier.py
- tools/template/beautify.wrapper.js

Fixes:
- Should read `conditional` rather than `conditionial`.
- Should read `overridden` rather than `overriden`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md