### PR TITLE
Fix: update toggle text when dark mode is enabled

### DIFF
--- a/web/common-function.js
+++ b/web/common-function.js
@@ -417,9 +417,11 @@ function switchTheme(themeToggleEvent) {
     $('.CodeMirror').addClass('cm-s-darcula');
     $('body').addClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-dark.svg");
+    document.getElementById('theme-span').innerHTML = 'Enable Light Mode'
   } else {
     $('.CodeMirror').removeClass('cm-s-darcula');
     $('body').removeClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-light.svg");
+    document.getElementById('theme-span').innerHTML = 'Enable Dark Mode'
   }
 }


### PR DESCRIPTION
# Description
- [x] Source branch in your fork has meaningful name (not `main`)

This PR updates the dark mode toggle logic on the website. When Dark Mode is enabled, the label text now updates to recommend switching to bright mode, as requested. 

Fixes Issue: #2418

# Before Merge Checklist 
These items can be completed after PR is created.

(Check any items that are not applicable (NA) for this PR)

- [x] JavaScript implementation
- [x] Python implementation (NA if HTML beautifier)
- [x] Added Tests to data file(s)
- [x] Added command-line option(s) 
- [x] README.md documents new feature/option(s)