### PR TITLE
Fix literal Django-like strings in quoted attributes

### DIFF
--- a/js/src/core/pattern.js
+++ b/js/src/core/pattern.js
@@ -34,16 +34,25 @@ function Pattern(input_scanner, parent) {
   this._match_pattern = null;
   this._until_pattern = null;
   this._until_after = false;
+  this._require_until = false;
 
   if (parent) {
     this._starting_pattern = this._input.get_regexp(parent._starting_pattern, true);
     this._match_pattern = this._input.get_regexp(parent._match_pattern, true);
     this._until_pattern = this._input.get_regexp(parent._until_pattern);
     this._until_after = parent._until_after;
+    this._require_until = parent._require_until;
   }
 }
 
 Pattern.prototype.read = function() {
+  if (this._require_until && this._starting_pattern && this._until_pattern) {
+    var until_regexp = this._input.get_regexp(this._until_pattern);
+    until_regexp.lastIndex = this._input.__position;
+    if (!until_regexp.test(this._input.__input)) {
+      return '';
+    }
+  }
   var result = this._input.read(this._starting_pattern);
   if (!this._starting_pattern || result) {
     result += this._input.read(this._match_pattern, this._until_pattern, this._until_after);
@@ -53,6 +62,13 @@ Pattern.prototype.read = function() {
 
 Pattern.prototype.read_match = function() {
   return this._input.match(this._match_pattern);
+};
+
+Pattern.prototype.require_until = function() {
+  var result = this._create();
+  result._require_until = true;
+  result._update();
+  return result;
 };
 
 Pattern.prototype.until_after = function(pattern) {

--- a/js/src/core/templatablepattern.js
+++ b/js/src/core/templatablepattern.js
@@ -61,12 +61,12 @@ function TemplatablePattern(input_scanner, parent) {
     php: pattern.starting_with(/<\?(?:[= ]|php)/).until_after(/\?>/),
     erb: pattern.starting_with(/<%[^%]/).until_after(/[^%]%>/),
     // django coflicts with handlebars a bit.
-    django: pattern.starting_with(/{%/).until_after(/%}/),
-    django_value: pattern.starting_with(/{{/).until_after(/}}/),
-    django_comment: pattern.starting_with(/{#/).until_after(/#}/),
-    smarty: pattern.starting_with(/{(?=[^}{\s\n])/).until_after(/[^\s\n]}/),
-    smarty_comment: pattern.starting_with(/{\*/).until_after(/\*}/),
-    smarty_literal: pattern.starting_with(/{literal}/).until_after(/{\/literal}/)
+    django: pattern.starting_with(/{%/).until_after(/%}/).require_until(),
+    django_value: pattern.starting_with(/{{/).until_after(/}}/).require_until(),
+    django_comment: pattern.starting_with(/{#/).until_after(/#}/).require_until(),
+    smarty: pattern.starting_with(/{(?=[^}{\s\n])/).until_after(/[^\s\n]}/).require_until(),
+    smarty_comment: pattern.starting_with(/{\*/).until_after(/\*}/).require_until(),
+    smarty_literal: pattern.starting_with(/{literal}/).until_after(/{\/literal}/).require_until()
   };
 }
 TemplatablePattern.prototype = new Pattern();

--- a/test/data/html/tests.js
+++ b/test/data/html/tests.js
@@ -1733,6 +1733,10 @@ exports.test_data = {
       }, {
         unchanged: '<div class=\\\'{{#if thingIs \\\'value\\\'}}^^^&content$$${{/if}}\\\'></div>'
       }, {
+        comment: 'Literal Django-like strings inside quoted attributes should not consume the rest of the file.',
+        input_: '<div attr="{#"><div>\n</div></div>',
+        output: '<div attr="{#">\n    <div>\n    </div>\n</div>'
+      }, {
         unchanged: '<span>{{condition < 0 ? "result1" : "result2"}}</span>'
       }, {
         unchanged: '<span>{{condition1 && condition2 && condition3 && condition4 < 0 ? "resForTrue" : "resForFalse"}}</span>'


### PR DESCRIPTION
Description of Solution
Fixed an issue where a literal string containing a Django comment start `{#` or tag start `{%` inside quoted attributes (e.g. `<div attr="{#">`) would incorrectly trigger the template parser and consume the rest of the file looking for the closing tag:

Core Pattern Parser (

pattern.js
): Introduced a _require_until property to Pattern. When enabled, Pattern.prototype.read first checks if the expected closing/until pattern exists in the remaining input. If the closing pattern is not found, it prevents the starting pattern from matching.
Templatable Patterns Update (

templatablepattern.js
): Appended .require_until() to Django and Smarty pattern definitions. This ensures that a {#, {%, or { is only treated as a template block if its closing tag matches later in the source.
Test Addition (

tests.js
): Added a test case Literal Django-like strings inside quoted attributes should not consume the rest of the file. to verify that the template parser respects literal strings and continues normal HTML formatting.
This solution successfully passes the new test case and resolves the issue without causing regressions in existing tests (like minimal template handling).
