### PR TITLE
fix: focus editor after clearAll #2430

### DIFF
--- a/web/common-function.js
+++ b/web/common-function.js
@@ -380,8 +380,10 @@ function selectAll() {
 function clearAll() {
   if (the.editor) {
     the.editor.setValue('');
+    the.editor.focus();
   } else {
     $('#source').val('');
+    $('#source').focus();
   }
 }
 


### PR DESCRIPTION
Closes #2430

After clicking "Clear", focus was not returned to the editor, requiring
the user to click manually before typing.

- CodeMirror path: call `the.editor.focus()` after `setValue('')`
- Textarea path: call `$('#source').focus()` after `val('')`

No core beautifier logic affected. No JS/Python parity required (UI-only change).
