### PR TITLE
Set nodejs minimum to v14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "browserslist": "ie 11",
   "dependencies": {


### PR DESCRIPTION
See #2168.  Transitive dependency `commander v10.x` requires nodejs v14.x.

Note, we only test on v16.x and above so this is not a guaranteed minimum. 

# Description
- [ ] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [ ] JavaScript implementation
- [ ] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)

