### PR TITLE
Use raw strings to define a regex in `packer.py`

### DIFF
--- a/python/jsbeautifier/unpackers/packer.py
+++ b/python/jsbeautifier/unpackers/packer.py
@@ -28,7 +28,7 @@ def detect(source):
     begin_offset = -1
     """Detects whether `source` is P.A.C.K.E.R. coded."""
     mystr = re.search(
-        "eval[ ]*\([ ]*function[ ]*\([ ]*p[ ]*,[ ]*a[ ]*,[ ]*c["
+        r"eval[ ]*\([ ]*function[ ]*\([ ]*p[ ]*,[ ]*a[ ]*,[ ]*c["
         " ]*,[ ]*k[ ]*,[ ]*e[ ]*,[ ]*",
         source,
     )


### PR DESCRIPTION
`'\('` raises a `DeprecationWarning`, because `\(` is not a valid escape sequence in Python:

```
tests/unit/test_cli/test_schema_commands.py::test_openapi_typescript_command[Custom-]
  D:\a\litestar\litestar\.venv\Lib\site-packages\jsbeautifier\unpackers\packer.py:31: DeprecationWarning: invalid escape sequence '\('
    "eval[ ]*\([ ]*function[ ]*\([ ]*p[ ]*,[ ]*a[ ]*,[ ]*c["
```
Link: https://github.com/litestar-org/litestar/actions/runs/6282794210/job/17062629903#step:11:71

But, `r'\('` is actually fine. So, let use it!


- [x] Source branch in your fork has meaningful name (not `main`)
- [ ] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s)
- [ ] Added command-line option(s) (NA if
- [ ] README.md documents new feature/option(s)
