### PR TITLE
fix(css): restore indent after }); in LESS/SCSS

### DIFF
--- a/js/src/css/beautifier.js
+++ b/js/src/css/beautifier.js
@@ -377,6 +377,7 @@ Beautifier.prototype.beautify = function() {
       }
       if (this._input.peek() === ')') {
         this._output.trim(true);
+        this._output.set_indent(this._indentLevel);
         if (this._options.brace_style === "expand") {
           this._output.add_new_line(true);
         }

--- a/python/cssbeautifier/css/beautifier.py
+++ b/python/cssbeautifier/css/beautifier.py
@@ -386,6 +386,7 @@ class Beautifier:
                         self._output.add_new_line(True)
                 if self._input.peek() == ")":
                     self._output.trim(True)
+                    self._output.set_indent(self._indentLevel)
                     if self._options.brace_style == "expand":
                         self._output.add_new_line(True)
             elif self._ch == ":":

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1930,7 +1930,20 @@ exports.test_data = {
           '    .sel-@{value} {',
           '        a: b;',
           '    }',
-          '});'
+           '});'
+        ]
+      }, {
+        comment: 'LESS each() - indentation preserved after }); (issue #2380)',
+        unchanged: [
+          '.my-function(@iterator) {',
+          '    each(@iterator, {',
+          '        color: red;',
+          '    });',
+          '',
+          '    .next-rule {',
+          '        color: blue;',
+          '    }',
+          '}'
         ]
       }, {
         comment: 'Ensure simple closing parens do not break behavior',

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1930,16 +1930,25 @@ exports.test_data = {
           '    .sel-@{value} {',
           '        a: b;',
           '    }',
-           '});'
+          '});'
         ]
       }, {
-        comment: 'LESS each() - indentation preserved after }); (issue #2380)',
-        unchanged: [
+        comment: 'LESS each() - indentation after }); (issue #2380)',
+        input: [
+          '.my-function(@iterator) {',
+          'each(@iterator, {',
+          'color: red;',
+          '});',
+          '.next-rule {',
+          'color: blue;',
+          '}',
+          '}'
+        ],
+        output: [
           '.my-function(@iterator) {',
           '    each(@iterator, {',
           '        color: red;',
           '    });',
-          '',
           '    .next-rule {',
           '        color: blue;',
           '    }',

--- a/test/data/css/tests.js
+++ b/test/data/css/tests.js
@@ -1955,6 +1955,59 @@ exports.test_data = {
           '}'
         ]
       }, {
+        comment: 'SCSS each() - indentation after }); (issue #2380)',
+        input: [
+          '@mixin generate-vars($list) {',
+          '@each $item in $list {',
+          '.item-#{$item} {',
+          'color: red;',
+          '}',
+          '}',
+          '.after-mixin {',
+          'color: blue;',
+          '}' 
+        ],
+        output: [
+          '@mixin generate-vars($list) {',
+          '    @each $item in $list {',
+          '        .item-#{$item} {',
+          '            color: red;',
+          '        }',
+          '    }',
+          '    .after-mixin {',
+          '        color: blue;',
+          '    }',
+          '}'
+        ]
+      }, {
+        comment: 'LESS nested mixins - multiple }); in sequence',
+        input: [
+          '.parent {',
+          '.mixin-a({',
+          'prop-a: 1;',
+          '});',
+          '.mixin-b({',
+          'prop-b: 2;',
+          '});',
+          '.sibling {',
+          'prop-c: 3;',
+          '}',
+          '}'
+        ],
+        output: [
+          '.parent {',
+          '    .mixin-a({',
+          '        prop-a: 1;',
+          '    });',
+          '    .mixin-b({',
+          '        prop-b: 2;',
+          '    });',
+          '    .sibling {',
+          '        prop-c: 3;',
+          '    }',
+          '}'
+        ]
+      }, {
         comment: 'Ensure simple closing parens do not break behavior',
         unchanged: [
           'strong {',


### PR DESCRIPTION
## Summary

Fixes #2380

## Problem

When beautifying LESS/SCSS code with `});` one-liner patterns (common in mixin calls like `each()`), the indent level was not restored after trimming the newline.

This caused subsequent code to be indented at the wrong level:

```less
.my-function(@iterator) {
  each(@iterator, {
    color: red;
  });

  .wrong-indentation-here {  /* <-- This was incorrectly indented */
    color: blue;
  }
}
```

## Solution

Added `set_indent()` call after `trim()` to restore the correct indent level in both JavaScript and Python implementations:

```javascript
// js/src/css/beautifier.js
if (this._input.peek() === ')') {
  this._output.trim(true);
  this._output.set_indent(this._indentLevel);  // Added
  if (this._options.brace_style === "expand") {
    this._output.add_new_line(true);
  }
}
```

```python
# python/cssbeautifier/css/beautifier.py
if self._input.peek() == ")":
    self._output.trim(True)
    self._output.set_indent(self._indentLevel)  # Added
    if self._options.brace_style == "expand":
        self._output.add_new_line(True)
```

## Testing

- All JS tests pass (39301 + 4810 + 11916 tests)
- All Python tests pass (46 tests)
- Feature parity maintained between JS and Python implementations
