### PR TITLE
fix: restore indent level after LESS each() mixin #2380

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -377,6 +377,7 @@ Beautifier.prototype.beautify = function() {
       }
       if (this._input.peek() === ')') {
         this._output.trim(true);
+        this.indent();
         if (this._options.brace_style === "expand") {
           this._output.add_new_line(true);
         }

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -394,6 +394,7 @@ class Beautifier:
                         self._output.add_new_line(True)
                 if self._input.peek() == ")":
                     self._output.trim(True)
+                    self.indent()
                     if self._options.brace_style == "expand":
                         self._output.add_new_line(True)
             elif self._ch == ":":

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1978,6 +1978,18 @@ exports.test_data = {
           '    border: @border-width solid @color;',
           '}'
         ]
+      }, {
+        comment: 'Issue #2380 - each() mixin should not break indentation of subsequent rules',
+        unchanged: [
+          '.my-function(@iterator) {',
+          '    each(@iterator, {',
+          '        color: red;',
+          '    });',
+          '    .correct-indentation {',
+          '        color: blue;',
+          '    }',
+          '}'
+        ]
       }]
     }, {
       name: "Preserve Newlines and max number of new lines",


### PR DESCRIPTION
Closes #2380

## Problem
After a LESS `each()` mixin call using object notation (`});`), the
beautifier zeroed the indent level for all subsequent rules, even when
still inside a parent block.

Root cause: the `}` handler calls `outdent()`, then when the next char
is `)`, `trim(true)` pops the newline — leaving `current_line` at the
previous (shallower) indent. The `{` opening the mixin body (preceded
by `,`) skips `indent()`, so the net result is one extra `outdent()`.

## Fix
Added `this.indent()` / `self.indent()` after `trim(true)` in the
`peek() === ')'` branch to compensate for the asymmetry.

Both JS and Python implementations updated.

## Verification

Input:
```css
.my-function(@iterator) { each(@iterator, { color: red; }); .wrong { color: blue; } }
```

Before fix:
```css
.my-function(@iterator) {
  each(@iterator, {
    color: red;
  });
.wrong {
  color: blue;
}
}
```

After fix:
```css
.my-function(@iterator) {
  each(@iterator, {
    color: red;
  });
  .wrong {
    color: blue;
  }
}
```
