### PR TITLE
fix: focus editor after clearAll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -353,6 +353,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -379,6 +380,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -623,6 +625,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3063,6 +3066,7 @@
       "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/web/common-function.js
+++ b/web/common-function.js
@@ -17,7 +17,7 @@ requirejs.config({
 });
 
 requirejs(['beautifier'],
-  function(beautifier) {
+  function (beautifier) {
     the.beautifier = beautifier;
   });
 
@@ -43,10 +43,10 @@ function set_editor_mode() {
 
 function run_tests() {
   $.when($.getScript("js/test/sanitytest.js"),
-      $.getScript("js/test/generated/beautify-javascript-tests.js"),
-      $.getScript("js/test/generated/beautify-css-tests.js"),
-      $.getScript("js/test/generated/beautify-html-tests.js"))
-    .done(function() {
+    $.getScript("js/test/generated/beautify-javascript-tests.js"),
+    $.getScript("js/test/generated/beautify-css-tests.js"),
+    $.getScript("js/test/generated/beautify-html-tests.js"))
+    .done(function () {
       var st = new SanityTest();
       run_javascript_tests(st, Urlencoded, the.beautifier.js, the.beautifier.html, the.beautifier.css);
       run_css_tests(st, Urlencoded, the.beautifier.js, the.beautifier.html, the.beautifier.css);
@@ -137,7 +137,7 @@ function unpacker_filter(source) {
   leading_comments += '\n';
   source = source.replace(/^\s+/, '');
 
-  var unpackers = [P_A_C_K_E_R, Urlencoded, JavascriptObfuscator /*, MyObfuscate*/ ];
+  var unpackers = [P_A_C_K_E_R, Urlencoded, JavascriptObfuscator /*, MyObfuscate*/];
   for (var i = 0; i < unpackers.length; i++) {
     if (unpackers[i].detect(source)) {
       unpacked = unpackers[i].unpack(source);
@@ -380,8 +380,10 @@ function selectAll() {
 function clearAll() {
   if (the.editor) {
     the.editor.setValue('');
+    the.editor.focus();
   } else {
     $('#source').val('');
+    $('#source').focus();
   }
 }
 
@@ -390,7 +392,7 @@ function changeToFileContent(input) {
   if (file) {
     var reader = new FileReader();
     reader.readAsText(file, "UTF-8");
-    reader.onload = function(event) {
+    reader.onload = function (event) {
       if (the.editor) {
         the.editor.setValue(event.target.result);
       } else {


### PR DESCRIPTION
# Description
Closes #2430

After clicking "Clear", focus was not returned to the editor, requiring users to click back into the input area before typing.

Changes:
- Call the.editor.focus() after setValue('')
- Call $('#source').focus() after val('')

This change only affects web UI behavior and does not modify core beautifier functionality.