### PR TITLE
Updated the theme toggle label to reflect action.

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <input type="checkbox" id="theme-toggle-btn" style="display: none" />
         <div id="theme-toggle-slider"></div>
       </label>
-      <span>Enable Dark Mode</span>
+      <span id = "toggle-slider-text">Enable Light Mode</span>
     </div>
     <select name="language" id="language">
       <option value="css">Beautify CSS</option>

--- a/web/common-function.js
+++ b/web/common-function.js
@@ -413,13 +413,18 @@ function setPreferredColorScheme() {
 }
 
 function switchTheme(themeToggleEvent) {
+  let toggle_text = document.querySelector("#toggle-slider-text");
+
   if (themeToggleEvent.target.checked) {
     $('.CodeMirror').addClass('cm-s-darcula');
     $('body').addClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-dark.svg");
+    toggle_text.textContent = "Enable Light Mode";
   } else {
     $('.CodeMirror').removeClass('cm-s-darcula');
     $('body').removeClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-light.svg");
+    toggle_text.textContent = "Enable Dark Mode";
   }
 }
+


### PR DESCRIPTION
The theme toggle label always displays "Enable Dark Mode" regardless of the current theme, which can be confusing for users.

### Fix

Updated the toggle label to reflect the action:
- "Enable Light Mode" when dark mode is active
- "Enable Dark Mode" when light mode is active

**Before:**
<img width="1910" height="123" alt="image" src="https://github.com/user-attachments/assets/bcc098f5-9716-4039-949a-4d50e2c4b876" />
<img width="1917" height="133" alt="image" src="https://github.com/user-attachments/assets/817e7e6b-e4b5-4a95-bc38-637dd7c6c0c3" />


**After:**
<img width="1919" height="131" alt="image" src="https://github.com/user-attachments/assets/bb34106b-373f-4b0f-ab41-9677028cc0f8" />
<img width="1904" height="126" alt="image" src="https://github.com/user-attachments/assets/fffe69c5-9b5a-429f-8d2e-ed853a792e64" />


Closes #2418 