### PR TITLE
Implementation of a insideNonNestedAtRule variable

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -287,7 +287,7 @@ Beautifier.prototype.beautify = function() {
         } else if (!insideRule && parenLevel === 0 && variableOrRule.indexOf(':') !== -1) {
           insidePropertyValue = true;
           this.indent();
-        }
+
           // might be a non-nested at-rule
         } else if( ! ( variableOrRule in this.NESTED_AT_RULE ) ) {
           insideNonNestedAtRule = true;

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -253,22 +253,22 @@ Beautifier.prototype.beautify = function() {
 
       this.print_string(this._ch);
 
-        // strip trailing space, if present, for hash property checks
-        var variable = this._input.peekUntilAfter(/[: ,;{}()[\]\/='"]/g);
+      // strip trailing space, if present, for hash property checks
+      var variable = this._input.peekUntilAfter(/[: ,;{}()[\]\/='"]/g);
 
-        if (variable.match(/[ :]$/)) {
-          // we have a variable or pseudo-class, add it and insert one space before continuing
-          variable = this.eatString(": ").replace(/\s$/, '');
-          this.print_string(variable);
-          this._output.space_before_token = true;
-        }
+      if (variable.match(/[ :]$/)) {
+        // we have a variable or pseudo-class, add it and insert one space before continuing
+        variable = this.eatString(": ").replace(/\s$/, '');
+        this.print_string(variable);
+        this._output.space_before_token = true;
+      }
 
-        variable = variable.replace(/\s$/, '');
+      variable = variable.replace(/\s$/, '');
 
       // might be sass variable
-      if(parenLevel === 0 && variable.indexOf(':') !== -1) {
-      insidePropertyValue = true;
-      this.indent();
+      if (parenLevel === 0 && variable.indexOf(':') !== -1) {
+        insidePropertyValue = true;
+        this.indent();
       }
     } else if (this._ch === '@') {
       this.preserveSingleSpace(isAfterSpace);
@@ -292,7 +292,7 @@ Beautifier.prototype.beautify = function() {
         variableOrRule = variableOrRule.replace(/\s$/, '');
 
         // might be less variable
-        if(parenLevel === 0 && variableOrRule.indexOf(':') !== -1) {
+        if (parenLevel === 0 && variableOrRule.indexOf(':') !== -1) {
           insidePropertyValue = true;
           this.indent();
 
@@ -304,7 +304,7 @@ Beautifier.prototype.beautify = function() {
           }
 
           // might be a non-nested at-rule
-        } else if( parenLevel === 0 && !insidePropertyValue ) {
+        } else if (parenLevel === 0 && !insidePropertyValue) {
           insideNonNestedAtRule = true;
         }
       }

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -345,7 +345,6 @@ Beautifier.prototype.beautify = function() {
       }
       insideAtImport = false;
       insideAtExtend = false;
-      insideAtApply = false;
       if (insidePropertyValue) {
         this.outdent();
         insidePropertyValue = false;
@@ -421,6 +420,7 @@ Beautifier.prototype.beautify = function() {
         }
         insideAtExtend = false;
         insideAtImport = false;
+        insideAtApply = false;
         this.print_string(this._ch);
         this.eatWhitespace(true);
 

--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -195,6 +195,7 @@ Beautifier.prototype.beautify = function() {
   var enteringConditionalGroup = false;
   var insideAtExtend = false;
   var insideAtImport = false;
+  var insideAtApply = false;
   var insideScssMap = false;
   var topCharacter = this._ch;
   var insideNonSemiColonValues = false;
@@ -276,6 +277,11 @@ Beautifier.prototype.beautify = function() {
           insideAtImport = true;
         }
 
+        // might be a tailwindcss ruleset
+        if (variableOrRule === 'apply') {
+          insideAtApply = true;
+        }
+
         // might be a nesting at-rule
         if (variableOrRule in this.NESTED_AT_RULE) {
           this._nestedLevel += 1;
@@ -339,6 +345,7 @@ Beautifier.prototype.beautify = function() {
       }
       insideAtImport = false;
       insideAtExtend = false;
+      insideAtApply = false;
       if (insidePropertyValue) {
         this.outdent();
         insidePropertyValue = false;
@@ -372,9 +379,10 @@ Beautifier.prototype.beautify = function() {
         }
       }
 
-      if ((insideRule || enteringConditionalGroup) && !(this._input.lookBack("&") || this.foundNestedPseudoClass()) && !this._input.lookBack("(") && !insideAtExtend && parenLevel === 0) {
+      if ((insideRule || enteringConditionalGroup) && !(this._input.lookBack("&") || this.foundNestedPseudoClass()) && !this._input.lookBack("(") && !insideAtExtend && !insideAtApply && parenLevel === 0) {
         // 'property: value' delimiter
         // which could be in a conditional group query
+
         this.print_string(':');
         if (!insidePropertyValue) {
           insidePropertyValue = true;

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -2003,7 +2003,7 @@ exports.test_data = {
       }, {
         unchanged: '@import url("chrome://communicator/skin/");'
       }, {
-        unchanged: '@apply w-4 lg:w-10 space-y-3 lg:space-x-12;',
+        unchanged: '@apply w-4 lg:w-10 space-y-3 lg:space-x-12;'
       }]
     }, {
 

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1995,6 +1995,17 @@ exports.test_data = {
         unchanged: 'p {\n    color: blue;\n}'
       }]
     }, {
+      name: "Issue #2012, #2142",
+      description: "Avoid whitespace between first colon and next character in non nested at-rules",
+      options: [],
+      tests: [{
+        unchanged: '@extend .btn-blue:hover;'
+      }, {
+        unchanged: '@import url("chrome://communicator/skin/");'
+      }, {
+        unchanged: '@apply w-4 lg:w-10 space-y-3 lg:space-x-12;',
+      }]
+    }, {
 
     }
   ]


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 

Implementation of a insideAtApply variable to determine if it is a Tailwind ruleset and avoid whitespace after variant [ currently thinking it is a property ]

It fixes issue #2012 :

Before : 
```
@apply flex flex-col lg:flex-row space-y-3 lg:space-x-12 items-start;
```

After :
```
@apply flex flex-col lg: flex-row space-y-3 lg:space-x-12 items-start;
```


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

