### PR TITLE
Fix 'brace-style' tests for Python

### DIFF
--- a/test/data/javascript/python.mustache
+++ b/test/data/javascript/python.mustache
@@ -367,7 +367,7 @@ class TestJSBeautifier(unittest.TestCase):
         test_fragment('foo {', 'foo {')
         test_fragment('return {', 'return {') # return needs the brace.
         test_fragment('return /* inline */ {', 'return /* inline */ {')
-        test_fragment('return;\n{', 'return; {')
+        test_fragment('return;\n{', 'return;\n{')
         bt("throw {}")
         bt("throw {\n    foo;\n}")
         bt('var foo = {}')
@@ -458,7 +458,7 @@ class TestJSBeautifier(unittest.TestCase):
         test_fragment('foo {', 'foo {')
         test_fragment('return {', 'return {') # return needs the brace.
         test_fragment('return /* inline */ {', 'return /* inline */ {')
-        test_fragment('return;\n{', 'return; {')
+        test_fragment('return;\n{', 'return;\n{')
         bt("throw {}")
         bt("throw {\n    foo;\n}")
         bt('var foo = {}')


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 
Commit c90470061c775a42b9c7a99840d2a5d436a89407 forgot to update the tests for Python, this commit updates the test-case to be equivalent to that of 'node.mustache' and to support the fix for #1852, which was implemented in #2117.

