### PR TITLE
Recognize <script type="importmap"> and beautify its JSON body

### DIFF
--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -166,7 +166,7 @@ var get_custom_beautifier_name = function(tag_check, raw_token) {
   // For those without a type attribute use default;
   if (typeAttribute.search('text/css') > -1) {
     result = 'css';
-  } else if (typeAttribute.search(/module|((text|application|dojo)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json|method|aspect))/) > -1) {
+  } else if (typeAttribute.search(/module|importmap|((text|application|dojo)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json|method|aspect))/) > -1) {
     result = 'javascript';
   } else if (typeAttribute.search(/(text|application|dojo)\/(x-)?(html)/) > -1) {
     result = 'html';

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -645,6 +645,19 @@ exports.test_data = {
           '</script>'
         ]
       }, {
+        comment: 'importmap holds JSON and should beautify like other json script types',
+        input: '<script type="importmap">{"imports":{"three":"x","three/addons/":"y"}}</script>',
+        output: [
+          '<script type="importmap">',
+          '    {',
+          '        "imports": {',
+          '            "three": "x",',
+          '            "three/addons/": "y"',
+          '        }',
+          '    }',
+          '</script>'
+        ]
+      }, {
         unchanged: '<style type="text/unknown"><tag></tag></style>'
       }, {
         input: '<style type="text/css"><tag></tag></style>',


### PR DESCRIPTION
## Problem

The HTML beautifier picks how to format a `<script>` body from its `type` attribute (`get_custom_beautifier_name` in `js/src/html/beautifier.js`). `application/json` and `application/ld+json` are recognized and formatted as JSON, but **`importmap` is not matched**, so it falls through to the "null" beautifier and its JSON body is left mis-indented.

Input:
```html
<script type="importmap">{"imports":{"three":"x","three/addons/":"y"}}</script>
```

Before (not treated as JSON — body indentation is mangled):
```html
<script type="importmap">
    {
  "imports": {
    "three": "x",
    "three/addons/": "y"
  }
      }
</script>
```

## Fix

Add `importmap` to the type pattern so it routes to the JavaScript beautifier, the same as the other JSON script types:

```js
} else if (typeAttribute.search(/module|importmap|((text|application|dojo)\/(x-)?(javascript|ecmascript|jscript|livescript|(ld\+)?json|method|aspect))/) > -1) {
  result = 'javascript';
}
```

After:
```html
<script type="importmap">
    {
        "imports": {
            "three": "x",
            "three/addons/": "y"
        }
    }
</script>
```

`<script type="importmap">` is a standard HTML feature whose body is always JSON, so this is consistent with how `application/json` / `application/ld+json` are already handled.

## Tests

Added an HTML beautifier test for the importmap case in `test/data/html/tests.js`. `make jstest` passes (html-beautifier: 11916 tests; full js/css/html suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
