### PR TITLE
Support Angular @let statements

### DIFF
--- a/js/src/html/tokenizer.js
+++ b/js/src/html/tokenizer.js
@@ -239,6 +239,20 @@ Tokenizer.prototype._read_control_flows = function(c, open_token) {
   }
 
   if (c === '@') {
+    // @let is a statement, not a block opener, so read it as plain text.
+    var let_next_char = this._input.peek(4);
+    if (this._input.peek(1) === 'l' &&
+      this._input.peek(2) === 'e' &&
+      this._input.peek(3) === 't' &&
+      !(let_next_char !== null && /[a-zA-Z0-9_$]/.test(let_next_char))) {
+      resulting_string = this._input.read(this._input.get_regexp(/@let\b/, true));
+      resulting_string += this._input.readUntil(this._input.get_regexp(/[;\r\n]/));
+      if (this._input.peek() === ';') {
+        resulting_string += this._input.next();
+      }
+      return this._create_token(TOKEN.TEXT, resulting_string);
+    }
+
     resulting_string = this.__patterns.angular_control_flow_start.read();
     if (resulting_string === '') {
       return token;

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -4092,6 +4092,20 @@ exports.test_data = {
         '<div> @if(true) { {{"{}" + " }"}} } </div>'
       ]
     }, {
+      comment: 'Angular @let statements should not be treated like block control flow.',
+      input: [
+        '<div>',
+        '@let total = count + items.length;',
+        '<p>{{ total }}</p>',
+        '</div>'
+      ],
+      output: [
+        '<div>',
+        '    @let total = count + items.length;',
+        '    <p>{{ total }}</p>',
+        '</div>'
+      ]
+    }, {
       input: [
         '<div>',
         '@for (item of items; track item.id; let idx = $index, e = $even) {',


### PR DESCRIPTION
Resolved Issue: Issue 2319 - Support Angular @let statements
Description of Solution
Implemented support for parsing Angular @let statements in the HTML tokenizer:

Tokenizer Fix (

tokenizer.js
): Since @let is a statement rather than a block opener, we added a specific check to prevent it from being parsed as block control flow. When @let is encountered, it reads until the end of the statement line (terminated by a semicolon, \r, or \n), treating it as plain text content so that its indentation aligns correctly with surrounding HTML code.
Test Addition (

tests.js
): Added a test case Angular @let statements should not be treated like block control flow. to verify that the statement remains in-line and does not cause incorrect nested indentation blocks.
All tests ran and passed successfully.