### PR TITLE
Fix custom element inlining default

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ HTML Beautifier Options:
   -M, --wrap-attributes-min-attrs    Minimum number of html tag attributes for force wrap attribute options [2]
   -i, --wrap-attributes-indent-size  Indent wrapped attributes to after N characters [indent-size] (ignored if wrap-attributes is "aligned")
   -d, --inline                       List of tags to be considered inline tags
-  --inline_custom_elements           Inline custom elements [true]
+  --inline_custom_elements           Inline custom elements [false]
   -U, --unformatted                  List of tags (defaults to inline) that should not be reformatted
   -T, --content_unformatted          List of tags (defaults to pre) whose content should not be reformatted
   -E, --extra_liners                 List of tags (defaults to [head,body,/html] that should have an extra newline before them.

--- a/js/src/html/options.js
+++ b/js/src/html/options.js
@@ -61,7 +61,7 @@ function Options(options) {
     // obsolete inline tags
     'acronym', 'big', 'strike', 'tt'
   ]);
-  this.inline_custom_elements = this._get_boolean('inline_custom_elements', true);
+  this.inline_custom_elements = this._get_boolean('inline_custom_elements', false);
   this.void_elements = this._get_array('void_elements', [
     // HTLM void elements - aka self-closing tags - aka singletons
     // https://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -3787,70 +3787,28 @@ exports.test_data = {
       ]
     }]
   }, {
-    name: "Does not add whitespace around custom elements ",
-    description: "Regression test for https://github.com/beautifier/js-beautify/issues/1989",
+    name: "Custom elements are block by default",
+    description: "Regression test for https://github.com/beautifier/js-beautify/issues/2375",
     tests: [{
       input: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span',
-        '        ><div>.</div',
-        '        ><section>27</section>',
-        '    </span>',
-        '</span>'
+        '<time-dot>.</time-dot><time-decimals>27</time-decimals>'
       ],
       output: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span>',
-        '        <div>.</div>',
-        '        <section>27</section>',
-        '    </span>',
-        '</span>'
-      ]
-    }, {
-      input: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span',
-        '        ><time-dot>.</time-dot',
-        '        ><time-decimals>27</time-decimals>',
-        '    </span>',
-        '</span>'
-      ],
-      output: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span><time-dot>.</time-dot><time-decimals>27</time-decimals>',
-        '    </span>',
-        '</span>'
+        '<time-dot>.</time-dot>',
+        '<time-decimals>27</time-decimals>'
       ]
     }]
   }, {
-    name: "Disables custom elements inlining with inline_custom_elements=false",
+    name: "Enables custom elements inlining with inline_custom_elements=true",
     description: "https://github.com/beautifier/js-beautify/issues/2113",
     options: [
-      { name: "inline_custom_elements", value: "false" }
+      { name: "inline_custom_elements", value: "true" }
     ],
     tests: [{
       input: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span',
-        '        ><time-dot>.</time-dot',
-        '        ><time-decimals>27</time-decimals>',
-        '    </span>',
-        '</span>'
+        '<time-dot>.</time-dot><time-decimals>27</time-decimals>'
       ],
-      output: [
-        '<span>',
-        '    <span>',
-        '        <span>The time for this result is 1:02</span>',
-        '        <time-dot>.</time-dot>',
-        '        <time-decimals>27</time-decimals>',
-        '    </span>',
-        '</span>'
-      ]
+      unchanged: '<time-dot>.</time-dot><time-decimals>27</time-decimals>'
     }]
   }, {
     name: "Indenting angular control flow with indent size 2",


### PR DESCRIPTION
Resolved Issue: Issue 2375 - Fix custom element inlining default
Description of Solution
Changed the default behavior of custom elements from being treated as inline elements to block elements:

Options Change (

options.js
): Changed the default value of the inline_custom_elements option from true to false. Custom elements are now treated as block-level tags by default unless explicitly configured otherwise.
Documentation Update (

README.md
): Updated the CLI/API option documentation for --inline_custom_elements to reflect the new default value of [false].
Test Suite Updates (

tests.js
): Modified and simplified the custom element tests to align with the new block-by-default behavior, confirming that custom tags are formatted as block elements under the default configuration and that inlining is correctly enabled when inline_custom_elements is explicitly set to true.
All tests ran and passed successfully.