### PR TITLE
Mark unpacking feature as unsafe

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
           <label for="comma-first">Use comma-first list style?</label>
           <br>
           <input class="checkbox" type="checkbox" id="detect-packers">
-          <label for="detect-packers">Detect packers and obfuscators?</label>
+          <label for="detect-packers">Detect packers and obfuscators? (unsafe)</label>
           <br>
           <input class="checkbox" type="checkbox" id="brace-preserve-inline">
           <label for="brace-preserve-inline">Preserve inline braces/code blocks?</label>

--- a/web/common-function.js
+++ b/web/common-function.js
@@ -69,7 +69,7 @@ function run_tests() {
 function read_settings_from_cookie() {
   $('#tabsize').val(any(Cookies.get('tabsize'), '4'));
   $('#brace-style').val(any(Cookies.get('brace-style'), 'collapse'));
-  $('#detect-packers').prop('checked', Cookies.get('detect-packers') !== 'off');
+  $('#detect-packers').prop('checked', Cookies.get('detect-packers') === 'on');
   $('#max-preserve-newlines').val(any(Cookies.get('max-preserve-newlines'), '5'));
   $('#keep-array-indentation').prop('checked', Cookies.get('keep-array-indentation') === 'on');
   $('#break-chained-methods').prop('checked', Cookies.get('break-chained-methods') === 'on');


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)

This marks the "Detect packers and obfuscators" feature as unsafe and disables it by default on the web interface.

Fixes Issue: #662 



# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) (NA if
- [x] README.md documents new feature/option(s)

