### PR TITLE
use correct variable name

### DIFF
--- a/python/cssbeautifier/__init__.py
+++ b/python/cssbeautifier/__init__.py
@@ -38,7 +38,7 @@ def beautify(string, opts=None):
 
 def beautify_file(file_name, opts=None):
     _main = __import__("cssbeautifier", globals(), locals(), ["_main"])._main
-    return _main.beautify_file(file, opts)
+    return _main.beautify_file(file_name, opts)
 
 
 def usage(stream=sys.stdout):


### PR DESCRIPTION
# Description
- [ x ] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 

`beautify_file` of `cssbeautifier` (python module) not working because usage of two different variable names `file` and `file_name`. 

See `__init__.py`:

```python
...
def beautify_file(file_name, opts=None):
    _main = __import__("cssbeautifier", globals(), locals(), ["_main"])._main
    return _main.beautify_file(file, opts)
...
```
results in:

```python
# file.py
import cssbeautifier

cssbeautifier.beautify_file('./file.css')
```

```shell
$ python file.py         
Traceback (most recent call last):
  File ".../file.py", line 3, in <module>
    x = cssbeautifier.beautify_file('./file.css')
  File ".../cssbeautifier/__init__.py", line 41, in beautify_file
    return _main.beautify_file(file, opts)
NameError: name 'file' is not defined. Did you mean: 'filter'?
```


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ x ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ x ] Added Tests to data file(s)
- [ x ] Added command-line option(s) (NA if
- [ x ] README.md documents new feature/option(s)

