### PR TITLE
fix: make theme toggle label consistent (#2483)

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <input type="checkbox" id="theme-toggle-btn" style="display: none" />
         <div id="theme-toggle-slider"></div>
       </label>
-      <span id="theme-text">Enable Light Mode</span>
+      <span id="theme-text">Dark Mode</span>
     </div>
     <select name="language" id="language">
       <option value="css">Beautify CSS</option>

--- a/web/common-function.js
+++ b/web/common-function.js
@@ -422,13 +422,9 @@ function switchTheme(themeToggleEvent) {
     $('.CodeMirror').addClass('cm-s-darcula');
     $('body').addClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-dark.svg");
-
-    $('#theme-text').text('Enable Light Mode');
   } else {
     $('.CodeMirror').removeClass('cm-s-darcula');
     $('body').removeClass('dark-mode');
     $('.logo').children('img').attr("src", "web/banner-light.svg");
-
-    $('#theme-text').text('Enable Dark Mode');
   }
 }


### PR DESCRIPTION
Fixes #2483

### Description of Changes
- Updated the static label in `index.html` to `Dark Mode`.
- Removed the dynamic text switching logic in `web/common-function.js` when toggling the theme switch so the label remains consistent.
