### PR TITLE
fix: keep \u2028, \u2029, \ufeff escaped when unescape_strings is true

### DIFF
--- a/js/src/javascript/tokenizer.js
+++ b/js/src/javascript/tokenizer.js
@@ -516,6 +516,9 @@ function unescape_string(s) {
       } else if (escaped === 0x22 || escaped === 0x27 || escaped === 0x5c) {
         // single-quote, apostrophe, backslash - escape these
         out += '\\' + String.fromCharCode(escaped);
+      } else if (escaped === 0x2028 || escaped === 0x2029 || escaped === 0xfeff) {
+        // U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR, U+FEFF BOM are JavaScript line terminators, keep escaped so the output remains valid JS.
+        out += '\\' + matched[0];
       } else {
         out += String.fromCharCode(escaped);
       }

--- a/python/jsbeautifier/javascript/tokenizer.py
+++ b/python/jsbeautifier/javascript/tokenizer.py
@@ -628,6 +628,9 @@ class Tokenizer(BaseTokenizer):
             elif escaped == 0x22 or escaped == 0x27 or escaped == 0x5C:
                 # single-quote, apostrophe, backslash - escape these
                 out += "\\" + chr(escaped)
+            elif escaped in (0x2028, 0x2029, 0xFEFF):
+                # U+2028 LINE SEPARATOR, U+2029 PARAGRAPH SEPARATOR, U+FEFF BOM are JavaScript line terminators, keep escaped so the output remains valid JS.
+                out += "\\" + matched.group(0)
             else:
                 out += self.acorn.six.unichr(escaped)
 


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)


Fixes Issue: #2141 


# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [ ] Added Tests to data file(s) - N/A
- [ ] Added command-line option(s) - N/A
- [ ] README.md documents new feature/option(s) - N/A

