### PR TITLE
Added the `hyphen_attributes` HTML beautifier option to enforce all HTML attributes are hyphenated and lowercased.

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ HTML Beautifier Options:
   --editorconfig                     Use EditorConfig to set up the options
   --indent_scripts                   Sets indent level inside script tags ("normal", "keep", "separate")
   --unformatted_content_delimiter    Keep text content together between this string [""]
+  --hyphen_attributes                Ensure HTML attributes are hypenated and lowercased (not camelCased)
   --indent-empty-lines               Keep indentation on empty lines
   --templating                       List of templating languages (auto,none,django,erb,handlebars,php,smarty) ["auto"] auto = none in JavaScript, all in html
 ```

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -122,6 +122,7 @@ var path = require('path'),
         "indent_scripts": ["keep", "separate", "normal"],
         "extra_liners": [String, Array],
         "unformatted_content_delimiter": String,
+        "hyphen_attributes": Boolean,
         // CLI
         "version": Boolean,
         "help": Boolean,
@@ -402,6 +403,7 @@ function usage(err) {
             msg.push('  -T, --content_unformatted         List of tags (defaults to pre) whose content should not be reformatted');
             msg.push('  -E, --extra_liners                List of tags (defaults to [head,body,/html] that should have an extra newline');
             msg.push('  --unformatted_content_delimiter    Keep text content together between this string [""]');
+            msg.push('  --hyphen_attributes                Ensure HTML attributes are hypenated and lowercased (not camelCased)');
             break;
         case "css":
             msg.push('  -b, --brace-style                       [collapse|expand] ["collapse"]');

--- a/js/src/html/options.js
+++ b/js/src/html/options.js
@@ -81,6 +81,7 @@ function Options(options) {
     'pre', 'textarea'
   ]);
   this.unformatted_content_delimiter = this._get_characters('unformatted_content_delimiter');
+  this.hyphen_attributes = this._get_boolean('hyphen_attributes', false);
   this.indent_scripts = this._get_selection('indent_scripts', ['normal', 'keep', 'separate']);
 
 }

--- a/js/src/html/tokenizer.js
+++ b/js/src/html/tokenizer.js
@@ -266,6 +266,12 @@ Tokenizer.prototype._read_attribute = function(c, previous_token, open_token) {
         } else {
           token = this._create_token(TOKEN.ATTRIBUTE, resulting_string);
         }
+
+        if (this._options.hyphen_attributes) {
+          token.text = token.text.replace(/[A-Z]/g, function(match, offset) {
+            return (offset > 0 ? '-' : '') + match.toLowerCase();
+          });
+        }
       }
     }
   }

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -814,6 +814,23 @@ exports.test_data = {
       output: '<span>0 0001 0002 0003 0004 0005 0006 0007 0008 0009 0^^0 0011 0012 0013 0014\n    0015 0016 0^^7 0018 0019 0020</span>'
     }]
   }, {
+    name: "hyphen_attributes:false",
+    description: "Ensure HTML attributes are hypenated and lowercased (not camelCased)",
+    options: [
+      { name: "hyphen_attributes", value: "false" }
+    ],
+    tests: [{ unchanged: '<span some="attribute" is-not="camelCase" butThis="is"></span>' }]
+  }, {
+    name: "hyphen_attributes:true",
+    description: "Ensure HTML attributes are hypenated and lowercased (not camelCased)",
+    options: [
+      { name: "hyphen_attributes", value: "true" }
+    ],
+    tests: [{
+      input: '<span some="attribute" is-not="camelCase" butThis="is"></span>',
+      output: '<span some="attribute" is-not="camelCase" but-this="is"></span>'
+    }]
+  }, {
     name: "Attribute Wrap",
     description: "Wraps attributes inside of html tags",
     matrix: [{


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 

Not necessarily an issue, but an improvement. Our codebase uses frameworks that rely on attributes being hyppenated and not camelCased, and having js-beautify automatically convert them would be great.

This added a new HTML only option `hyphen_attributes` which when enabled, will convert all attributes to hyphenated lowercase. By default, this is disabled and should be a noop for all current users.

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

