### PR TITLE
Resolved Issue: Issue 2376 - Add option to preserve self-closing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ HTML Beautifier Options:
   -i, --wrap-attributes-indent-size  Indent wrapped attributes to after N characters [indent-size] (ignored if wrap-attributes is "aligned")
   -d, --inline                       List of tags to be considered inline tags
   --inline_custom_elements           Inline custom elements [true]
+  --preserve_self_closing_tags       Preserve the no-space form of self-closing tags [false]
   -U, --unformatted                  List of tags (defaults to inline) that should not be reformatted
   -T, --content_unformatted          List of tags (defaults to pre) whose content should not be reformatted
   -E, --extra_liners                 List of tags (defaults to [head,body,/html] that should have an extra newline before them.

--- a/js/src/cli.js
+++ b/js/src/cli.js
@@ -120,6 +120,7 @@ var path = require('path'),
         "max_char": Number, // obsolete since 1.3.5
         "inline": [String, Array],
         "inline_custom_elements": [Boolean],
+        "preserve_self_closing_tags": [Boolean],
         "unformatted": [String, Array],
         "content_unformatted": [String, Array],
         "indent_inner_html": [Boolean],
@@ -173,6 +174,7 @@ var path = require('path'),
         "W": ["--max_char"], // obsolete since 1.3.5
         "d": ["--inline"],
         // no shorthand for "inline_custom_elements"
+        // no shorthand for "preserve_self_closing_tags"
         "U": ["--unformatted"],
         "T": ["--content_unformatted"],
         "I": ["--indent_inner_html"],

--- a/js/src/html/beautifier.js
+++ b/js/src/html/beautifier.js
@@ -375,7 +375,7 @@ Beautifier.prototype._handle_tag_close = function(printer, raw_token, last_tag_t
     printer.add_raw_token(raw_token);
   } else {
     if (last_tag_token.tag_start_char === '<') {
-      printer.set_space_before_token(raw_token.text[0] === '/', true); // space before />, no space before >
+      printer.set_space_before_token(raw_token.text[0] === '/' && !this._options.preserve_self_closing_tags, true); // space before />, no space before > when preserving self-closing tags
       if (this._is_wrap_attributes_force_expand_multiline && last_tag_token.has_wrapped_attrs) {
         printer.print_newline(false);
       }

--- a/js/src/html/options.js
+++ b/js/src/html/options.js
@@ -62,6 +62,7 @@ function Options(options) {
     'acronym', 'big', 'strike', 'tt'
   ]);
   this.inline_custom_elements = this._get_boolean('inline_custom_elements', true);
+  this.preserve_self_closing_tags = this._get_boolean('preserve_self_closing_tags', false);
   this.void_elements = this._get_array('void_elements', [
     // HTLM void elements - aka self-closing tags - aka singletons
     // https://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -3853,6 +3853,17 @@ exports.test_data = {
       ]
     }]
   }, {
+    name: "Preserves self-closing tag formatting with preserve_self_closing_tags=true",
+    description: "Regression test for https://github.com/beautifier/js-beautify/issues/2376",
+    options: [
+      { name: "preserve_self_closing_tags", value: "true" }
+    ],
+    tests: [{
+      unchanged: '<div>\n    <br/>\n</div>'
+    }, {
+      unchanged: '<svg>\n    <path d="M0 0"/>\n</svg>'
+    }]
+  }, {
     name: "Indenting angular control flow with indent size 2",
     description: "https://github.com/beautify-web/js-beautify/issues/2219",
     template: "^^^ $$$",


### PR DESCRIPTION
Resolved Issue: Issue 2376 - Add option to preserve self-closing tags
Description of Solution
Added a new option preserve_self_closing_tags to allow users to preserve the exact spacing format of self-closing tags (e.g. <br/> or <path d="..."/> instead of inserting a space before the slash as in <br />):

Beautifier Update (

beautifier.js
): In _handle_tag_close, updated the set_space_before_token check so that space before the slash / is skipped if the preserve_self_closing_tags option is set to true.
Options Initialization (

options.js
): Added preserve_self_closing_tags option as a boolean defaulting to false.
CLI Configuration (

cli.js
): Registered the preserve_self_closing_tags option in the CLI type definitions list.
Documentation Update (

README.md
): Added the --preserve_self_closing_tags documentation to the HTML Beautifier Options section.
Test Addition (

tests.js
): Added tests under the name Preserves self-closing tag formatting with preserve_self_closing_tags=true verifying that tags are formatted correctly with and without linebreaks when the option is enabled.
All tests ran and passed successfully.