### PR TITLE
docs: clarify version numbering policy for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,3 +137,32 @@ To publish a Beta or RC (Release Candidate), add `-beta1` or `-rc1` to the end o
 
 
 
+## Version Numbering Policy
+
+This project follows semantic versioning for API compatibility, with additional guidance for formatting changes.
+
+### What each version number means
+
+* Major (`x.0.0`): API compatibility changes. We reserve major versions for intentional API-incompatible changes.
+* Minor (`x.y.0`): Significant formatting fixes, behavior improvements, or new features/options that may affect output.
+* Patch (`x.y.z`): Small, low-risk fixes that should not cause side effects.
+
+### Output compatibility expectations
+
+Formatting output for the same input may change in minor and patch releases.
+For this project, output compatibility is not equivalent to API compatibility:
+
+* API compatibility is represented by major versions.
+* Formatting correctness and behavior improvements are delivered in minor/patch releases based on scope and risk.
+
+### Rules for introducing formatting behavior changes
+
+* Fixes for strictly incorrect formatting should be enabled by default.
+* New formatting features should be introduced as options and must default to off, so valid input formatting does not change unexpectedly.
+* We avoid unnecessary output churn and treat invalid input handling as best-effort.
+
+### Guidance for consumers
+
+If your workflows are sensitive to output differences, pin exact versions or use conservative ranges.
+Using broad ranges (for example, `^x.y.z`) may pull in output-affecting updates by design.
+


### PR DESCRIPTION
# Description

* [x] Source branch in your fork has meaningful name (not `main`)

This PR adds a **Version Numbering Policy** section to `CONTRIBUTING.md` to clarify how releases should be categorized in this project.

The new documentation explains:

* How **major**, **minor**, and **patch** versions should be interpreted
* The distinction between **API compatibility** and **formatter output stability**
* When formatting/output changes should trigger major vs minor releases
* Guidance for contributors on default-on fixes versus option-gated formatting features
* Guidance for consumers on dependency pinning when output stability is important

This helps maintainers make more consistent release decisions and sets clearer upgrade expectations for users of the formatter.

Fixes Issue: #1257

# Before Merge Checklist

* [ ] JavaScript implementation
* [ ] Python implementation (NA if HTML beautifier)
* [ ] Added Tests to data file(s)
* [x] Added command-line option(s) (NA if not applicable)
* [x] README.md documents new feature/option(s)